### PR TITLE
Fix bugs in Goals page

### DIFF
--- a/src/routes/goals/goals.tsx
+++ b/src/routes/goals/goals.tsx
@@ -102,7 +102,7 @@ export const Goals = () => {
 
         if (item === 'edit') {
             const goal = allGoals.find(x => x.goalId === goalId);
-            const relatedUnit = [...characters, ...resolvedMows].find(x => x.snowprintId === goal?.unitId);
+            const relatedUnit = [...characters, ...resolvedMows].find(x => x.id === goal?.unitId);
             if (relatedUnit && goal) {
                 setEditUnit(relatedUnit);
                 setEditGoal(goal);

--- a/src/shared-components/goals/edit-goal-dialog.tsx
+++ b/src/shared-components/goals/edit-goal-dialog.tsx
@@ -121,7 +121,7 @@ export const EditGoalDialog: React.FC<Props> = ({ isOpen, onClose, goal, unit })
                 });
             }
 
-            enqueueSnackbar(`Goal for ${updatedGoal.unitName} is updated`, { variant: 'success' });
+            enqueueSnackbar(`Goal for ${updatedGoal.unitId} is updated`, { variant: 'success' });
         }
         setOpenDialog(false);
         if (onClose) {

--- a/src/shared-components/goals/set-goal-dialog.tsx
+++ b/src/shared-components/goals/set-goal-dialog.tsx
@@ -84,7 +84,8 @@ export const SetGoalDialog = ({ onClose }: { onClose?: (goal?: IPersonalGoal) =>
         if (goal) {
             goal.dailyRaids = [PersonalGoalType.UpgradeRank, PersonalGoalType.MowAbilities].includes(goal.type);
             dispatch.goals({ type: 'Add', goal });
-            enqueueSnackbar(`Goal for ${goal.character} is added`, { variant: 'success' });
+            const character = characters.find(c => c.snowprintId === goal.character);
+            enqueueSnackbar(`Goal for ${character?.shortName ?? goal.character} is added`, { variant: 'success' });
         }
         setOpenDialog(false);
         setUnit(null);


### PR DESCRIPTION
This PR fixes a few bugs in the Goals page:
- clicking the pencil icon to edit a goal was doing nothing
- the notifications after setting/editing a goal were showing the snowprintID, not the character's name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Editing a goal now correctly links to the related unit using the canonical identifier, preventing mismatches when opening or updating goals.
  * Success notification on goal edit now displays a consistent identifier for the unit, improving accuracy.

* **Style**
  * Improved snackbar messages when setting a goal: character names now prefer the display short name when available, with a sensible fallback.
  * Refined success copy in the edit dialog to present clearer, more consistent identifiers in notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->