### PR TITLE
total gold for abilities should take into account goals with no xp required

### DIFF
--- a/src/routes/goals/goals.tsx
+++ b/src/routes/goals/goals.tsx
@@ -206,9 +206,7 @@ export const Goals = () => {
     );
 
     const totalGoldAbilities = sum(
-        goalsEstimate
-            .filter(x => !!x.abilitiesEstimate && !!x.xpEstimateAbilities)
-            .map(x => x.abilitiesEstimate!.gold + x.xpEstimateAbilities!.gold)
+        goalsEstimate.map(x => (x.abilitiesEstimate?.gold ?? 0) + (x.xpEstimateAbilities?.gold ?? 0))
     );
 
     return (


### PR DESCRIPTION
The filter condition on total gold for abilities currently excludes goals that don't require xp (it checks for the presence of an estimate for both gold and xp). This PR removes the condition and adds up the cost for all goals, setting it to 0 if not present. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calculation of total gold abilities to ensure all entries are included, treating missing gold values as zero instead of excluding them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->