### PR TITLE
Fix LRE crash for invalid characters

### DIFF
--- a/src/fsd/1-pages/plan-lre/lre-tile.tsx
+++ b/src/fsd/1-pages/plan-lre/lre-tile.tsx
@@ -21,21 +21,20 @@ export const LreTile: React.FC<Props> = ({ character, settings, onClick = () => 
             : character.bias === CharacterBias.recommendLast
               ? pooEmoji
               : '';
-    const rankBackgroundCssClass = settings.lreTileShowUnitRankBackground
-        ? ` ${Rank[character.rank].toLowerCase()}`
-        : '';
-
+    const rankBackgroundCssClass =
+        settings.lreTileShowUnitRankBackground && character.rank ? ` ${Rank[character.rank]?.toLowerCase()}` : '';
     const showHealTrait =
         settings.lreTileShowUnitHealTraits && character.traits && character.traits.includes(Trait['Healer']);
     const showMechanicTrait =
         settings.lreTileShowUnitHealTraits && character.traits && character.traits.includes(Trait['Mechanic']);
-
+    const showShardIcon = settings.lreTileShowUnitIcon && character.name && character.icon;
+    const showRarity = settings.lreTileShowUnitRarity && typeof character.rarity !== 'undefined';
     return (
         <div
             className={'flex-box gap10 full-width ' + rankBackgroundCssClass}
             style={{ columnGap: '10px' }}
             onClick={() => onClick(character)}>
-            {settings.lreTileShowUnitIcon && (
+            {showShardIcon && (
                 <UnitShardIcon
                     key={character.name}
                     icon={character.icon}
@@ -44,9 +43,9 @@ export const LreTile: React.FC<Props> = ({ character, settings, onClick = () => 
                     width={30}
                 />
             )}
-            {settings.lreTileShowUnitRarity && <RarityIcon rarity={character.rarity} />}
+            {showRarity && <RarityIcon rarity={character.rarity} />}
             {settings.lreTileShowUnitRank && <RankIcon key={character.rank} rank={character.rank} />}
-            {settings.lreTileShowUnitName && <span>{character.shortName}</span>}
+            {settings.lreTileShowUnitName && <span>{character.shortName || 'Invalid Unit'}</span>}
             {settings.lreTileShowUnitActiveAbility && <span>A{character.activeAbilityLevel}</span>}
             {settings.lreTileShowUnitPassiveAbility && <span>P{character.passiveAbilityLevel}</span>}
             {showHealTrait && (


### PR DESCRIPTION
The LRETile component was prone to crashing when not supplied with expected attributes for a unit, such as `rank` and `rarity`.  This issue was reported in [the Discord bug reports here](https://discord.com/channels/1146809197023997972/1380847322761658368/1380847322761658368).

This was coming up after I migrated the 'Unknown' character to 'Trajann', as some users had the now-orphaned 'Unknown' character in their JSON data.

The component now guards against each required attribute, and avoids rendering those aspects. This allows the invalid character to still be displayed, giving the user a means of deleting it.

Here's how it looks:
![lre-tile](https://github.com/user-attachments/assets/8644aec7-99d1-4929-b6ee-e295c0de4cb0)


### Pros / Cons / Alternatives
This solution gives the user power to fix their own data, by deleting the invalid unit. However, it means they have to delete and recreate any LRE teams for that unit.

I felt this was a smoother UX than an alternative I considered: adding character ids to track them independently of their name. This would allow any goals to transition when a new character's name is revealed. The downsides are the scope of work required, and the need to migrate users' JSON data to match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved handling of UI rendering conditions for unit icons and rarity icons, enhancing reliability and safety in the display logic.
  * Updated display of character short names to show a fallback message if missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->