### PR TITLE
Use parens to fix an order-of-operations bug resulting in NaN being d…

### DIFF
--- a/src/routes/tables/rankLookup.tsx
+++ b/src/routes/tables/rankLookup.tsx
@@ -194,7 +194,7 @@ export const RankLookup = () => {
         },
         {
             valueGetter: params => {
-                return Math.max(params.data.count - inventory.upgrades[params.data!.id] ?? 0, 0);
+                return Math.max(params.data!.count - (inventory.upgrades[params.data!.id] ?? 0), 0);
             },
             headerName: 'Remaining',
             maxWidth: 90,


### PR DESCRIPTION
…isplayed in the Rank Lookup page.