### PR TITLE
Show points on LRE team cards

### DIFF
--- a/src/fsd/1-pages/plan-lre/legendary-event.tsx
+++ b/src/fsd/1-pages/plan-lre/legendary-event.tsx
@@ -27,7 +27,13 @@ export const LegendaryEvent = ({ legendaryEvent }: { legendaryEvent: ILegendaryE
 
     const selectedTeams: ILreTeam[] = leSelectedTeams[legendaryEvent.id]?.teams ?? [];
 
+    // Compute virtual attributes (not saved in JSON) for display on LRE team cards.
     selectedTeams.forEach(team => {
+        team.points = 0;
+        for (const id of team.restrictionsIds) {
+            team.points += legendaryEvent[team.section].getRestrictionPoints(id);
+        }
+
         team.characters = team.charactersIds.map(id => {
             const character = characters.find(x => x.id === id);
 

--- a/src/fsd/1-pages/plan-lre/selected-teams-card.tsx
+++ b/src/fsd/1-pages/plan-lre/selected-teams-card.tsx
@@ -17,6 +17,8 @@ interface Props {
 
 export const SelectedTeamCard: React.FC<Props> = ({ team, menuItemSelect }) => {
     const { viewPreferences } = useContext(StoreContext);
+    let subheader = team.restrictionsIds.join(', ');
+    if (team.points) subheader += ` (${team.points} points)`;
     return (
         <Card
             variant="outlined"
@@ -36,7 +38,7 @@ export const SelectedTeamCard: React.FC<Props> = ({ team, menuItemSelect }) => {
                     </>
                 }
                 title={team.name}
-                subheader={team.restrictionsIds.join(', ')}
+                subheader={subheader}
             />
             <CardContent className="flex-box column gap1 start" style={{ minHeight: 150 }}>
                 {team.characters?.map(x => <LreTile key={x.id} character={x} settings={viewPreferences} />)}

--- a/src/fsd/3-features/lre/lre.model.ts
+++ b/src/fsd/3-features/lre/lre.model.ts
@@ -65,6 +65,7 @@ export interface ILreTeam {
      * Client Side only
      */
     characters?: ICharacter2[];
+    points?: number;
 }
 
 export interface ILegendaryEventSelectedRequirements {


### PR DESCRIPTION
This PR proposes we render the LRE points totals on the LRE team cards, according to the restrictions the team satisfies. The points are a client-side virtual attribute, and aren't saved in the user's JSON.

We may not wish to merge this, if it's just my own personal preference. I've been manually adding the points to the team name so I can pick the most-valuable team for my next token. This PR makes that redundant.

### UI
![lre_team](https://github.com/user-attachments/assets/589734d1-ee7b-4a5c-bb79-d93613594e2b)
