### PR TITLE
Fixed typo in getStarsCoeff

### DIFF
--- a/src/v2/features/characters/characters-power.service.ts
+++ b/src/v2/features/characters/characters-power.service.ts
@@ -130,7 +130,7 @@ export class CharactersPowerService {
             case RarityStars.RedOneStar:
                 return 1.525;
             case RarityStars.RedTwoStars:
-                return 1.5;
+                return 1.55;
             case RarityStars.RedThreeStars:
                 return 1.575;
             case RarityStars.RedFourStars:


### PR DESCRIPTION
value for RedTwoStars was 1.5 same as for FiveStars. Changed it to 1.55.