### PR TITLE
Add "Unfarmable" filter to Who You Own page

### DIFF
--- a/src/fsd/3-features/view-settings/view-controls.tsx
+++ b/src/fsd/3-features/view-settings/view-controls.tsx
@@ -67,6 +67,8 @@ export const CharactersViewControls = ({
                 return 'MoW only';
             case CharactersFilterBy.None:
                 return 'None';
+            case CharactersFilterBy.CantFarm:
+                return "Can't Farm";
             default:
                 return '';
         }

--- a/src/fsd/3-features/view-settings/view-controls.tsx
+++ b/src/fsd/3-features/view-settings/view-controls.tsx
@@ -67,8 +67,8 @@ export const CharactersViewControls = ({
                 return 'MoW only';
             case CharactersFilterBy.None:
                 return 'None';
-            case CharactersFilterBy.CantFarm:
-                return "Can't Farm";
+            case CharactersFilterBy.Unfarmable:
+                return 'Unfarmable';
             default:
                 return '';
         }

--- a/src/fsd/4-entities/character/characters-filter-by.enum.ts
+++ b/src/fsd/4-entities/character/characters-filter-by.enum.ts
@@ -7,4 +7,5 @@
     Imperial,
     Xenos,
     MoW,
+    CantFarm,
 }

--- a/src/fsd/4-entities/character/characters-filter-by.enum.ts
+++ b/src/fsd/4-entities/character/characters-filter-by.enum.ts
@@ -7,5 +7,5 @@
     Imperial,
     Xenos,
     MoW,
-    CantFarm,
+    Unfarmable,
 }

--- a/src/fsd/4-entities/upgrade/upgrades.service.ts
+++ b/src/fsd/4-entities/upgrade/upgrades.service.ts
@@ -532,7 +532,7 @@ export class UpgradesService {
 
     private static getFarmableCharacters(): IMaterialFull['id'][] {
         const chars: IMaterialFull['id'][] = [];
-        return Object.values(this.recipeDataFull).reduce((acc, upgrade) => {
+        return Object.values(UpgradesService.recipeDataFull).reduce((acc, upgrade) => {
             if (upgrade.stat === 'Shard') acc.push(upgrade.id);
             return acc;
         }, chars);

--- a/src/fsd/4-entities/upgrade/upgrades.service.ts
+++ b/src/fsd/4-entities/upgrade/upgrades.service.ts
@@ -28,6 +28,7 @@ export class UpgradesService {
     static readonly recipeDataFull: IRecipeDataFull = this.convertRecipeData();
     static readonly recipeExpandedUpgradeData: IRecipeExpandedUpgradeData = this.expandRecipeData();
     public static readonly materialByLabel: Record<string, string> = this.createMaterialByLabelLookup();
+    public static readonly farmableCharacters: IMaterialFull['id'][] = this.getFarmableCharacters();
 
     /**
      * @returns a lookup table keyed by material ID or material label pointing
@@ -527,5 +528,13 @@ export class UpgradesService {
 
     static isValidUpgrade(upgrade: string): boolean {
         return Object.hasOwn(recipeDataByName, upgrade);
+    }
+
+    private static getFarmableCharacters(): IMaterialFull['id'][] {
+        const chars: IMaterialFull['id'][] = [];
+        return Object.values(this.recipeDataFull).reduce((acc, upgrade) => {
+            if (upgrade.stat === 'Shard') acc.push(upgrade.id);
+            return acc;
+        }, chars);
     }
 }

--- a/src/v2/features/characters/characters.service.ts
+++ b/src/v2/features/characters/characters.service.ts
@@ -10,6 +10,7 @@ import { ICharacter2 } from '@/fsd/4-entities/character';
 import { IMow } from '@/fsd/4-entities/mow';
 import { IUnit } from '@/fsd/4-entities/unit';
 import { isCharacter, isMow, isUnlocked } from '@/fsd/4-entities/unit/units.functions';
+import { IMaterialFull, UpgradesService } from '@/fsd/4-entities/upgrade';
 
 import { rarityCaps } from 'src/v2/features/characters/characters.contants';
 
@@ -30,6 +31,8 @@ export class CharactersService {
         const filteredCharactersByName = nameFilter
             ? characters.filter(x => x.name.toLowerCase().includes(nameFilter.toLowerCase()))
             : characters;
+
+        let farmableChars: Set<IMaterialFull['id']> | undefined;
 
         switch (filterBy) {
             case CharactersFilterBy.NeedToAscend:
@@ -53,6 +56,12 @@ export class CharactersService {
                 return filteredCharactersByName.filter(filterXenos);
             case CharactersFilterBy.MoW:
                 return filteredCharactersByName.filter(isMow);
+            case CharactersFilterBy.CantFarm:
+                if (typeof farmableChars === 'undefined') farmableChars = new Set(UpgradesService.farmableCharacters);
+
+                return filteredCharactersByName.filter(char => {
+                    return !isMow(char) && !farmableChars?.has(char.id);
+                });
             case CharactersFilterBy.None:
             default:
                 return filteredCharactersByName;

--- a/src/v2/features/characters/characters.service.ts
+++ b/src/v2/features/characters/characters.service.ts
@@ -56,7 +56,7 @@ export class CharactersService {
                 return filteredCharactersByName.filter(filterXenos);
             case CharactersFilterBy.MoW:
                 return filteredCharactersByName.filter(isMow);
-            case CharactersFilterBy.CantFarm:
+            case CharactersFilterBy.Unfarmable:
                 if (typeof farmableChars === 'undefined') farmableChars = new Set(UpgradesService.farmableCharacters);
 
                 return filteredCharactersByName.filter(char => {


### PR DESCRIPTION
This PR proposes a new `Unfarmable` filter to the Who You Own Page. It may help folks decide who to honour in Onslaught, if they avoid honouring farmable characters.

This may not be a useful-enough feature to merge, I'm open to suggestion. It'll help me personally, a small amount, when I'm deciding on a new Onslaught character.

The definition of "Unfarmable" is: the character's shards are not declared as potential rewards in `recipeData.json`.

<img width="927" height="695" alt="unfarmable" src="https://github.com/user-attachments/assets/ef2868a2-a292-441e-a2ae-7191043c4526" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a new filter option to display characters that cannot be farmed.
  * Updated character view controls to show "Unfarmable" as a filter choice.

* **Enhancements**
  * Improved filtering logic to accurately identify and exclude farmable characters when using the new filter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->