### PR TITLE
Fix the core characters for the Tyranid campaign

### DIFF
--- a/src/assets/UnitData.json
+++ b/src/assets/UnitData.json
@@ -24,6 +24,7 @@
         "Number": 1,
         "ForcedSummons": false,
         "RequiredInCampaign": true,
+        "CampaignsRequiredIn": ["Indomitus"],
         "Icon": "VarroTigurius.webp"
     },
     {
@@ -51,6 +52,7 @@
         "Number": 2,
         "ForcedSummons": false,
         "RequiredInCampaign": true,
+        "CampaignsRequiredIn": ["Indomitus"],
         "Icon": "certus-removebg-preview.webp"
     },
     {
@@ -75,6 +77,7 @@
         "Number": 3,
         "ForcedSummons": false,
         "RequiredInCampaign": true,
+        "CampaignsRequiredIn": ["Indomitus", "Tyranids"],
         "Icon": "bellator.webp"
     },
     {
@@ -98,6 +101,7 @@
         "Number": 4,
         "ForcedSummons": false,
         "RequiredInCampaign": false,
+        "CampaignsRequiredIn": ["Tyranids"],
         "Icon": "incisus-removebg-preview.webp"
     },
     {
@@ -146,6 +150,7 @@
         "Number": 79,
         "ForcedSummons": false,
         "RequiredInCampaign": false,
+        "CampaignsRequiredIn": ["Tyranids"],
         "Icon": "titus.webp",
         "releaseDate": "2024-09-01T00:00:00Z"
     },
@@ -173,6 +178,7 @@
         "Number": 21,
         "ForcedSummons": false,
         "RequiredInCampaign": true,
+        "CampaignsRequiredIn": ["Indomitus Mirror"],
         "Icon": "Makhotep-removebg-preview.webp"
     },
     {
@@ -200,6 +206,7 @@
         "Number": 22,
         "ForcedSummons": false,
         "RequiredInCampaign": true,
+        "CampaignsRequiredIn": ["Indomitus Mirror"],
         "Icon": "Imospekh-removebg-preview.webp"
     },
     {
@@ -223,6 +230,7 @@
         "Number": 23,
         "ForcedSummons": false,
         "RequiredInCampaign": true,
+        "CampaignsRequiredIn": ["Indomitus Mirror"],
         "Icon": "Aleph-null.webp"
     },
     {
@@ -304,6 +312,7 @@
         "Number": 26,
         "ForcedSummons": false,
         "RequiredInCampaign": true,
+        "CampaignsRequiredIn": ["Fall of Cadia Mirror"],
         "Icon": "Sibyll-removebg-preview.webp"
     },
     {
@@ -354,6 +363,7 @@
         "Number": 28,
         "ForcedSummons": false,
         "RequiredInCampaign": true,
+        "CampaignsRequiredIn": ["Fall of Cadia Mirror"],
         "Icon": "Kutskoden-removebg-preview.webp"
     },
     {
@@ -381,6 +391,7 @@
         "Number": 29,
         "ForcedSummons": false,
         "RequiredInCampaign": true,
+        "CampaignsRequiredIn": ["Fall of Cadia Mirror"],
         "Icon": "Thaddeusnoble-removebg-preview.webp"
     },
     {
@@ -429,6 +440,7 @@
         "Number": 6,
         "ForcedSummons": false,
         "RequiredInCampaign": true,
+        "CampaignsRequiredIn": ["Fall of Cadia"],
         "Icon": "Angrax.webp"
     },
     {
@@ -483,6 +495,7 @@
         "Number": 8,
         "ForcedSummons": true,
         "RequiredInCampaign": true,
+        "CampaignsRequiredIn": ["Fall of Cadia"],
         "Icon": "archimatos.webp"
     },
     {
@@ -507,6 +520,7 @@
         "Number": 9,
         "ForcedSummons": false,
         "RequiredInCampaign": true,
+        "CampaignsRequiredIn": ["Fall of Cadia"],
         "Icon": "HaarkenWorldclaimer-removebg-preview.webp"
     },
     {
@@ -711,6 +725,7 @@
         "Number": 12,
         "ForcedSummons": false,
         "RequiredInCampaign": true,
+        "CampaignsRequiredIn": ["Octarius"],
         "Icon": "Gibbascrapz-removebg-preview.webp"
     },
     {
@@ -738,6 +753,7 @@
         "Number": 13,
         "ForcedSummons": false,
         "RequiredInCampaign": true,
+        "CampaignsRequiredIn": ["Octarius"],
         "Icon": "Snappawrecka-removebg-preview.webp"
     },
     {
@@ -789,6 +805,7 @@
         "Number": 15,
         "ForcedSummons": false,
         "RequiredInCampaign": true,
+        "CampaignsRequiredIn": ["Octarius"],
         "Icon": "BossGulgortz-removebg-preview.webp"
     },
     {
@@ -813,6 +830,7 @@
         "Number": 36,
         "ForcedSummons": false,
         "RequiredInCampaign": true,
+        "CampaignsRequiredIn": ["Octarius Mirror"],
         "Icon": "sbg-removebg-preview.webp"
     },
     {
@@ -841,6 +859,7 @@
         "Number": 37,
         "ForcedSummons": false,
         "RequiredInCampaign": true,
+        "CampaignsRequiredIn": ["Octarius Mirror"],
         "Icon": "brotherBurchard-removebg-preview.webp"
     },
     {
@@ -864,6 +883,7 @@
         "Number": 38,
         "ForcedSummons": false,
         "RequiredInCampaign": true,
+        "CampaignsRequiredIn": ["Octarius Mirror"],
         "Icon": "AncientThoread.webp"
     },
     {
@@ -967,6 +987,7 @@
         "Number": 32,
         "ForcedSummons": false,
         "RequiredInCampaign": true,
+        "CampaignsRequiredIn": ["Adeptus Mechanicus"],
         "Icon": "Maladus-removebg-preview.webp"
     },
     {
@@ -1015,6 +1036,7 @@
         "Number": 34,
         "ForcedSummons": false,
         "RequiredInCampaign": true,
+        "CampaignsRequiredIn": ["Adeptus Mechanicus"],
         "Icon": "Pestillian-removebg-preview.webp"
     },
     {
@@ -1038,6 +1060,7 @@
         "Number": 35,
         "ForcedSummons": false,
         "RequiredInCampaign": true,
+        "CampaignsRequiredIn": ["Adeptus Mechanicus"],
         "Icon": "Corrodius-removebg-preview.webp"
     },
     {
@@ -1065,6 +1088,7 @@
         "Number": 41,
         "ForcedSummons": false,
         "RequiredInCampaign": true,
+        "CampaignsRequiredIn": ["Saim-Hann"],
         "Icon": "Calandis-removebg-preview.webp"
     },
     {
@@ -1089,6 +1113,7 @@
         "Number": 42,
         "ForcedSummons": false,
         "RequiredInCampaign": true,
+        "CampaignsRequiredIn": ["Saim-Hann"],
         "Icon": "Aethana.webp"
     },
     {
@@ -1116,6 +1141,7 @@
         "Number": 43,
         "ForcedSummons": false,
         "RequiredInCampaign": true,
+        "CampaignsRequiredIn": ["Saim-Hann"],
         "Icon": "eldryon-removebg-preview.webp"
     },
     {
@@ -1468,6 +1494,7 @@
         "Number": 55,
         "ForcedSummons": false,
         "RequiredInCampaign": true,
+        "CampaignsRequiredIn": ["Saim-Hann Mirror"],
         "Icon": "Yazaghor.webp"
     },
     {
@@ -1495,6 +1522,7 @@
         "Number": 56,
         "ForcedSummons": false,
         "RequiredInCampaign": true,
+        "CampaignsRequiredIn": ["Saim-Hann Mirror"],
         "Icon": "toth.webp"
     },
     {
@@ -1523,6 +1551,7 @@
         "Number": 57,
         "ForcedSummons": false,
         "RequiredInCampaign": true,
+        "CampaignsRequiredIn": ["Saim-Hann Mirror"],
         "Icon": "Abraxas.webp"
     },
     {

--- a/src/models/interfaces.ts
+++ b/src/models/interfaces.ts
@@ -78,6 +78,15 @@ export interface UnitDataRaw {
     Number: number;
     ForcedSummons: boolean;
     RequiredInCampaign: boolean;
+    /**
+     * The prefix of each campaign in which this character is required. Some examples:
+     * - 'Maladus' would be ['Adeptus Mechanicus']
+     * - 'Bellator' would be ['Indomitus', 'Tyranids']
+     *
+     * By using prefixes, we ensure that the elite, extremis, and challenge campaigns
+     * will be included in the list of required campaigns.
+     */
+    CampaignsRequiredIn?: string[];
     Icon: string;
     ReleaseRarity?: CharacterReleaseRarity;
     releaseDate?: string;
@@ -111,6 +120,7 @@ export interface IUnitData {
     movement: number;
     forcedSummons: boolean;
     requiredInCampaign: boolean;
+    campaignsRequiredIn?: string[];
     icon: string;
     legendaryEvents: ICharLegendaryEvents;
     lre?: ILreCharacterStaticData;

--- a/src/services/static-data.service.ts
+++ b/src/services/static-data.service.ts
@@ -333,6 +333,7 @@ export class StaticDataService {
             movement: rawData.Movement,
             forcedSummons: rawData.ForcedSummons,
             requiredInCampaign: rawData.RequiredInCampaign,
+            campaignsRequiredIn: rawData.CampaignsRequiredIn,
             legendaryEvents: {} as ICharLegendaryEvents,
             traits: rawData.Traits,
             icon: rawData.Icon,

--- a/src/v2/features/campaigns/campaign-progress.tsx
+++ b/src/v2/features/campaigns/campaign-progress.tsx
@@ -67,8 +67,17 @@ export const CampaignProgress: React.FC<Props> = ({
 
     // Filter characters required for the campaign.
     const coreCharacters = useMemo(
-        () => characters.filter(x => x.faction === campaign.faction && x.requiredInCampaign),
-        [characters]
+        () =>
+            characters.filter(x => {
+                if (x.campaignsRequiredIn == undefined) return false;
+                return x.campaignsRequiredIn!.reduce((inCampaign, campaignPrefix) => {
+                    if (campaign.name.indexOf('Mirror') != -1 && campaignPrefix.indexOf('Mirror') == -1) {
+                        return inCampaign;
+                    }
+                    return campaign.name.startsWith(campaignPrefix);
+                }, false);
+            }),
+        [characters, campaign]
     );
 
     const updateProgress = (value: number): void => {

--- a/src/v2/pages/my-progress/my-progress.tsx
+++ b/src/v2/pages/my-progress/my-progress.tsx
@@ -17,6 +17,7 @@ export const MyProgress = () => {
     const dispatch = useContext(DispatchContext);
 
     const standardCampaignsByGroup = Object.entries(groupBy(CampaignsService.standardCampaigns, 'groupType'));
+    const campaignEventsByGroup = Object.entries(groupBy(CampaignsService.campaignEvents, 'groupType'));
 
     const updateCampaignProgress = (id: Campaign, value: number) => {
         dispatch.campaignsProgress({
@@ -53,7 +54,13 @@ export const MyProgress = () => {
                 ))}
             </div>
             <h2>Campaign Events</h2>
-            <div className="flex gap-10 flex-wrap">{CampaignsService.campaignEvents.map(renderCampaignProgress)}</div>
+            <div className="flex gap-10 flex-wrap">
+                {campaignEventsByGroup.map(([group, campaigns]) => (
+                    <div key={group} className="flex gap-10 flex-wrap">
+                        {campaigns.map(renderCampaignProgress)}
+                    </div>
+                ))}
+            </div>
         </>
     );
 };


### PR DESCRIPTION
Fix the core characters for the Tyranid campaign by specifying the campaigns in which a character is required. This is necessary because the new Tyranids campaign requires the Ultramarines, and this is the first time we have two campaigns requiring the same faction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - **Enhanced Unit Campaign Details:** Units now display precise campaign associations that clarify their required roles.
  - **Improved Campaign Progress:** Updated filtering ensures that only relevant characters are shown based on campaign-specific criteria.
  - **Organized Event Display:** Campaign events on the progress page are now grouped by type for a clearer, more navigable experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->