### PR TITLE
[WIP] Allow Drag-and-drop to change Priority of Goals

### DIFF
--- a/src/routes/goals/goals-table.tsx
+++ b/src/routes/goals/goals-table.tsx
@@ -30,7 +30,6 @@ import { StatCalculatorService } from 'src/v2/functions/stat-calculator-service'
 import { StaticDataService } from 'src/services';
 import { StoreContext } from 'src/reducers/store.provider';
 import { ICharacter2 } from 'src/models/interfaces';
-
 interface Props {
     rows: CharacterRaidGoalSelect[];
     estimate: IGoalEstimate[];

--- a/src/routes/goals/goals.tsx
+++ b/src/routes/goals/goals.tsx
@@ -1,4 +1,4 @@
-﻿import React, { useContext, useMemo, useState } from 'react';
+﻿import React, { useContext, useMemo, useState, useRef } from 'react';
 import { SetGoalDialog } from 'src/shared-components/goals/set-goal-dialog';
 import { EditGoalDialog } from 'src/shared-components/goals/edit-goal-dialog';
 import { PersonalGoalType, Rank } from 'src/models/enums';
@@ -41,6 +41,10 @@ export const Goals = () => {
 
     const [editGoal, setEditGoal] = useState<CharacterRaidGoalSelect | null>(null);
     const [editUnit, setEditUnit] = useState<IUnit>(characters[0]);
+
+    const upgradeRankOrMowGoalsContainerRef = useRef<HTMLDivElement>(null);
+    const shardsGoalsContainerRef = useRef<HTMLDivElement>(null);
+    const abilitiesContainerRef = useRef<HTMLDivElement>(null);
 
     const { allGoals, shardsGoals, upgradeRankOrMowGoals, upgradeAbilities } = useMemo(() => {
         return GoalsService.prepareGoals(goals, [...characters, ...mows], false);
@@ -258,13 +262,15 @@ export const Goals = () => {
                         </span>
                     </div>
                     {!viewPreferences.goalsTableView && (
-                        <div className="flex gap-3 flex-wrap">
+                        <div className="flex gap-3 flex-wrap" ref={upgradeRankOrMowGoalsContainerRef}>
                             {upgradeRankOrMowGoals.map(goal => (
                                 <GoalCard
                                     key={goal.goalId}
                                     goal={goal}
                                     goalEstimate={goalsEstimate.find(x => x.goalId === goal.goalId)}
                                     menuItemSelect={item => handleMenuItemSelect(goal.goalId, item)}
+                                    containerRef={upgradeRankOrMowGoalsContainerRef}
+                                    goalList={upgradeRankOrMowGoals}
                                 />
                             ))}
                         </div>
@@ -295,13 +301,15 @@ export const Goals = () => {
                         </span>
                     </div>
                     {!viewPreferences.goalsTableView && (
-                        <div className="flex gap-3 flex-wrap">
+                        <div className="flex gap-3 flex-wrap" ref={shardsGoalsContainerRef}>
                             {shardsGoals.map(goal => (
                                 <GoalCard
                                     key={goal.goalId}
                                     goal={goal}
                                     goalEstimate={goalsEstimate.find(x => x.goalId === goal.goalId)}
                                     menuItemSelect={item => handleMenuItemSelect(goal.goalId, item)}
+                                    containerRef={shardsGoalsContainerRef}
+                                    goalList={shardsGoals}
                                 />
                             ))}
                         </div>
@@ -324,13 +332,15 @@ export const Goals = () => {
                         </span>
                     </div>
                     {!viewPreferences.goalsTableView && (
-                        <div className="flex gap-3 flex-wrap">
+                        <div className="flex gap-3 flex-wrap" ref={abilitiesContainerRef}>
                             {upgradeAbilities.map(goal => (
                                 <GoalCard
                                     key={goal.goalId}
                                     goal={goal}
                                     goalEstimate={goalsEstimate.find(x => x.goalId === goal.goalId)}
                                     menuItemSelect={item => handleMenuItemSelect(goal.goalId, item)}
+                                    containerRef={abilitiesContainerRef}
+                                    goalList={upgradeAbilities}
                                 />
                             ))}
                         </div>


### PR DESCRIPTION
Very quick WIP to see if this is something that would be desired.

I've found it a pain point myself.

If there is interest in the functionality I'll complete it to work better and apply it to the table view also.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a more intuitive drag-and-drop mechanism for reordering goal cards, complete with a dedicated drag handle.
  - Improved goal organization by clearly segmenting items into distinct sections for easier navigation.
  - Enhanced interactivity, simplifying goal management across the app.

- **Refactor**
  - Streamlined the goals table interface by removing redundant menu options for a cleaner user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->