### PR TITLE
Bug fixes

### DIFF
--- a/src/assets/UnitData.json
+++ b/src/assets/UnitData.json
@@ -2363,7 +2363,7 @@
         "Melee Damage": "Projectile",
         "Melee Hits": 3,
         "Ranged Damage": "Projectile",
-        "Ranged Hits": 1,
+        "Ranged Hits": 3,
         "Distance": 2,
         "Movement": 3,
         "Equipment1": "Crit",

--- a/src/assets/WhatsNew.json
+++ b/src/assets/WhatsNew.json
@@ -590,7 +590,7 @@
                 {
                     "text": "Added learn Guides feature. This is the first iteration for the feature so please share your feedback",
                     "subPoints": [
-                        "Find or create guides for specific game modes (Guid Raids, Tournament Arena, Guild Wars)",
+                        "Find or create guides for specific game modes (Guild Raids, Tournament Arena, Guild Wars)",
                         "Anyone can view/share guides but only logged in users can create a guide",
                         "Guide will be moderated before being publicly available",
                         "Team in the guide can consist of 5 characters and 1 mow. Each slot can be turned into \"flex\" and fit up to 3 characters. MoW slot is optional"
@@ -629,7 +629,7 @@
                     "text": "Added popup that shows up when user is not logged in. You can still use app without account"
                 },
                 {
-                    "text": "Included MoWs data into Insights and Guid Insights",
+                    "text": "Included MoWs data into Insights and Guild Insights",
                     "route": "learn/insights",
                     "images": [
                         {
@@ -1455,7 +1455,7 @@
                     ]
                 },
                 {
-                    "text": "Updated Guid War defense page",
+                    "text": "Updated Guild War defense page",
                     "subPoints": [
                         "Added \"Zone difficulty\" selector instead of BF level and Section selectors",
                         "Moved total teams to the battle field levels info table"

--- a/src/assets/rankUpData.json
+++ b/src/assets/rankUpData.json
@@ -11525,7 +11525,7 @@
             "Quake Bolts",
             "Digital Weapons",
             "Purity Seal of the Primarch",
-            "Ancient Tasset Plate"
+            "Relic Tasset Plate"
         ],
         "Gold I": [
             "Bloodstone Icon",

--- a/src/assets/rankUpData.json
+++ b/src/assets/rankUpData.json
@@ -10807,7 +10807,7 @@
         "Bronze II": [
             "Blessed Brazen Jaws",
             "Advanced Bionics",
-            "Classified Data-Slate",
+            "Krak Grenade",
             "Refined Combat Stimms",
             "Cadaere Renissum",
             "Mutation: Warped Skin"

--- a/src/v2/features/tacticus-integration/tacticus-integration.dialog.tsx
+++ b/src/v2/features/tacticus-integration/tacticus-integration.dialog.tsx
@@ -125,7 +125,7 @@ export const TacticusIntegrationDialog: React.FC<Props> = ({
                         />
                         <TextField
                             name={`guildApikey-${Math.random()}`}
-                            description="Used to fetch Guid Raid data. Ask your guild leader or co-leader to generate API jey with 'Guild Raid' and 'Guild' scopes"
+                            description="Used to fetch Guild Raid data. Ask your guild leader or co-leader to generate API key with 'Guild Raid' and 'Guild' scopes"
                             type="password"
                             label="Guild API key"
                             className="w-[80%]"
@@ -137,7 +137,7 @@ export const TacticusIntegrationDialog: React.FC<Props> = ({
                         <TextField
                             name={`apikey-${Math.random()}`}
                             type="password"
-                            description="Used to identify your account in the Guid Raid data"
+                            description="Used to identify your account in the Guild Raid data"
                             label="Tacticus User ID"
                             className="w-[80%]"
                             value={userId}


### PR DESCRIPTION
This PR addresses a few bugs that were hanging around the Tacticus Planner Discord.

- Judh Ranged hits bug [reported by Raptor](https://discord.com/channels/1146809197023997972/1146809197023997975/1367133478658900028)
- Tarvakh upgrade bug [reported by Unlucky☆SirEldricIV](https://discord.com/channels/1146809197023997972/1362587355726217276/1362587355726217276) (not Kharn, CodeRabbit got that wrong)
- Sync screen typo [reported by Lobo](https://discord.com/channels/1146809197023997972/1362317520614326476/1362317520614326476)
- Dante upgrade bug [reported by Janson](https://discord.com/channels/1146809197023997972/1361514583118057755/1361514583118057755) (not Mataneo, CodeRabbit got that one wrong)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected typographical errors in the "What's New" section and Tacticus Integration dialog, ensuring "Guild" is used instead of "Guid" and fixing minor wording issues.
- **Data Updates**
  - Updated the "Ranged Hits" for the unit "Judh" from 1 to 3.
  - Replaced "Classified Data-Slate" with "Krak Grenade" for "Kharn" at "Bronze II" rank.
  - Replaced "Ancient Tasset Plate" with "Relic Tasset Plate" for "Mataneo" at "Silver III" rank.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->