### PR TITLE
Update wiki links

### DIFF
--- a/src/fsd/3-features/thank-you/data/thankYou.json
+++ b/src/fsd/3-features/thank-you/data/thankYou.json
@@ -20,7 +20,7 @@
         "type": "Contributor",
         "thankYou": "Thank you for sharing Ranks images ©Severyn",
         "resourceDescription": "Tacticus Wiki",
-        "resourceLink": "https://tacticus.fandom.com/wiki/Tacticus_Wiki",
+        "resourceLink": "https://tacticus.wiki.gg",
         "avatarIcon": "lucky.webp"
     },
     {

--- a/src/fsd/4-entities/lre/data/1-Aunshi.json
+++ b/src/fsd/4-entities/lre/data/1-Aunshi.json
@@ -1,7 +1,7 @@
 ﻿{
     "id": 2,
     "name": "Aun'Shi",
-    "wikiLink": "https://tacticus.fandom.com/wiki/LE-Aun%27Shi",
+    "wikiLink": "https://tacticus.wiki.gg/wiki/LE-Aun%27Shi",
     "eventStage": 3,
     "nextEventDate": "Finished",
     "battlesCount": 12,
@@ -34,7 +34,7 @@
         "name": "Alpha (No Orks)",
         "enemies": {
             "label": "Orks",
-            "link": "https://tacticus.fandom.com/wiki/Orks#NPC_Units"
+            "link": "https://tacticus.wiki.gg/wiki/Orks#NPC_Units"
         },
         "killPoints": 27,
         "battlesPoints": [38, 40, 58, 58, 40, 41, 62, 43, 47, 49, 64, 48]
@@ -43,7 +43,7 @@
         "name": "Beta (No Imperials)",
         "enemies": {
             "label": "Black Templars",
-            "link": "https://tacticus.fandom.com/wiki/Black_Templars#NPC_Units"
+            "link": "https://tacticus.wiki.gg/wiki/Black_Templars#NPC_Units"
         },
         "killPoints": 53,
         "battlesPoints": [29, 35, 28, 39, 35, 34, 34, 38, 43, 29, 39, 49]
@@ -52,7 +52,7 @@
         "name": "Gamma (No Chaos)",
         "enemies": {
             "label": "Chaos",
-            "link": "https://tacticus.fandom.com/wiki/Black_Legion#NPC_Units"
+            "link": "https://tacticus.wiki.gg/wiki/Black_Legion#NPC_Units"
         },
         "killPoints": 40,
         "battlesPoints": [36, 36, 34, 42, 40, 43, 41, 49, 44, 40, 49, 56]

--- a/src/fsd/4-entities/lre/data/10-Lucius.json
+++ b/src/fsd/4-entities/lre/data/10-Lucius.json
@@ -1,7 +1,7 @@
 {
     "id": 12,
     "name": "Lucius",
-    "wikiLink": "https://tacticus.fandom.com/wiki/Legendary_Character_Events",
+    "wikiLink": "https://tacticus.wiki.gg/wiki/Legendary_Character_Events",
     "eventStage": 1,
     "nextEventDate": "August 10",
     "nextEventDateUtc": "Sun, 10 August 2025 00:00:00 GMT",
@@ -33,7 +33,7 @@
         "name": "Alpha (No Xenos)",
         "enemies": {
             "label": "Aeldari",
-            "link": "https://tacticus.fandom.com/wiki/Aeldari#NPC_Units"
+            "link": "https://tacticus.wiki.gg/wiki/Aeldari#NPC_Units"
         },
         "killPoints": 37,
         "battlesPoints": [30, 28, 34, 42, 50, 47, 38, 50, 45, 42, 39, 55, 57, 53]
@@ -42,7 +42,7 @@
         "name": "Beta (No Chaos)",
         "enemies": {
             "label": "Tyranids",
-            "link": "https://tacticus.fandom.com/wiki/Tyranids#NPC_Units"
+            "link": "https://tacticus.wiki.gg/wiki/Tyranids#NPC_Units"
         },
         "killPoints": 26,
         "battlesPoints": [31, 35, 46, 52, 51, 52, 50, 49, 53, 54, 45, 54, 58, 59]
@@ -51,7 +51,7 @@
         "name": "Gamma (No Imperials)",
         "enemies": {
             "label": "Ultramarines & Astra Militarum",
-            "link": "https://tacticus.fandom.com/wiki/Ultramarines#NPC_Units"
+            "link": "https://tacticus.wiki.gg/wiki/Ultramarines#NPC_Units"
         },
         "killPoints": 32,
         "battlesPoints": [29, 33, 46, 48, 51, 53, 50, 51, 48, 38, 51, 47, 51, 53]

--- a/src/fsd/4-entities/lre/data/2-Shadowsun.json
+++ b/src/fsd/4-entities/lre/data/2-Shadowsun.json
@@ -1,7 +1,7 @@
 ﻿{
     "id": 4,
     "name": "Shadowsun",
-    "wikiLink": "https://tacticus.fandom.com/wiki/LE-Shadowsun",
+    "wikiLink": "https://tacticus.wiki.gg/wiki/LE-Shadowsun",
     "eventStage": 3,
     "nextEventDate": "Finished",
     "regularMissions": [
@@ -32,7 +32,7 @@
         "name": "Alpha (No Necrons)",
         "enemies": {
             "label": "Necrons",
-            "link": "https://tacticus.fandom.com/wiki/Necrons#NPC_Units"
+            "link": "https://tacticus.wiki.gg/wiki/Necrons#NPC_Units"
         },
         "killPoints": 35,
         "battlesPoints": [29, 39, 33, 48, 36, 52, 45, 39, 54, 50, 50, 65]
@@ -41,7 +41,7 @@
         "name": "Beta (No Tyranids)",
         "enemies": {
             "label": "Tyranids",
-            "link": "https://tacticus.fandom.com/wiki/Tyranids#NPC_Units"
+            "link": "https://tacticus.wiki.gg/wiki/Tyranids#NPC_Units"
         },
         "killPoints": 19,
         "battlesPoints": [34, 40, 57, 59, 49, 58, 55, 50, 54, 58, 59, 63]
@@ -50,7 +50,7 @@
         "name": "Gamma (No Imperials)",
         "enemies": {
             "label": "Ultramarines & Astra Militarum",
-            "link": "https://tacticus.fandom.com/wiki/Ultramarines#NPC_Units"
+            "link": "https://tacticus.wiki.gg/wiki/Ultramarines#NPC_Units"
         },
         "killPoints": 18,
         "battlesPoints": [31, 36, 56, 48, 53, 61, 67, 50, 57, 60, 67, 56]

--- a/src/fsd/4-entities/lre/data/3-Ragnar.json
+++ b/src/fsd/4-entities/lre/data/3-Ragnar.json
@@ -1,7 +1,7 @@
 ﻿{
     "id": 5,
     "name": "Ragnar",
-    "wikiLink": "https://tacticus.fandom.com/wiki/LE-Ragnar",
+    "wikiLink": "https://tacticus.wiki.gg/wiki/LE-Ragnar",
     "eventStage": 3,
     "nextEventDate": "Finished",
     "regularMissions": [
@@ -32,7 +32,7 @@
         "name": "Alpha (No Xenos)",
         "enemies": {
             "label": "Orks",
-            "link": "https://tacticus.fandom.com/wiki/Orks#NPC_Units"
+            "link": "https://tacticus.wiki.gg/wiki/Orks#NPC_Units"
         },
         "killPoints": 24,
         "battlesPoints": [40, 38, 50, 48, 50, 48, 60, 55, 47, 52, 59, 59]
@@ -41,7 +41,7 @@
         "name": "Beta (No Chaos)",
         "enemies": {
             "label": "Thousand Sons",
-            "link": "https://tacticus.fandom.com/wiki/Thousand_Sons#NPC_Units"
+            "link": "https://tacticus.wiki.gg/wiki/Thousand_Sons#NPC_Units"
         },
         "killPoints": 30,
         "battlesPoints": [33, 36, 45, 47, 50, 49, 50, 50, 50, 57, 43, 60]
@@ -50,7 +50,7 @@
         "name": "Gamma (No Imperials)",
         "enemies": {
             "label": "Black Templars",
-            "link": "https://tacticus.fandom.com/wiki/Black_Templars#NPC_Units"
+            "link": "https://tacticus.wiki.gg/wiki/Black_Templars#NPC_Units"
         },
         "killPoints": 34,
         "battlesPoints": [28, 35, 39, 43, 40, 57, 43, 50, 58, 48, 50, 55]

--- a/src/fsd/4-entities/lre/data/4-Vitruvius.json
+++ b/src/fsd/4-entities/lre/data/4-Vitruvius.json
@@ -1,7 +1,7 @@
 ﻿{
     "id": 6,
     "name": "Vitruvius",
-    "wikiLink": "https://tacticus.fandom.com/wiki/LE-Vitruvius",
+    "wikiLink": "https://tacticus.wiki.gg/wiki/LE-Vitruvius",
     "eventStage": 3,
     "nextEventDate": "Finished",
     "regularMissions": [
@@ -32,7 +32,7 @@
         "name": "Alpha (No Necrons)",
         "enemies": {
             "label": "Necrons",
-            "link": "https://tacticus.fandom.com/wiki/Necrons#NPC_Units"
+            "link": "https://tacticus.wiki.gg/wiki/Necrons#NPC_Units"
         },
         "killPoints": 21,
         "battlesPoints": [36, 40, 51, 51, 53, 48, 43, 60, 57, 63, 57, 65]
@@ -41,7 +41,7 @@
         "name": "Beta (No Chaos)",
         "enemies": {
             "label": "Black Legion",
-            "link": "https://tacticus.fandom.com/wiki/Black_Legion#NPC_Units"
+            "link": "https://tacticus.wiki.gg/wiki/Black_Legion#NPC_Units"
         },
         "killPoints": 21,
         "battlesPoints": [40, 41, 43, 53, 48, 50, 61, 58, 55, 56, 62, 57]
@@ -50,7 +50,7 @@
         "name": "Gamma (No Imperials)",
         "enemies": {
             "label": "Astra Militarum",
-            "link": "https://tacticus.fandom.com/wiki/Astra_Militarum#NPC_Units"
+            "link": "https://tacticus.wiki.gg/wiki/Astra_Militarum#NPC_Units"
         },
         "killPoints": 35,
         "battlesPoints": [42, 46, 41, 39, 50, 37, 44, 45, 48, 46, 46, 56]

--- a/src/fsd/4-entities/lre/data/5-Kharn.json
+++ b/src/fsd/4-entities/lre/data/5-Kharn.json
@@ -1,7 +1,7 @@
 ﻿{
     "id": 7,
     "name": "Kharn",
-    "wikiLink": "https://tacticus.fandom.com/wiki/LE-Kharn",
+    "wikiLink": "https://tacticus.wiki.gg/wiki/LE-Kharn",
     "eventStage": 3,
     "nextEventDate": "Finished",
     "regularMissions": [
@@ -32,7 +32,7 @@
         "name": "Alpha (No Imperials)",
         "enemies": {
             "label": "Ultramarines & Astra Militarum",
-            "link": "https://tacticus.fandom.com/wiki/Ultramarines#NPC_Units"
+            "link": "https://tacticus.wiki.gg/wiki/Ultramarines#NPC_Units"
         },
         "killPoints": 27,
         "battlesPoints": [38, 40, 44, 51, 55, 51, 45, 48, 53, 47, 46, 54, 54, 60]
@@ -41,7 +41,7 @@
         "name": "Beta (No Tyranids)",
         "enemies": {
             "label": "Tyranids",
-            "link": "https://tacticus.fandom.com/wiki/Tyranids#NPC_Units"
+            "link": "https://tacticus.wiki.gg/wiki/Tyranids#NPC_Units"
         },
         "killPoints": 35,
         "battlesPoints": [34, 36, 41, 46, 43, 41, 48, 41, 58, 44, 42, 44, 54, 58]
@@ -50,7 +50,7 @@
         "name": "Gamma (No Thousand Sons)",
         "enemies": {
             "label": "Thousand Sons",
-            "link": "https://tacticus.fandom.com/wiki/Thousand_Sons#NPC_Units"
+            "link": "https://tacticus.wiki.gg/wiki/Thousand_Sons#NPC_Units"
         },
         "killPoints": 39,
         "battlesPoints": [26, 38, 43, 40, 52, 35, 47, 57, 36, 41, 40, 43, 51, 53]

--- a/src/fsd/4-entities/lre/data/6-Mephiston.json
+++ b/src/fsd/4-entities/lre/data/6-Mephiston.json
@@ -1,7 +1,7 @@
 ﻿{
     "id": 8,
     "name": "Mephiston",
-    "wikiLink": "https://tacticus.fandom.com/wiki/LE-Mephiston",
+    "wikiLink": "https://tacticus.wiki.gg/wiki/LE-Mephiston",
     "eventStage": 3,
     "nextEventDate": "July 6",
     "nextEventDateUtc": "Sun, 06 July 2025 00:00:00 GMT",
@@ -33,7 +33,7 @@
         "name": "Alpha (No Imperials)",
         "enemies": {
             "label": "Astra Militarum",
-            "link": "https://tacticus.fandom.com/wiki/Astra_Militarum#NPC_Units"
+            "link": "https://tacticus.wiki.gg/wiki/Astra_Militarum#NPC_Units"
         },
         "killPoints": 31,
         "battlesPoints": [34, 37, 48, 45, 45, 46, 40, 47, 48, 55, 51, 51, 53, 58]
@@ -42,7 +42,7 @@
         "name": "Beta (No Chaos)",
         "enemies": {
             "label": "Black Legion & Death Guard",
-            "link": "https://tacticus.fandom.com/wiki/Death_Guard#NPC_Units"
+            "link": "https://tacticus.wiki.gg/wiki/Death_Guard#NPC_Units"
         },
         "killPoints": 37,
         "battlesPoints": [31, 37, 45, 49, 49, 51, 38, 46, 51, 35, 42, 45, 49, 48]
@@ -51,7 +51,7 @@
         "name": "Gamma (Imperial Only)",
         "enemies": {
             "label": "Aeldari",
-            "link": "https://tacticus.fandom.com/wiki/Aeldari#NPC_Units"
+            "link": "https://tacticus.wiki.gg/wiki/Aeldari#NPC_Units"
         },
         "killPoints": 34,
         "battlesPoints": [31, 31, 45, 42, 56, 47, 47, 48, 48, 49, 42, 51, 45, 55]

--- a/src/fsd/4-entities/lre/data/7-Patermine.json
+++ b/src/fsd/4-entities/lre/data/7-Patermine.json
@@ -1,7 +1,7 @@
 ﻿{
     "id": 9,
     "name": "Patermine",
-    "wikiLink": "https://tacticus.fandom.com/wiki/LE-The_Patermine",
+    "wikiLink": "https://tacticus.wiki.gg/wiki/LE-The_Patermine",
     "eventStage": 2,
     "nextEventDate": "TBA",
     "nextEventDateUtc": "",
@@ -33,7 +33,7 @@
         "name": "Alpha (No Orks)",
         "enemies": {
             "label": "Orks",
-            "link": "https://tacticus.fandom.com/wiki/Orks#NPC_Units"
+            "link": "https://tacticus.wiki.gg/wiki/Orks#NPC_Units"
         },
         "killPoints": 36,
         "battlesPoints": [27, 31, 38, 41, 40, 53, 51, 45, 43, 58, 43, 48, 58, 47]
@@ -42,7 +42,7 @@
         "name": "Beta (No Imperials)",
         "enemies": {
             "label": "Black Templars",
-            "link": "https://tacticus.fandom.com/wiki/Black_Templars#NPC_Units"
+            "link": "https://tacticus.wiki.gg/wiki/Black_Templars#NPC_Units"
         },
         "killPoints": 47,
         "battlesPoints": [24, 31, 33, 37, 40, 34, 39, 37, 44, 42, 47, 45, 41, 52]
@@ -51,7 +51,7 @@
         "name": "Gamma (No Chaos)",
         "enemies": {
             "label": "Black Legion",
-            "link": "https://tacticus.fandom.com/wiki/Black_Legion#NPC_Units"
+            "link": "https://tacticus.wiki.gg/wiki/Black_Legion#NPC_Units"
         },
         "killPoints": 25,
         "battlesPoints": [33, 49, 44, 46, 42, 53, 52, 56, 53, 50, 50, 50, 57, 65]

--- a/src/fsd/4-entities/lre/data/8-Dante.json
+++ b/src/fsd/4-entities/lre/data/8-Dante.json
@@ -1,7 +1,7 @@
 {
     "id": 10,
     "name": "Dante",
-    "wikiLink": "https://tacticus.fandom.com/wiki/LE-Dante",
+    "wikiLink": "https://tacticus.wiki.gg/wiki/LE-Dante",
     "eventStage": 1,
     "nextEventDate": "March 23",
     "nextEventDateUtc": "Sun, 23 March 2025 00:00:00 GMT",
@@ -33,7 +33,7 @@
         "name": "Alpha (No Xenos)",
         "enemies": {
             "label": "Necrons",
-            "link": "https://tacticus.fandom.com/wiki/Necrons#NPC_Units"
+            "link": "https://tacticus.wiki.gg/wiki/Necrons#NPC_Units"
         },
         "killPoints": 40,
         "battlesPoints": [27, 32, 38, 41, 40, 43, 42, 50, 44, 40, 47, 48, 59, 44]
@@ -42,7 +42,7 @@
         "name": "Beta (No Chaos)",
         "enemies": {
             "label": "Black Legion",
-            "link": "https://tacticus.fandom.com/wiki/Black_Legion#NPC_Units"
+            "link": "https://tacticus.wiki.gg/wiki/Black_Legion#NPC_Units"
         },
         "killPoints": 26,
         "battlesPoints": [36, 44, 42, 45, 45, 46, 58, 50, 64, 42, 49, 51, 54, 67]
@@ -51,7 +51,7 @@
         "name": "Gamma (No Imperial)",
         "enemies": {
             "label": "Astra Militarum/Blood Angels",
-            "link": "https://tacticus.fandom.com/wiki/Astra_Militarum#NPC_Units"
+            "link": "https://tacticus.wiki.gg/wiki/Astra_Militarum#NPC_Units"
         },
         "killPoints": 28,
         "battlesPoints": [39, 36, 44, 50, 47, 44, 48, 52, 48, 48, 50, 56, 56, 61]

--- a/src/fsd/4-entities/lre/data/9-Trajann.json
+++ b/src/fsd/4-entities/lre/data/9-Trajann.json
@@ -1,7 +1,7 @@
 {
     "id": 11,
     "name": "Trajann",
-    "wikiLink": "https://tacticus.fandom.com/wiki/Legendary_Character_Events",
+    "wikiLink": "https://tacticus.wiki.gg/wiki/Legendary_Character_Events",
     "eventStage": 1,
     "nextEventDate": "June 1",
     "nextEventDateUtc": "Sun, 01 June 2025 00:00:00 GMT",
@@ -33,7 +33,7 @@
         "name": "Alpha (No Chaos)",
         "enemies": {
             "label": "Thousand Sons",
-            "link": "https://tacticus.fandom.com/wiki/Thousand_Sons#NPC_Units"
+            "link": "https://tacticus.wiki.gg/wiki/Thousand_Sons#NPC_Units"
         },
         "killPoints": 37,
         "battlesPoints": [30, 28, 34, 42, 50, 47, 38, 50, 45, 42, 39, 55, 57, 53]
@@ -42,7 +42,7 @@
         "name": "Beta (No Imperial)",
         "enemies": {
             "label": "Ultramarines & Astra Militarum",
-            "link": "https://tacticus.fandom.com/wiki/Ultramarines#NPC_Units"
+            "link": "https://tacticus.wiki.gg/wiki/Ultramarines#NPC_Units"
         },
         "killPoints": 26,
         "battlesPoints": [31, 35, 46, 52, 51, 52, 50, 49, 53, 54, 45, 54, 58, 59]
@@ -51,7 +51,7 @@
         "name": "Gamma (No Xenos)",
         "enemies": {
             "label": "Genestealer Cults & Tyranids",
-            "link": "https://tacticus.fandom.com/wiki/Genestealer_Cults#NPC_Units"
+            "link": "https://tacticus.wiki.gg/wiki/Genestealer_Cults#NPC_Units"
         },
         "killPoints": 32,
         "battlesPoints": [29, 33, 46, 48, 51, 53, 50, 51, 48, 38, 51, 47, 51, 53]


### PR DESCRIPTION
The Tacticus wiki has moved from fandom.com to wiki.gg.

The link structure stayed the same between the 2 hosts, so only a domain change was required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated all in-app links to the Tacticus Wiki, changing the domain from "tacticus.fandom.com" to "tacticus.wiki.gg" for improved accuracy and consistency across contributor and character data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->