### PR TITLE
Allow duplicate upgrades to be applied individually

### DIFF
--- a/src/shared-components/character-upgrades.tsx
+++ b/src/shared-components/character-upgrades.tsx
@@ -79,8 +79,18 @@ export const CharacterUpgrades: React.FC<Props> = ({ upgradesChanges, upgrades, 
             const isNewUpgrade = rank !== formData.originalRank || !formData.originalUpgrades.includes(value);
             newUpgrades = isNewUpgrade ? [...formData.newUpgrades, value] : formData.newUpgrades;
         } else {
-            currentUpgrades = formData.currentUpgrades.filter(x => x !== value);
-            newUpgrades = formData.newUpgrades.filter(x => x !== value);
+            const c_idx = formData.currentUpgrades.indexOf(value);
+            const n_idx = formData.newUpgrades.indexOf(value);
+
+            currentUpgrades = [...formData.currentUpgrades];
+            if (c_idx !== -1) {
+                currentUpgrades.splice(c_idx, 1);
+            }
+
+            newUpgrades = [...formData.newUpgrades];
+            if (n_idx !== -1) {
+                newUpgrades.splice(c_idx, 1);
+            }
         }
 
         if (!newUpgrades.length) {
@@ -95,7 +105,9 @@ export const CharacterUpgrades: React.FC<Props> = ({ upgradesChanges, upgrades, 
     };
 
     const topLevelUpgrades = useMemo<Array<IBaseUpgrade | ICraftedUpgrade>>(() => {
-        const newUpgrades = possibleUpgrades.filter(x => formData.newUpgrades.includes(x.id));
+        const newUpgrades = formData.newUpgrades
+            .map(x => possibleUpgrades.find(y => y.id == x))
+            .filter(x => x !== undefined);
         let upgradesToConsider: Array<IBaseUpgrade | ICraftedUpgrade>;
 
         if (rank <= formData.originalRank) {
@@ -142,6 +154,17 @@ export const CharacterUpgrades: React.FC<Props> = ({ upgradesChanges, upgrades, 
         }
     }, [rank]);
 
+    const upgradeStack = [...formData.currentUpgrades];
+
+    const pop = (us: string[], find: string) => {
+        const upgrade = us.indexOf(find);
+        if (upgrade === -1) {
+            return false;
+        }
+        us.splice(upgrade, 1);
+        return true;
+    };
+
     return (
         <div>
             {hasDuplicateUpgrades && (
@@ -156,7 +179,7 @@ export const CharacterUpgrades: React.FC<Props> = ({ upgradesChanges, upgrades, 
                         <UpgradeControl
                             key={x.id + index}
                             upgrade={x}
-                            checked={formData.currentUpgrades.includes(x.id)}
+                            checked={pop(upgradeStack, x.id)}
                             checkedChanges={value => handleUpgradeChange(value, x.id)}
                         />
                     ))}
@@ -167,7 +190,7 @@ export const CharacterUpgrades: React.FC<Props> = ({ upgradesChanges, upgrades, 
                         <UpgradeControl
                             key={x.id + index}
                             upgrade={x}
-                            checked={formData.currentUpgrades.includes(x.id)}
+                            checked={pop(upgradeStack, x.id)}
                             checkedChanges={value => handleUpgradeChange(value, x.id)}
                         />
                     ))}
@@ -178,7 +201,7 @@ export const CharacterUpgrades: React.FC<Props> = ({ upgradesChanges, upgrades, 
                         <UpgradeControl
                             key={x.id + index}
                             upgrade={x}
-                            checked={formData.currentUpgrades.includes(x.id)}
+                            checked={pop(upgradeStack, x.id)}
                             checkedChanges={value => handleUpgradeChange(value, x.id)}
                         />
                     ))}
@@ -189,7 +212,7 @@ export const CharacterUpgrades: React.FC<Props> = ({ upgradesChanges, upgrades, 
                     <UpgradeControl
                         key={x.id + index}
                         upgrade={x}
-                        checked={formData.currentUpgrades.includes(x.id)}
+                        checked={pop(upgradeStack, x.id)}
                         checkedChanges={value => handleUpgradeChange(value, x.id)}
                     />
                 ))}

--- a/src/shared-components/character-upgrades.tsx
+++ b/src/shared-components/character-upgrades.tsx
@@ -70,6 +70,16 @@ export const CharacterUpgrades: React.FC<Props> = ({ upgradesChanges, upgrades, 
         [possibleUpgrades]
     );
 
+    /* Return true if the item existed in the array. The first matching item in the array will be removed */
+    const findAndRemoveItem = (arr: string[], x: string) => {
+        const itemIdx = arr.indexOf(x);
+        if (itemIdx === -1) {
+            return false;
+        }
+        arr.splice(itemIdx, 1);
+        return true;
+    };
+
     const handleUpgradeChange = (checked: boolean, value: string) => {
         let currentUpgrades: string[];
         let newUpgrades: string[];
@@ -79,18 +89,11 @@ export const CharacterUpgrades: React.FC<Props> = ({ upgradesChanges, upgrades, 
             const isNewUpgrade = rank !== formData.originalRank || !formData.originalUpgrades.includes(value);
             newUpgrades = isNewUpgrade ? [...formData.newUpgrades, value] : formData.newUpgrades;
         } else {
-            const c_idx = formData.currentUpgrades.indexOf(value);
-            const n_idx = formData.newUpgrades.indexOf(value);
-
             currentUpgrades = [...formData.currentUpgrades];
-            if (c_idx !== -1) {
-                currentUpgrades.splice(c_idx, 1);
-            }
+            findAndRemoveItem(currentUpgrades, value);
 
             newUpgrades = [...formData.newUpgrades];
-            if (n_idx !== -1) {
-                newUpgrades.splice(c_idx, 1);
-            }
+            findAndRemoveItem(newUpgrades, value);
         }
 
         if (!newUpgrades.length) {
@@ -156,15 +159,6 @@ export const CharacterUpgrades: React.FC<Props> = ({ upgradesChanges, upgrades, 
 
     const upgradeStack = [...formData.currentUpgrades];
 
-    const pop = (us: string[], find: string) => {
-        const upgrade = us.indexOf(find);
-        if (upgrade === -1) {
-            return false;
-        }
-        us.splice(upgrade, 1);
-        return true;
-    };
-
     return (
         <div>
             {hasDuplicateUpgrades && (
@@ -179,7 +173,7 @@ export const CharacterUpgrades: React.FC<Props> = ({ upgradesChanges, upgrades, 
                         <UpgradeControl
                             key={x.id + index}
                             upgrade={x}
-                            checked={pop(upgradeStack, x.id)}
+                            checked={findAndRemoveItem(upgradeStack, x.id)}
                             checkedChanges={value => handleUpgradeChange(value, x.id)}
                         />
                     ))}
@@ -190,7 +184,7 @@ export const CharacterUpgrades: React.FC<Props> = ({ upgradesChanges, upgrades, 
                         <UpgradeControl
                             key={x.id + index}
                             upgrade={x}
-                            checked={pop(upgradeStack, x.id)}
+                            checked={findAndRemoveItem(upgradeStack, x.id)}
                             checkedChanges={value => handleUpgradeChange(value, x.id)}
                         />
                     ))}
@@ -201,7 +195,7 @@ export const CharacterUpgrades: React.FC<Props> = ({ upgradesChanges, upgrades, 
                         <UpgradeControl
                             key={x.id + index}
                             upgrade={x}
-                            checked={pop(upgradeStack, x.id)}
+                            checked={findAndRemoveItem(upgradeStack, x.id)}
                             checkedChanges={value => handleUpgradeChange(value, x.id)}
                         />
                     ))}
@@ -212,7 +206,7 @@ export const CharacterUpgrades: React.FC<Props> = ({ upgradesChanges, upgrades, 
                     <UpgradeControl
                         key={x.id + index}
                         upgrade={x}
-                        checked={pop(upgradeStack, x.id)}
+                        checked={findAndRemoveItem(upgradeStack, x.id)}
                         checkedChanges={value => handleUpgradeChange(value, x.id)}
                     />
                 ))}

--- a/src/shared-components/character-upgrades.tsx
+++ b/src/shared-components/character-upgrades.tsx
@@ -56,11 +56,6 @@ export const CharacterUpgrades: React.FC<Props> = ({ upgradesChanges, upgrades, 
         return rankUpgrades.upgrades.map(x => UpgradesService.getUpgrade(x));
     }, [rank]);
 
-    const hasDuplicateUpgrades = useMemo(() => {
-        const upgrades = groupBy(possibleUpgrades.map(x => x.id));
-        return Object.values(upgrades).some(x => x.length === 2);
-    }, [possibleUpgrades]);
-
     const healthUpgrades = useMemo(() => possibleUpgrades.filter(x => x.stat === 'Health'), [possibleUpgrades]);
     const damageUpgrades = useMemo(() => possibleUpgrades.filter(x => x.stat === 'Damage'), [possibleUpgrades]);
     const armourUpgrades = useMemo(() => possibleUpgrades.filter(x => x.stat === 'Armour'), [possibleUpgrades]);
@@ -161,11 +156,6 @@ export const CharacterUpgrades: React.FC<Props> = ({ upgradesChanges, upgrades, 
 
     return (
         <div>
-            {hasDuplicateUpgrades && (
-                <div className="flex-box gap3">
-                    <Warning color="warning" /> Duplicated upgrades will be applied both at once
-                </div>
-            )}
             <div style={{ display: 'flex' }}>
                 <div className="upgrades-column">
                     <MiscIcon icon={'health'} height={30} />

--- a/src/shared-logic/functions.ts
+++ b/src/shared-logic/functions.ts
@@ -191,3 +191,18 @@ function getDaySuffix(day: number) {
             return 'th';
     }
 }
+
+/* Find and remove the first occurrence of an item from an array.
+ * IMPORTANT: This function modifies the input array directly.
+ * @param arr - The array to modify (will be changed by this function)
+ * @param x - The item to find and remove
+ * @return true if the item was found and removed, false otherwise
+ */
+export const findAndRemoveItem = <T>(arr: T[], x: T) => {
+    const itemIdx = arr.indexOf(x);
+    if (itemIdx === -1) {
+        return false;
+    }
+    arr.splice(itemIdx, 1);
+    return true;
+};


### PR DESCRIPTION
First stab at fixing the issue https://github.com/svehera/tacticusplanner/issues/146

Make a temp copy of the currentUpgrades array and remove an item from it when creating each of the UpgradeControl components.

Otherwise replace a few places where we were filtering with a similar approach that maintains the count of items in the array.

Seems to work with a little manual testing. 

I think I've got the inventory update bit working as well. Not sure if there's anything else that would be impacted here that I should test.

<img width="391" alt="image" src="https://github.com/user-attachments/assets/7623fcee-d922-45dd-8496-cf58882fae39" />
<img width="281" alt="image" src="https://github.com/user-attachments/assets/8e988088-1456-4081-9572-0b8bbb012a59" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new method for removing items from upgrade selections, enhancing the management of upgrades.
- **Refactor**
  - Streamlined the handling of upgrade changes by directly updating selections, resulting in improved responsiveness.
  - Optimized the logic for determining available upgrade options to ensure accurate, efficient processing.
  - Enhanced update operations to deliver faster and more reliable interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->