### PR TITLE
Better UX for some API errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ yarn-error.log*
 
 # IDE
 .idea
+
+tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # IDE
-.idea
+/.idea/
 
-tmp/
+/tmp/

--- a/src/fsd/4-entities/equipment/ui/equipment-icon.tsx
+++ b/src/fsd/4-entities/equipment/ui/equipment-icon.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { AccessibleTooltip, getImageUrl } from '@/fsd/5-shared/ui';
 
-import { EquipmentService, IEquipment } from '@/fsd/4-entities/equipment';
+import { EquipmentService } from '../equipment.service';
+import type { IEquipment } from '../model';
 
 export const EquipmentIcon = ({
     equipment,

--- a/src/fsd/4-entities/equipment/ui/equipment-type-icon.tsx
+++ b/src/fsd/4-entities/equipment/ui/equipment-type-icon.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { AccessibleTooltip, getImageUrl } from '@/fsd/5-shared/ui';
 
-import { EquipmentService, EquipmentType } from '@/fsd/4-entities/equipment';
+import type { EquipmentType } from '../enums';
+import { EquipmentService } from '../equipment.service';
 
 export const EquipmentTypeIcon = ({
     equipmentType,

--- a/src/fsd/5-shared/api/makeApiCall.ts
+++ b/src/fsd/5-shared/api/makeApiCall.ts
@@ -7,7 +7,7 @@ export const makeApiCall = <TResponse, TRequestBody = any>(
     method: Method,
     url: string,
     body?: TRequestBody
-): Promise<{ data: TResponse | null; error: string | null }> => {
+): Promise<{ data: TResponse | null; error: AxiosError<IErrorResponse> | string | null }> => {
     const fetchData = async () => {
         try {
             const response = await API<TResponse, AxiosResponse<TResponse>, TRequestBody>({
@@ -28,8 +28,10 @@ export const makeApiCall = <TResponse, TRequestBody = any>(
                     console.info('Request was canceled');
                     return { data: null, error: null };
                 }
-                return { data: null, error: error?.response?.data?.message || error.message };
+                error.message = error?.response?.data?.message || error.message;
+                return { data: null, error };
             } else {
+                console.error(`Unexpected error during API call`, error);
                 return { data: null, error: error.message };
             }
         }

--- a/src/fsd/5-shared/ui/icons/unit-shard.icon.tsx
+++ b/src/fsd/5-shared/ui/icons/unit-shard.icon.tsx
@@ -16,7 +16,7 @@ export const UnitShardIcon = ({
     height?: number;
     width?: number;
 }) => {
-    if (!icon) return;
+    if (!icon) return null;
     const imageUrl = getImageUrl(`characters/resized/${icon.replace('.webp', '.png')}`);
 
     const image = (

--- a/src/fsd/5-shared/ui/icons/unit-shard.icon.tsx
+++ b/src/fsd/5-shared/ui/icons/unit-shard.icon.tsx
@@ -1,6 +1,7 @@
 ﻿import React from 'react';
 
-import { AccessibleTooltip, getImageUrl } from '@/fsd/5-shared/ui';
+import { getImageUrl } from '../get-image-url';
+import { AccessibleTooltip } from '../tooltip';
 
 export const UnitShardIcon = ({
     icon,

--- a/src/shared-components/user-menu/auth.endpoints.ts
+++ b/src/shared-components/user-menu/auth.endpoints.ts
@@ -2,8 +2,14 @@ import { IErrorResponse, makeApiCall } from '@/fsd/5-shared/api';
 
 import { ILoginResponse, IRegistrationResponse } from './auth.model';
 
-export const registerUser = (username: string, password: string) =>
-    makeApiCall<IRegistrationResponse, IErrorResponse>('POST', 'RegisterUser', { username, password } as any);
+export const registerUser = async (username: string, password: string) => {
+    const { data, error } = await makeApiCall<IRegistrationResponse, IErrorResponse>('POST', 'RegisterUser', {
+        username,
+        password,
+    } as any);
+    if (error) throw error;
+    return { data, error: null };
+};
 
 export const loginUser = (username: string, password: string) =>
     makeApiCall<ILoginResponse, IErrorResponse>('POST', 'LoginUser', { username, password } as any);

--- a/src/shared-components/user-menu/auth.endpoints.ts
+++ b/src/shared-components/user-menu/auth.endpoints.ts
@@ -1,15 +1,22 @@
-import { IErrorResponse, makeApiCall } from '@/fsd/5-shared/api';
+import { makeApiCall } from '@/fsd/5-shared/api';
 
 import { ILoginResponse, IRegistrationResponse } from './auth.model';
 
 export const registerUser = async (username: string, password: string) => {
-    const { data, error } = await makeApiCall<IRegistrationResponse, IErrorResponse>('POST', 'RegisterUser', {
-        username,
-        password,
-    } as any);
+    const { data, error } = await makeApiCall<IRegistrationResponse, { username: string; password: string }>(
+        'POST',
+        'RegisterUser',
+        {
+            username,
+            password,
+        }
+    );
     if (error) throw error;
     return { data, error: null };
 };
 
 export const loginUser = (username: string, password: string) =>
-    makeApiCall<ILoginResponse, IErrorResponse>('POST', 'LoginUser', { username, password } as any);
+    makeApiCall<ILoginResponse, { username: string; password: string }>('POST', 'LoginUser', {
+        username,
+        password,
+    });

--- a/src/shared-components/user-menu/auth.endpoints.ts
+++ b/src/shared-components/user-menu/auth.endpoints.ts
@@ -15,8 +15,15 @@ export const registerUser = async (username: string, password: string) => {
     return { data, error: null };
 };
 
-export const loginUser = (username: string, password: string) =>
-    makeApiCall<ILoginResponse, { username: string; password: string }>('POST', 'LoginUser', {
-        username,
-        password,
-    });
+export const loginUser = async (username: string, password: string) => {
+    const { data, error } = await makeApiCall<ILoginResponse, { username: string; password: string }>(
+        'POST',
+        'LoginUser',
+        {
+            username,
+            password,
+        }
+    );
+    if (error) throw error;
+    return { data, error: null };
+};

--- a/src/v2/features/tacticus-integration/tacticus-integration.dialog.tsx
+++ b/src/v2/features/tacticus-integration/tacticus-integration.dialog.tsx
@@ -1,8 +1,10 @@
+import type { AxiosError } from 'axios';
 import { enqueueSnackbar } from 'notistack';
 import React, { useState } from 'react';
 
 import { DialogProps } from 'src/v2/models/dialog.props';
 
+import type { IErrorResponse } from '@/fsd/5-shared/api';
 import { updateTacticusApiKey } from '@/fsd/5-shared/lib/tacticus-api';
 import { useAuth } from '@/fsd/5-shared/model';
 import { Button } from '@/fsd/5-shared/ui/button';
@@ -44,16 +46,19 @@ export const TacticusIntegrationDialog: React.FC<Props> = ({
         await syncWithTacticus(syncOptions);
     }
 
+    function buildErrMsg(error: string | Error | null): string {
+        const baseMsg = 'Failed to update settings';
+        const detail = typeof error === 'string' ? error : error?.message;
+        return detail ? `${baseMsg}: ${detail}` : baseMsg;
+    }
+
     async function updateApiKey() {
         loader.startLoading('Updating settings. Please wait...');
         try {
             const response = await updateTacticusApiKey(apiKey, guildApiKey, userId);
 
             if (!response.data) {
-                const baseMsg = 'Failed to update settings';
-                const detail = typeof response.error === 'string' ? response.error : response.error?.message;
-                const message = detail ? `${baseMsg}: ${detail}` : baseMsg;
-                enqueueSnackbar(message, { variant: 'error' });
+                enqueueSnackbar(buildErrMsg(response.error), { variant: 'error' });
                 return;
             }
 
@@ -70,7 +75,9 @@ export const TacticusIntegrationDialog: React.FC<Props> = ({
             enqueueSnackbar('Settings updated', { variant: 'success' });
         } catch (error) {
             console.error(error);
-            enqueueSnackbar('Failed to update settings', { variant: 'error' });
+            const parsedError =
+                typeof error === 'string' || error instanceof Error || error === null ? error : String(error);
+            enqueueSnackbar(buildErrMsg(parsedError), { variant: 'error' });
         } finally {
             loader.endLoading();
         }

--- a/src/v2/features/tacticus-integration/tacticus-integration.dialog.tsx
+++ b/src/v2/features/tacticus-integration/tacticus-integration.dialog.tsx
@@ -51,9 +51,9 @@ export const TacticusIntegrationDialog: React.FC<Props> = ({
 
             if (!response.data) {
                 const baseMsg = 'Failed to update settings';
-                let errMsg = typeof response.error === 'string' ? response.error : response.error?.message;
-                if (errMsg) errMsg = `${baseMsg}: ${errMsg}`;
-                enqueueSnackbar(errMsg, { variant: 'error' });
+                const detail = typeof response.error === 'string' ? response.error : response.error?.message;
+                const message = detail ? `${baseMsg}: ${detail}` : baseMsg;
+                enqueueSnackbar(message, { variant: 'error' });
                 return;
             }
 

--- a/src/v2/features/tacticus-integration/tacticus-integration.dialog.tsx
+++ b/src/v2/features/tacticus-integration/tacticus-integration.dialog.tsx
@@ -50,7 +50,10 @@ export const TacticusIntegrationDialog: React.FC<Props> = ({
             const response = await updateTacticusApiKey(apiKey, guildApiKey, userId);
 
             if (!response.data) {
-                enqueueSnackbar('Failed to update settings', { variant: 'error' });
+                const baseMsg = 'Failed to update settings';
+                let errMsg = typeof response.error === 'string' ? response.error : response.error?.message;
+                if (errMsg) errMsg = `${baseMsg}: ${errMsg}`;
+                enqueueSnackbar(errMsg, { variant: 'error' });
                 return;
             }
 


### PR DESCRIPTION
This PR improves the UX for some operations that call the planner's API:

- attempting to register with a claimed username will now alert the user to that fact,
- attempting to login with invalid creds won't partially succeed, and will tell the user why, and
- attempting to update a Tacticus API key with an invalid key will include that info in the user notification

It also fixes some build warnings related to circular dependencies in some FSD modules, and addresses some-but-not-all CodeRabbit nitpicks.

This PR is also intended as a testdrive for my new contributor permissions for the repo, so I'll see how far I can cowboy solo 🤠 🏇 PR approvals and a release.
EDIT: not super far - I require approval from another user with write access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API error handling to surface clearer server messages across the app.
  * More informative error notifications when updating Tacticus integration settings.
  * Standardized user registration and login handling to provide consistent success/failure feedback.

* **Chores**
  * Updated ignore rules to exclude temporary IDE files and temp folders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->