### PR TITLE
Sort inventory by label when alphabetised

### DIFF
--- a/src/fsd/1-pages/input-inventory/inventory.tsx
+++ b/src/fsd/1-pages/input-inventory/inventory.tsx
@@ -43,9 +43,7 @@ export const Inventory: React.FC<Props> = ({ itemsFilter = [], onUpdate }) => {
                     visible: true,
                     alphabet: (x.label ?? x.material)[0].toUpperCase(),
                 })),
-            viewPreferences.inventoryShowAlphabet
-                ? ['rarity', 'material', 'faction']
-                : ['rarity', 'faction', 'material'],
+            viewPreferences.inventoryShowAlphabet ? ['rarity', 'label', 'faction'] : ['rarity', 'faction', 'label'],
             ['desc', 'asc', 'asc']
         );
     }, [viewPreferences.inventoryShowAlphabet, inventory.upgrades]);


### PR DESCRIPTION
This PR adjusts the sort order of Input > Inventory, sorting by `label` instead of `material`.

I did this after noticing the new `Boon of Slaanesh` upgrade wasn't appearing next to the other Chaos boon upgrades. I'm unclear why this change was required, as the `material` field looks like it should do the same thing.

### Before
<img width="903" height="392" alt="sort1" src="https://github.com/user-attachments/assets/a5b46041-2680-470c-952a-f56197719140" />

### After
<img width="887" height="381" alt="sort2" src="https://github.com/user-attachments/assets/0fc78ff1-0a28-4fcc-a835-bd95a0fb3eaa" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the sorting order for inventory items to improve item organization based on user view preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->