### PR TITLE
Allow copying names of user who have bombs or tokens

### DIFF
--- a/src/v2/features/tacticus-integration/guild-raid-v2.tsx
+++ b/src/v2/features/tacticus-integration/guild-raid-v2.tsx
@@ -706,7 +706,7 @@ export const TacticusGuildRaidVisualization: React.FC<{ userIdMapper: (userId: s
         return Array.from(userMap.values());
     }, [filteredEntries]);
 
-    const [usePrefixForCopyUser, setSsePrefixForCopyUser] = useState<boolean>(true);
+    const [usePrefixForCopyUser, setSePrefixForCopyUser] = useState<boolean>(true);
 
     const getPrefixForCopyUser = () => (usePrefixForCopyUser ? '@' : '');
 
@@ -926,7 +926,7 @@ export const TacticusGuildRaidVisualization: React.FC<{ userIdMapper: (userId: s
                             control={
                                 <Checkbox
                                     checked={usePrefixForCopyUser}
-                                    onChange={event => setSsePrefixForCopyUser(!usePrefixForCopyUser)}
+                                    onChange={event => setSePrefixForCopyUser(!usePrefixForCopyUser)}
                                     inputProps={{ 'aria-label': 'controlled' }}
                                 />
                             }

--- a/src/v2/features/tacticus-integration/guild-raid-v2.tsx
+++ b/src/v2/features/tacticus-integration/guild-raid-v2.tsx
@@ -920,8 +920,8 @@ export const TacticusGuildRaidVisualization: React.FC<{ userIdMapper: (userId: s
             {/* Player Summary Table */}
             <div className="bg-overlay rounded-lg shadow p-4 mb-6">
                 <h2 className="text-lg font-semibold mb-3 text-overlay-fg">Player Summary</h2>
-                <div className="grid grid-cols-1 md:grid-cols-5 gap-4 mb-6">
-                    <div style={{ marginTop: 1 }}>
+                <div className="flex flex-wrap items-center gap-4 mb-6">
+                    <div>
                         <FormControlLabel
                             control={
                                 <Checkbox
@@ -933,14 +933,14 @@ export const TacticusGuildRaidVisualization: React.FC<{ userIdMapper: (userId: s
                             label={'@ prefix'}
                         />
                     </div>
-                    <div className="font-medium text-overlay-fg">Users with bombs</div>
-                    <div style={{ marginTop: 1 }}>
+                    <div className="flex items-center gap-2">
+                        <span className="font-medium text-overlay-fg">Users with bombs:</span>
                         <Button onClick={() => copyUsersWithBomb()} color={'inherit'}>
                             <ContentCopyIcon /> Copy
                         </Button>
                     </div>
-                    <div className="font-medium text-overlay-fg">Users with tokens</div>
-                    <div style={{ marginTop: 1 }}>
+                    <div className="flex items-center gap-2">
+                        <span className="font-medium text-overlay-fg">Users with bombs:</span>
                         <Button onClick={() => copyUsersWithToken()} color={'inherit'}>
                             <ContentCopyIcon /> Copy
                         </Button>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a control panel with options to copy lists of users who have bombs or tokens available, with an optional '@' prefix for usernames.
  - Introduced a checkbox to toggle the '@' prefix when copying usernames.
  - Added copy buttons for "Users with bombs" and "Users with tokens", along with clipboard feedback notifications.

- **Refactor**
  - Improved bomb cooldown display logic for clearer status updates in the player summary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->