### PR TITLE
Fix a bug that would surface when calculating base stats for ascension goals.

### DIFF
--- a/src/routes/goals/goals-table.tsx
+++ b/src/routes/goals/goals-table.tsx
@@ -303,7 +303,7 @@ export const GoalsTable: React.FC<Props> = ({ rows, estimate, menuItemSelect }) 
                                     <MiscIcon icon="health" width={15} height={15} />
                                     {StatCalculatorService.calculateHealth(
                                         data.unitId,
-                                        getUnitRarity(data.unitId),
+                                        data.rarityStart,
                                         data.starsStart,
                                         getUnitRank(data.unitId),
                                         StatCalculatorService.countHealthUpgrades(getUnit(data.unitId))
@@ -311,10 +311,10 @@ export const GoalsTable: React.FC<Props> = ({ rows, estimate, menuItemSelect }) 
                                     <ArrowForward width={15} height={15} />
                                     {StatCalculatorService.calculateHealth(
                                         data.unitId,
-                                        getUnitRarity(data.unitId),
+                                        data.rarityEnd,
                                         data.starsEnd,
                                         getUnitRank(data.unitId),
-                                        0
+                                        StatCalculatorService.countHealthUpgrades(getUnit(data.unitId))
                                     )}
                                 </div>
                             );
@@ -355,7 +355,7 @@ export const GoalsTable: React.FC<Props> = ({ rows, estimate, menuItemSelect }) 
                                     <MiscIcon icon="damage" width={15} height={15} />
                                     {StatCalculatorService.calculateDamage(
                                         data.unitId,
-                                        getUnitRarity(data.unitId),
+                                        data.rarityStart,
                                         data.starsStart,
                                         getUnitRank(data.unitId),
                                         StatCalculatorService.countDamageUpgrades(getUnit(data.unitId))
@@ -363,10 +363,10 @@ export const GoalsTable: React.FC<Props> = ({ rows, estimate, menuItemSelect }) 
                                     <ArrowForward width={15} height={15} />
                                     {StatCalculatorService.calculateDamage(
                                         data.unitId,
-                                        getUnitRarity(data.unitId),
+                                        data.rarityEnd,
                                         data.starsEnd,
                                         getUnitRank(data.unitId),
-                                        0
+                                        StatCalculatorService.countDamageUpgrades(getUnit(data.unitId))
                                     )}
                                 </div>
                             );
@@ -407,7 +407,7 @@ export const GoalsTable: React.FC<Props> = ({ rows, estimate, menuItemSelect }) 
                                     <MiscIcon icon="armour" width={15} height={15} />
                                     {StatCalculatorService.calculateArmor(
                                         data.unitId,
-                                        getUnitRarity(data.unitId),
+                                        data.rarityStart,
                                         data.starsStart,
                                         getUnitRank(data.unitId),
                                         StatCalculatorService.countArmorUpgrades(getUnit(data.unitId))
@@ -415,10 +415,10 @@ export const GoalsTable: React.FC<Props> = ({ rows, estimate, menuItemSelect }) 
                                     <ArrowForward width={15} height={15} />
                                     {StatCalculatorService.calculateArmor(
                                         data.unitId,
-                                        getUnitRarity(data.unitId),
+                                        data.rarityEnd,
                                         data.starsEnd,
                                         getUnitRank(data.unitId),
-                                        0
+                                        StatCalculatorService.countArmorUpgrades(getUnit(data.unitId))
                                     )}
                                 </div>
                             );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Balance Changes**
  - Refined unit statistics for improved gameplay: one unit now gains higher health with a slight reduction in damage, while another sees a decrease in armour.

- **Refactor**
  - Enhanced stat calculations to better account for unit rarity and upgrade levels, delivering more accurate performance outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->