### PR TITLE
Patch to fix rarity calculation for gold

### DIFF
--- a/src/fsd/4-entities/unit/characters-value.service.ts
+++ b/src/fsd/4-entities/unit/characters-value.service.ts
@@ -103,8 +103,8 @@ export class CharactersValueService {
         return Math.ceil(
             sum(
                 result
-                    // filter out Gold, which has an undefined label
-                    .filter(x => x.label !== undefined)
+                    // filter out Gold and an undefined labels
+                    .filter(x => x.label !== undefined && x.label !== 'Gold')
                     .map(x => x.count * MaterialBS[x.rarity])
             )
         );


### PR DESCRIPTION
A label was added to the material Gold, which means it is no longer being filtered from the value calculation.

Since its rarity is NaN, that is being propagated through so that all character Blackstone values result in NaN. I've updated the filter to explicitly filter Gold as well as any undefined labels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering to exclude materials labeled as 'Gold' from certain calculations, ensuring more accurate results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->