### PR TITLE
Fix React hooks error in learn > guild page

### DIFF
--- a/src/v2/features/tacticus-integration/guild-raid-v2.tsx
+++ b/src/v2/features/tacticus-integration/guild-raid-v2.tsx
@@ -393,32 +393,8 @@ export const TacticusGuildRaidVisualization: React.FC<{ userIdMapper: (userId: s
 
     const stats = calculateStats();
 
-    if (loading) {
-        return (
-            <div className="flex items-center justify-center h-64">
-                <div className="text-muted-fg">Loading raid data...</div>
-            </div>
-        );
-    }
-
-    if (error) {
-        return (
-            <div className="bg-danger/20 border border-danger/70 text-danger-fg px-4 py-3 rounded">
-                <p>{error}</p>
-            </div>
-        );
-    }
-
-    if (!raidData) {
-        return (
-            <div className="bg-warning/20 border border-warning/70 text-warning-fg px-4 py-3 rounded">
-                <p>No raid data available.</p>
-            </div>
-        );
-    }
-
     // Get unique tiers for filter dropdown
-    const units = [...new Set(raidData.entries.map(entry => entry.unitId))].sort();
+    const units = raidData === null ? [] : [...new Set(raidData.entries.map(entry => entry.unitId))].sort();
 
     // Add this component near other renderers
     const BombStatusRenderer: React.FC<{ data: UserSummary }> = ({ data }) => {
@@ -460,14 +436,14 @@ export const TacticusGuildRaidVisualization: React.FC<{ userIdMapper: (userId: s
         // Initialize with worst case scenario:
         // season started at first damage, user had played his 3 token at the exact end of last season
         // 2 tokens recharged from the 24H inter season
-        const firstEntryStart = (raidData.entries.find(entry => entry.startedOn !== null)?.startedOn ?? 0) * 1000;
+        const firstEntryStart = (raidData!.entries.find(entry => entry.startedOn !== null)?.startedOn ?? 0) * 1000;
         const seasonStart = firstEntryStart === 0 ? now : firstEntryStart;
         const tokenStatus = {
             count: 2,
             reloadStart: seasonStart,
         };
 
-        raidData.entries
+        raidData!.entries
             .filter(
                 entry =>
                     entry.userId === data.userId &&
@@ -627,6 +603,7 @@ export const TacticusGuildRaidVisualization: React.FC<{ userIdMapper: (userId: s
     ];
 
     const summaryData = useMemo(() => {
+        if (raidData === null) return [];
         const userMap = new Map<string, UserSummary>();
 
         filteredEntries.forEach(entry => {
@@ -690,6 +667,30 @@ export const TacticusGuildRaidVisualization: React.FC<{ userIdMapper: (userId: s
 
         return Array.from(userMap.values());
     }, [filteredEntries]);
+
+    if (loading) {
+        return (
+            <div className="flex items-center justify-center h-64">
+                <div className="text-muted-fg">Loading raid data...</div>
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div className="bg-danger/20 border border-danger/70 text-danger-fg px-4 py-3 rounded">
+                <p>{error}</p>
+            </div>
+        );
+    }
+
+    if (!raidData) {
+        return (
+            <div className="bg-warning/20 border border-warning/70 text-warning-fg px-4 py-3 rounded">
+                <p>No raid data available.</p>
+            </div>
+        );
+    }
 
     return (
         <div className="container mx-auto p-4">


### PR DESCRIPTION
The Full error was
```
react-dom_client.js?v=2729a327:4146 React has detected a change in the order of Hooks called by TacticusGuildRaidVisualization. This will lead to bugs and errors if not fixed. For more information, read the Rules of Hooks: https://react.dev/link/rules-of-hooks

   Previous render            Next render
   ------------------------------------------------------
1. useState                   useState
2. useState                   useState
3. useState                   useState
4. useState                   useState
5. useState                   useState
6. useState                   useState
7. useEffect                  useEffect
8. useEffect                  useEffect
9. undefined                  useMemo
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

updateHookTypesDev @ react-dom_client.js?v=2729a327:4146Understand this error
react-dom_client.js?v=2729a327:4344 Uncaught Error: Rendered more hooks than during the previous render.
    at updateWorkInProgressHook (react-dom_client.js?v=2729a327:4344:19)
    at updateMemo (react-dom_client.js?v=2729a327:5065:20)
    at Object.useMemo (react-dom_client.js?v=2729a327:16763:20)
    at exports.useMemo (chunk-HSUUC2QV.js?v=2729a327:915:36)
    at TacticusGuildRaidVisualization (guild-raid-v2.tsx:615:25)
```

My understanding is that we always need to useMemo() even when there's nothing to do in there.