### PR TITLE
Fix Tarvakh's D2->3 bottom-line upgrades.

### DIFF
--- a/src/assets/rankUpData.json
+++ b/src/assets/rankUpData.json
@@ -10878,11 +10878,11 @@
         ],
         "Diamond II": [
             "Mark of Khorne",
-            "Preternatural Constitution",
+            "Superaugmented Constitution",
             "Butcher's Nails",
-            "Preternatural Strength",
+            "Superaugmented Strength",
             "Collar of Khorne",
-            "Preternatural Defences"
+            "Superaugmented Defences"
         ]
     },
     "Mataneo": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated item names for "Kharn" and "Tarvakh" at the "Diamond II" rank to use "Superaugmented" items instead of "Preternatural" items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->