### PR TITLE
Add missing Titus trait

### DIFF
--- a/src/fsd/4-entities/character/data/characters.data.json
+++ b/src/fsd/4-entities/character/data/characters.data.json
@@ -145,7 +145,7 @@
         "Equipment1": "Crit",
         "Equipment2": "Defense",
         "Equipment3": "Crit Booster",
-        "Traits": ["Final Vengeance"],
+        "Traits": ["Beast Slayer", "Final Vengeance"],
         "Active Ability": "Bolter",
         "Number": 79,
         "ForcedSummons": false,


### PR DESCRIPTION
This PR fixes Titus' missing Beast Slayer trait, reported in [the Planner Discord](https://discord.com/channels/1146809197023997972/1379706570413183028/1379706570413183028)
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the character "Titus" to include the "Beast Slayer" trait in addition to "Final Vengeance".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->