### PR TITLE
Add Saim-Hann Mirror campaign data for 2 first mission blocks

### DIFF
--- a/src/assets/battleData.json
+++ b/src/assets/battleData.json
@@ -3576,6 +3576,217 @@
         "reward": "Single Power Pack",
         "expectedGold": 53
     },
+    "SHM1": {
+        "campaign": "Saim-Hann Mirror",
+        "campaignType": "Mirror",
+        "nodeNumber": 1,
+        "reward": "Mutation: Warped Muscles",
+        "expectedGold": 53
+    },
+    "SHM10": {
+        "campaign": "Saim-Hann Mirror",
+        "campaignType": "Mirror",
+        "nodeNumber": 10,
+        "reward": "Targeting Link",
+        "expectedGold": 53
+    },
+    "SHM11": {
+        "campaign": "Saim-Hann Mirror",
+        "campaignType": "Mirror",
+        "nodeNumber": 11,
+        "reward": "Single Power Pack",
+        "expectedGold": 53
+    },
+    "SHM12": {
+        "campaign": "Saim-Hann Mirror",
+        "campaignType": "Mirror",
+        "nodeNumber": 12,
+        "reward": "Adamantium Ore",
+        "expectedGold": 53
+    },
+    "SHM13": {
+        "campaign": "Saim-Hann Mirror",
+        "campaignType": "Mirror",
+        "nodeNumber": 13,
+        "reward": "Mutation: Warped Lungs",
+        "expectedGold": 53
+    },
+    "SHM14": {
+        "campaign": "Saim-Hann Mirror",
+        "campaignType": "Mirror",
+        "nodeNumber": 14,
+        "reward": "Mutation: Warped Heart",
+        "expectedGold": 53
+    },
+    "SHM15": {
+        "campaign": "Saim-Hann Mirror",
+        "campaignType": "Mirror",
+        "nodeNumber": 15,
+        "reward": "Calandis",
+        "expectedGold": 59
+    },
+
+    "SHM16": {
+        "campaign": "Saim-Hann Mirror",
+        "campaignType": "Mirror",
+        "nodeNumber": 16,
+        "reward": "Pile of Salvage",
+        "expectedGold": 59
+    },
+    "SHM17": {
+        "campaign": "Saim-Hann Mirror",
+        "campaignType": "Mirror",
+        "nodeNumber": 17,
+        "reward": "Weapon Anointment Oils",
+        "expectedGold": 59
+    },
+    "SHM18": {
+        "campaign": "Saim-Hann Mirror",
+        "campaignType": "Mirror",
+        "nodeNumber": 18,
+        "reward": "Chip Damage",
+        "expectedGold": 59
+    },
+    "SHM19": {
+        "campaign": "Saim-Hann Mirror",
+        "campaignType": "Mirror",
+        "nodeNumber": 19,
+        "reward": "The Iron Phoenix",
+        "expectedGold": 59
+    },
+    "SHM2": {
+        "campaign": "Saim-Hann Mirror",
+        "campaignType": "Mirror",
+        "nodeNumber": 2,
+        "reward": "Nasty Spikes",
+        "expectedGold": 53
+    },
+    "SHM20": {
+        "campaign": "Saim-Hann Mirror",
+        "campaignType": "Mirror",
+        "nodeNumber": 20,
+        "reward": "Barrel of Promethium",
+        "expectedGold": 59
+    },
+    "SHM21": {
+        "campaign": "Saim-Hann Mirror",
+        "campaignType": "Mirror",
+        "nodeNumber": 21,
+        "reward": "Metal Joints",
+        "expectedGold": 59
+    },
+    "SHM22": {
+        "campaign": "Saim-Hann Mirror",
+        "campaignType": "Mirror",
+        "nodeNumber": 22,
+        "reward": "Round of Ammo",
+        "expectedGold": 59
+    },
+    "SHM23": {
+        "campaign": "Saim-Hann Mirror",
+        "campaignType": "Mirror",
+        "nodeNumber": 23,
+        "reward": "Nano Swarm",
+        "expectedGold": 59
+    },
+    "SHM24": {
+        "campaign": "Saim-Hann Mirror",
+        "campaignType": "Mirror",
+        "nodeNumber": 24,
+        "reward": "Frag Grenade",
+        "expectedGold": 59
+    },
+    "SHM25": {
+        "campaign": "Saim-Hann Mirror",
+        "campaignType": "Mirror",
+        "nodeNumber": 25,
+        "reward": "Ceramite Lump",
+        "expectedGold": 59
+    },
+    "SHM26": {
+        "campaign": "Saim-Hann Mirror",
+        "campaignType": "Mirror",
+        "nodeNumber": 26,
+        "reward": "Reinforced Cables",
+        "expectedGold": 59
+    },
+    "SHM27": {
+        "campaign": "Saim-Hann Mirror",
+        "campaignType": "Mirror",
+        "nodeNumber": 27,
+        "reward": "Blessed Tasset Plate",
+        "expectedGold": 59
+    },
+    "SHM28": {
+        "campaign": "Saim-Hann Mirror",
+        "campaignType": "Mirror",
+        "nodeNumber": 28,
+        "reward": "Slicing Claws",
+        "expectedGold": 59
+    },
+    "SHM29": {
+        "campaign": "Saim-Hann Mirror",
+        "campaignType": "Mirror",
+        "nodeNumber": 29,
+        "reward": "Ancient Runes",
+        "expectedGold": 59
+    },
+    "SHM3": {
+        "campaign": "Saim-Hann Mirror",
+        "campaignType": "Mirror",
+        "nodeNumber": 3,
+        "reward": "Sophisticated Material",
+        "expectedGold": 53
+    },
+    "SHM30": {
+        "campaign": "Saim-Hann Mirror",
+        "campaignType": "Mirror",
+        "nodeNumber": 30,
+        "reward": "Aethana",
+        "expectedGold": 65
+    },
+    "SHM4": {
+        "campaign": "Saim-Hann Mirror",
+        "campaignType": "Mirror",
+        "nodeNumber": 4,
+        "reward": "Can of Promethium",
+        "expectedGold": 53
+    },
+    "SHM5": {
+        "campaign": "Saim-Hann Mirror",
+        "campaignType": "Mirror",
+        "nodeNumber": 5,
+        "reward": "Armor Trim",
+        "expectedGold": 53
+    },
+    "SHM6": {
+        "campaign": "Saim-Hann Mirror",
+        "campaignType": "Mirror",
+        "nodeNumber": 6,
+        "reward": "Scrolls",
+        "expectedGold": 53
+    },
+    "SHM7": {
+        "campaign": "Saim-Hann Mirror",
+        "campaignType": "Mirror",
+        "nodeNumber": 7,
+        "reward": "Mission Assignment",
+        "expectedGold": 53
+    },
+    "SHM8": {
+        "campaign": "Saim-Hann Mirror",
+        "campaignType": "Mirror",
+        "nodeNumber": 8,
+        "reward": "Adamantium Filaments",
+        "expectedGold": 53
+    },
+    "SHM9": {
+        "campaign": "Saim-Hann Mirror",
+        "campaignType": "Mirror",
+        "nodeNumber": 9,
+        "reward": "Thick Skin",
+        "expectedGold": 53
+    },
     "IE1": {
         "campaign": "Indomitus Elite",
         "campaignType": "Elite",

--- a/src/assets/recipeData.json
+++ b/src/assets/recipeData.json
@@ -6365,5 +6365,19 @@
         "stat": "Shard",
         "faction": "Thousand Sons",
         "rarity": "Shard"
+    },
+    "Calandis": {
+        "material": "Calandis",
+        "craftable": false,
+        "stat": "Shard",
+        "faction": "Aeldari",
+        "rarity": "Shard"
+    },
+    "Aethana": {
+        "material": "Aethana",
+        "craftable": false,
+        "stat": "Shard",
+        "faction": "Aeldari",
+        "rarity": "Shard"
     }
 }

--- a/src/assets/shardsData.json
+++ b/src/assets/shardsData.json
@@ -286,5 +286,21 @@
         "faction": "Thousand Sons",
         "rarity": "Shard",
         "locations": ["SH75"]
+    },
+    "Calandis": {
+        "material": "Calandis",
+        "craftable": false,
+        "stat": "Shard",
+        "faction": "Aeldari",
+        "rarity": "Shard",
+        "locations": ["SHM15"]
+    },
+    "Aethana": {
+        "material": "Aethana",
+        "craftable": false,
+        "stat": "Shard",
+        "faction": "Aeldari",
+        "rarity": "Shard",
+        "locations": ["SH30"]
     }
 }

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -170,6 +170,7 @@ export const defaultCampaignsProgress: ICampaignsProgress = {
     'Octarius Mirror Elite': 40,
 
     'Saim-Hann': 75,
+    'Saim-Hann Mirror': 30,
 };
 
 export const campaignsNames: Array<keyof ICampaignsProgress> = Object.keys(defaultCampaignsProgress) as Array<

--- a/src/models/interfaces.ts
+++ b/src/models/interfaces.ts
@@ -697,6 +697,7 @@ export type ICampaignsProgress = {
     'Octarius Mirror Elite': number;
 
     'Saim-Hann': number;
+    'Saim-Hann Mirror': number;
 };
 
 export interface IInventory {


### PR DESCRIPTION
Add the first 2 blocks of missions of Saim-Hann Mirror. 
The rest are still blocked, so adding them in due time might make sense.

Note: If there's an argument to add placeholders for all the missions of the other three blocks, I can add them here.