### PR TITLE
Emperor's Children faction color now matches game

### DIFF
--- a/src/v2/data/factions.json
+++ b/src/v2/data/factions.json
@@ -117,6 +117,6 @@
         "alliance": "Chaos",
         "name": "Emperor's Children",
         "icon": "Emperor's Children.png",
-        "color": "#DF6CC5"
+        "color": "#874470"
     }
 ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the color for the "Emperor's Children" faction in the Chaos alliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->