### PR TITLE
Add Cawl and Survival to teams

### DIFF
--- a/src/v2/features/teams/components/teams-grid.tsx
+++ b/src/v2/features/teams/components/teams-grid.tsx
@@ -28,6 +28,7 @@ export const TeamsGrid: React.FC<Props> = ({ teams, characters, mows, deleteTeam
     const guildRaidTeams = teams.filter(x => x.primaryGameMode === GameMode.guildRaids);
     const taTeams = teams.filter(x => x.primaryGameMode === GameMode.tournamentArena);
     const gwTeams = teams.filter(x => x.primaryGameMode === GameMode.guildWar);
+    const survivalTeams = teams.filter(x => x.primaryGameMode === GameMode.survival);
 
     const renderTeam = (team: IPersonalTeam) => {
         const teamCharacters = team.lineup.map(id => characters.find(character => id === character.id)!);
@@ -156,6 +157,13 @@ export const TeamsGrid: React.FC<Props> = ({ teams, characters, mows, deleteTeam
                 <div>
                     <h2>Guild War</h2>
                     <div className="flex gap-3 flex-wrap items-center">{gwTeams.map(renderCappedTeam)}</div>
+                </div>
+            )}
+
+            {!!survivalTeams.length && (
+                <div>
+                    <h2>Survival</h2>
+                    <div className="flex gap-3 flex-wrap items-center">{survivalTeams.map(renderCappedTeam)}</div>
                 </div>
             )}
         </div>

--- a/src/v2/features/teams/teams.constants.ts
+++ b/src/v2/features/teams/teams.constants.ts
@@ -20,6 +20,11 @@ export const gameModes: IMenuOption[] = [
         label: 'Guild War',
         selected: false,
     },
+    {
+        value: GameMode.survival,
+        label: 'Survival',
+        selected: false,
+    },
 ];
 
 export const gameModesForGuides: IMenuOption[] = [

--- a/src/v2/features/teams/teams.constants.ts
+++ b/src/v2/features/teams/teams.constants.ts
@@ -46,6 +46,11 @@ export const guildRaidBosses: IMenuOption[] = [
         selected: false,
     },
     {
+        value: GuildRaidBoss.cawl,
+        label: 'Belisarius Cawl',
+        selected: false,
+    },
+    {
         value: GuildRaidBoss.ghazghkull,
         label: 'Ghazghkull',
         selected: false,
@@ -96,6 +101,16 @@ export const guildRaidPrimes: IMenuOption[] = [
     {
         value: GuildRaidBoss.avatar + rightSidePrimeSuffix,
         label: 'Eldryon (Avatar)',
+        selected: false,
+    },
+    {
+        value: GuildRaidBoss.cawl + leftSidePrimeSuffix,
+        label: "Tan Gi'da (Cawl)",
+        selected: false,
+    },
+    {
+        value: GuildRaidBoss.cawl + rightSidePrimeSuffix,
+        label: 'Actus (Cawl)',
         selected: false,
     },
     {
@@ -225,6 +240,9 @@ export const grEncounterToFaction: Record<string, Faction> = {
     [GuildRaidBoss.avatar]: Faction.Aeldari,
     [GuildRaidBoss.avatar + leftSidePrimeSuffix]: Faction.Aeldari,
     [GuildRaidBoss.avatar + rightSidePrimeSuffix]: Faction.Aeldari,
+    [GuildRaidBoss.cawl]: Faction.AdeptusMechanicus,
+    [GuildRaidBoss.cawl + leftSidePrimeSuffix]: Faction.AdeptusMechanicus,
+    [GuildRaidBoss.cawl + rightSidePrimeSuffix]: Faction.AdeptusMechanicus,
     [GuildRaidBoss.ghazghkull]: Faction.Orks,
     [GuildRaidBoss.ghazghkull + leftSidePrimeSuffix]: Faction.Orks,
     [GuildRaidBoss.ghazghkull + rightSidePrimeSuffix]: Faction.Orks,

--- a/src/v2/features/teams/teams.enums.ts
+++ b/src/v2/features/teams/teams.enums.ts
@@ -16,6 +16,7 @@ export enum GuildRaidBoss {
     screamerKiller = '_screamer',
     szarekh = '_szarekh',
     tervigon = '_tervigon',
+    cawl = '_cawl',
 }
 
 export enum TaMode {

--- a/src/v2/features/teams/teams.enums.ts
+++ b/src/v2/features/teams/teams.enums.ts
@@ -4,6 +4,7 @@
     guildWar = '_gw',
     legendaryRelease = '_lre',
     incursion = '_inc',
+    survival = '_sur',
 }
 
 export enum GuildRaidBoss {


### PR DESCRIPTION
This PR adds the Belisarius Cawl boss to Guild Raids teams, and adds Survival mode to teams as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for a new "Survival" game mode, including filtering and displaying teams with this mode in a dedicated section.
  - Introduced a new guild raid boss, "Belisarius Cawl," and its prime variants "Tan Gi'da (Cawl)" and "Actus (Cawl)."

- **Enhancements**
  - Updated faction associations to include the new boss and its variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->