### PR TITLE
Add detailed NPC info for Octarius Mirror and Saim-Hann

### DIFF
--- a/src/assets/newBattleData.json
+++ b/src/assets/newBattleData.json
@@ -15839,6 +15839,12 @@
                 "count": 2,
                 "rank": "Silver 3",
                 "stars": 11
+            },
+            {
+                "name": "Scarab Swarm",
+                "count": 2,
+                "rank": "Gold 1",
+                "stars": 10
             }
         ]
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Expanded battle information by adding a new entry for "Scarab Swarm" featuring a count of 2, a rank of Gold 1, and a star rating of 10.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->