### PR TITLE
Render upgrade/shard images on campaign pages

### DIFF
--- a/src/fsd/1-pages/learn-campaigns/campaigns.tsx
+++ b/src/fsd/1-pages/learn-campaigns/campaigns.tsx
@@ -7,10 +7,12 @@ import React, { useMemo, useRef, useState } from 'react';
 import { isMobile } from 'react-device-detect';
 
 import { useFitGridOnWindowResize, useQueryState } from '@/fsd/5-shared/lib';
-import { RarityIcon } from '@/fsd/5-shared/ui/icons';
+import { RarityIcon, UnitShardIcon } from '@/fsd/5-shared/ui/icons';
 
 import { Campaign, ICampaignBattleComposed, CampaignLocation, CampaignsService } from '@/fsd/4-entities/campaign';
+import { CharactersService } from '@/fsd/4-entities/character';
 import { FactionImage } from '@/fsd/4-entities/faction';
+import { UpgradeImage, UpgradesService } from '@/fsd/4-entities/upgrade';
 
 import { CampaignBattle } from './campaign-battle';
 import { CampaignBattleEnemies } from './campaign-battle-enemies';
@@ -85,6 +87,23 @@ export const Campaigns = () => {
             field: 'reward',
             headerName: 'Reward',
             minWidth: 170,
+            cellRenderer: (params: ICellRendererParams<ICampaignBattleComposed>) => {
+                const { reward } = params.data ?? {};
+                if (!reward) return undefined;
+                const upgrade = UpgradesService.getUpgrade(reward);
+                if (!upgrade) return reward;
+
+                if (upgrade.stat !== 'Shard') {
+                    return (
+                        <UpgradeImage material={upgrade.label} iconPath={upgrade.iconPath} rarity={upgrade.rarity} />
+                    );
+                }
+
+                const char = upgrade.stat === 'Shard' && CharactersService.getUnit(reward);
+                if (char) return <UnitShardIcon name={reward} icon={char.icon} />;
+
+                return reward;
+            },
         },
         {
             field: 'slots',

--- a/src/fsd/1-pages/plan-campaign-progression/campaign-progression-material-goals.tsx
+++ b/src/fsd/1-pages/plan-campaign-progression/campaign-progression-material-goals.tsx
@@ -127,11 +127,24 @@ export const CampaignProgressionMaterialGoals: React.FC<Props> = ({ campaignData
                     const savingsData = params.data.savingsData;
                     if (!savingsData) return '';
                     const savings: BattleSavings = savingsData[0].savings;
-                    if (UpgradesService.getUpgradeMaterial(savings.battle.reward)) {
+                    const reward = UpgradesService.getUpgradeMaterial(savings.battle.reward);
+                    if (reward && reward.stat === 'Shard') {
+                        const char = CharactersService.getUnit(reward.material);
+                        if (char)
+                            return (
+                                <UnitShardIcon
+                                    name={reward.material}
+                                    icon={char.icon}
+                                    height={30}
+                                    width={30}
+                                    tooltip={`${reward.material} shards`}
+                                />
+                            );
+                    } else if (reward) {
                         return (
                             <UpgradeImage
                                 material={savings.battle.reward}
-                                iconPath={UpgradesService.getUpgradeMaterial(savings.battle.reward)?.icon ?? ''}
+                                iconPath={reward?.icon ?? ''}
                                 rarity={savings.battle.rarityEnum}
                                 size={30}
                             />
@@ -249,11 +262,24 @@ export const CampaignProgressionMaterialGoals: React.FC<Props> = ({ campaignData
                     const savingsData = params.data.savingsData;
                     if (!savingsData) return '';
                     const savings: BattleSavings = savingsData[0].savings;
-                    if (UpgradesService.getUpgradeMaterial(savings.battle.reward)) {
+                    const reward = UpgradesService.getUpgradeMaterial(savings.battle.reward);
+                    if (reward && reward.stat === 'Shard') {
+                        const char = CharactersService.getUnit(reward.material);
+                        if (char)
+                            return (
+                                <UnitShardIcon
+                                    name={reward.material}
+                                    icon={char.icon}
+                                    height={30}
+                                    width={30}
+                                    tooltip={`${reward.material} shards`}
+                                />
+                            );
+                    } else if (reward) {
                         return (
                             <UpgradeImage
                                 material={savings.battle.reward}
-                                iconPath={UpgradesService.getUpgradeMaterial(savings.battle.reward)?.icon ?? ''}
+                                iconPath={reward?.icon ?? ''}
                                 rarity={savings.battle.rarityEnum}
                                 size={30}
                             />

--- a/src/fsd/4-entities/upgrade/data/recipeData.json
+++ b/src/fsd/4-entities/upgrade/data/recipeData.json
@@ -7695,6 +7695,13 @@
         "faction": "Adeptus Mechanicus",
         "rarity": "Shard"
     },
+    "Sy-Gex": {
+        "material": "Sy-Gex",
+        "craftable": false,
+        "stat": "Shard",
+        "faction": "Adeptus Mechanicus",
+        "rarity": "Shard"
+    },
     "Winged Tyrant Prime": {
         "material": "Winged Tyrant Prime",
         "craftable": false,


### PR DESCRIPTION
This PR renders upgrade images, or character shard portraits, on campaign pages.

Previously:
- the `Learn > Campaign` page was showing node rewards as text; and
- the `Plan > Campaign Progression` page was showing a missing image for shard nodes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Learn > Campaign
#### Before
![campaigns_before](https://github.com/user-attachments/assets/05b5622b-5656-43f7-b0e6-6fb7f361c14c)

#### After
![campaigns_after](https://github.com/user-attachments/assets/f085e239-90c1-45a0-8c1a-2c81a751981d)

### Plan > Campaign Progression
#### Before
![cp_before](https://github.com/user-attachments/assets/8624c22e-5111-42c1-ac14-558969bf45e9)

#### After
![cp_after](https://github.com/user-attachments/assets/95a3ee1c-b89f-47c4-ac18-c4fb40a3c1e7)


## Summary by CodeRabbit

- **New Features**
  - Added support for displaying "Sy-Gex" as a new shard-type material in campaign rewards and progression goals.
  - Enhanced reward icons to show character shard icons when applicable, improving visual clarity in campaign and progression grids.

- **Refactor**
  - Improved internal logic for rendering reward icons, ensuring consistent and efficient display across both mobile and desktop views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->