### PR TITLE
HOTFIX: Fix crash when API returns Mythic progressionIndex

### DIFF
--- a/.github/workflows/azure-static-web-apps-brave-flower-021735410.yml
+++ b/.github/workflows/azure-static-web-apps-brave-flower-021735410.yml
@@ -33,6 +33,7 @@ jobs:
                   api_location: '' # Api source code path - optional
                   output_location: 'dist' # Built app content directory - optional
                   app_build_command: 'npm run build-ci'
+                  skip_deploy_on_missing_secrets: true
                   ###### End of Repository/Build Configurations ######
 
     close_pull_request_job:

--- a/src/v2/features/tacticus-integration/tacticus-integration.service.spec.ts
+++ b/src/v2/features/tacticus-integration/tacticus-integration.service.spec.ts
@@ -7,73 +7,27 @@ import { TacticusIntegrationService } from './tacticus-integration.service';
 describe('TacticusIntegrationService', () => {
     describe('convertProgressionIndex', () => {
         it('should convert index to correct Rarity/RarityStars', () => {
-            expect(TacticusIntegrationService.convertProgressionIndex(0)).toEqual([Rarity.Common, RarityStars.None]);
-
-            expect(TacticusIntegrationService.convertProgressionIndex(1)).toEqual([Rarity.Common, RarityStars.OneStar]);
-
-            expect(TacticusIntegrationService.convertProgressionIndex(2)).toEqual([
-                Rarity.Common,
-                RarityStars.TwoStars,
-            ]);
-
-            expect(TacticusIntegrationService.convertProgressionIndex(3)).toEqual([
-                Rarity.Uncommon,
-                RarityStars.TwoStars,
-            ]);
-
-            expect(TacticusIntegrationService.convertProgressionIndex(4)).toEqual([
-                Rarity.Uncommon,
-                RarityStars.ThreeStars,
-            ]);
-
-            expect(TacticusIntegrationService.convertProgressionIndex(5)).toEqual([
-                Rarity.Uncommon,
-                RarityStars.FourStars,
-            ]);
-
-            expect(TacticusIntegrationService.convertProgressionIndex(6)).toEqual([Rarity.Rare, RarityStars.FourStars]);
-
-            expect(TacticusIntegrationService.convertProgressionIndex(7)).toEqual([Rarity.Rare, RarityStars.FiveStars]);
-
-            expect(TacticusIntegrationService.convertProgressionIndex(8)).toEqual([
-                Rarity.Rare,
-                RarityStars.RedOneStar,
-            ]);
-
-            expect(TacticusIntegrationService.convertProgressionIndex(9)).toEqual([
-                Rarity.Epic,
-                RarityStars.RedOneStar,
-            ]);
-
-            expect(TacticusIntegrationService.convertProgressionIndex(10)).toEqual([
-                Rarity.Epic,
-                RarityStars.RedTwoStars,
-            ]);
-
-            expect(TacticusIntegrationService.convertProgressionIndex(11)).toEqual([
-                Rarity.Epic,
-                RarityStars.RedThreeStars,
-            ]);
-
-            expect(TacticusIntegrationService.convertProgressionIndex(12)).toEqual([
-                Rarity.Legendary,
-                RarityStars.RedThreeStars,
-            ]);
-
-            expect(TacticusIntegrationService.convertProgressionIndex(13)).toEqual([
-                Rarity.Legendary,
-                RarityStars.RedFourStars,
-            ]);
-
-            expect(TacticusIntegrationService.convertProgressionIndex(14)).toEqual([
-                Rarity.Legendary,
-                RarityStars.RedFiveStars,
-            ]);
-
-            expect(TacticusIntegrationService.convertProgressionIndex(15)).toEqual([
-                Rarity.Legendary,
-                RarityStars.BlueStar,
-            ]);
+            const cases: Array<[number, Rarity, RarityStars]> = [
+                [0, Rarity.Common, RarityStars.None],
+                [1, Rarity.Common, RarityStars.OneStar],
+                [2, Rarity.Common, RarityStars.TwoStars],
+                [3, Rarity.Uncommon, RarityStars.TwoStars],
+                [4, Rarity.Uncommon, RarityStars.ThreeStars],
+                [5, Rarity.Uncommon, RarityStars.FourStars],
+                [6, Rarity.Rare, RarityStars.FourStars],
+                [7, Rarity.Rare, RarityStars.FiveStars],
+                [8, Rarity.Rare, RarityStars.RedOneStar],
+                [9, Rarity.Epic, RarityStars.RedOneStar],
+                [10, Rarity.Epic, RarityStars.RedTwoStars],
+                [11, Rarity.Epic, RarityStars.RedThreeStars],
+                [12, Rarity.Legendary, RarityStars.RedThreeStars],
+                [13, Rarity.Legendary, RarityStars.RedFourStars],
+                [14, Rarity.Legendary, RarityStars.RedFiveStars],
+                [15, Rarity.Legendary, RarityStars.BlueStar],
+            ];
+            for (const [idx, rarity, stars] of cases) {
+                expect(TacticusIntegrationService.convertProgressionIndex(idx)).toEqual([rarity, stars]);
+            }
         });
 
         it('should clamp higher indices to Legendary Blue Wings', () => {

--- a/src/v2/features/tacticus-integration/tacticus-integration.service.spec.ts
+++ b/src/v2/features/tacticus-integration/tacticus-integration.service.spec.ts
@@ -82,7 +82,7 @@ describe('TacticusIntegrationService', () => {
             // These test expectations will need to be modified as we add support for them.
             const highVals = [16, 17, 18, 19, 20, 999];
             for (let i = 0; i < highVals.length; i++) {
-                const result = TacticusIntegrationService.convertProgressionIndex(16);
+                const result = TacticusIntegrationService.convertProgressionIndex(highVals[i]);
 
                 expect(result).toEqual([Rarity.Legendary, RarityStars.BlueStar]);
             }

--- a/src/v2/features/tacticus-integration/tacticus-integration.service.spec.ts
+++ b/src/v2/features/tacticus-integration/tacticus-integration.service.spec.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+
+import { Rarity, RarityStars } from '@/fsd/5-shared/model';
+
+import { TacticusIntegrationService } from './tacticus-integration.service';
+
+describe('TacticusIntegrationService', () => {
+    describe('convertProgressionIndex', () => {
+        it('should convert index to correct Rarity/RarityStars', () => {
+            expect(TacticusIntegrationService.convertProgressionIndex(0)).toEqual([Rarity.Common, RarityStars.None]);
+
+            expect(TacticusIntegrationService.convertProgressionIndex(1)).toEqual([Rarity.Common, RarityStars.OneStar]);
+
+            expect(TacticusIntegrationService.convertProgressionIndex(2)).toEqual([
+                Rarity.Common,
+                RarityStars.TwoStars,
+            ]);
+
+            expect(TacticusIntegrationService.convertProgressionIndex(3)).toEqual([
+                Rarity.Uncommon,
+                RarityStars.TwoStars,
+            ]);
+
+            expect(TacticusIntegrationService.convertProgressionIndex(4)).toEqual([
+                Rarity.Uncommon,
+                RarityStars.ThreeStars,
+            ]);
+
+            expect(TacticusIntegrationService.convertProgressionIndex(5)).toEqual([
+                Rarity.Uncommon,
+                RarityStars.FourStars,
+            ]);
+
+            expect(TacticusIntegrationService.convertProgressionIndex(6)).toEqual([Rarity.Rare, RarityStars.FourStars]);
+
+            expect(TacticusIntegrationService.convertProgressionIndex(7)).toEqual([Rarity.Rare, RarityStars.FiveStars]);
+
+            expect(TacticusIntegrationService.convertProgressionIndex(8)).toEqual([
+                Rarity.Rare,
+                RarityStars.RedOneStar,
+            ]);
+
+            expect(TacticusIntegrationService.convertProgressionIndex(9)).toEqual([
+                Rarity.Epic,
+                RarityStars.RedOneStar,
+            ]);
+
+            expect(TacticusIntegrationService.convertProgressionIndex(10)).toEqual([
+                Rarity.Epic,
+                RarityStars.RedTwoStars,
+            ]);
+
+            expect(TacticusIntegrationService.convertProgressionIndex(11)).toEqual([
+                Rarity.Epic,
+                RarityStars.RedThreeStars,
+            ]);
+
+            expect(TacticusIntegrationService.convertProgressionIndex(12)).toEqual([
+                Rarity.Legendary,
+                RarityStars.RedThreeStars,
+            ]);
+
+            expect(TacticusIntegrationService.convertProgressionIndex(13)).toEqual([
+                Rarity.Legendary,
+                RarityStars.RedFourStars,
+            ]);
+
+            expect(TacticusIntegrationService.convertProgressionIndex(14)).toEqual([
+                Rarity.Legendary,
+                RarityStars.RedFiveStars,
+            ]);
+
+            expect(TacticusIntegrationService.convertProgressionIndex(15)).toEqual([
+                Rarity.Legendary,
+                RarityStars.BlueStar,
+            ]);
+        });
+
+        it('should clamp higher indices to Legendary Blue Wings', () => {
+            // Indices 16-19 are being incrementally rolled out for Mythic, so we
+            // can expect them to show up in Tacticus API responses in future.
+            // These test expectations will need to be modified as we add support for them.
+            const highVals = [16, 17, 18, 19, 20, 999];
+            for (let i = 0; i < highVals.length; i++) {
+                const result = TacticusIntegrationService.convertProgressionIndex(16);
+
+                expect(result).toEqual([Rarity.Legendary, RarityStars.BlueStar]);
+            }
+        });
+
+        it('should clamp negative indices to Common w no stars', () => {
+            const negVals = [-999, -1];
+            for (let i = 0; i < negVals.length; i++) {
+                const result = TacticusIntegrationService.convertProgressionIndex(negVals[i]);
+
+                expect(result).toEqual([Rarity.Common, RarityStars.None]);
+            }
+        });
+    });
+});

--- a/src/v2/features/tacticus-integration/tacticus-integration.service.ts
+++ b/src/v2/features/tacticus-integration/tacticus-integration.service.ts
@@ -12,13 +12,14 @@ export class TacticusIntegrationService {
     static convertProgressionIndex(progressionIndex: number): [Rarity, RarityStars] {
         const maxSupportedIndex = 15;
         if (progressionIndex < 0) {
-            console.error(`API returned invalid progressionIndex ${progressionIndex}, setting to 0 (Common No Stars)`);
+            console.warn(`API returned invalid progressionIndex ${progressionIndex}, setting to 0`);
             progressionIndex = 0;
         }
         if (progressionIndex > maxSupportedIndex) {
             console.warn(
                 `API returned unsupported progressionIndex ${progressionIndex}, setting to ${maxSupportedIndex}`
             );
+            progressionIndex = maxSupportedIndex;
         }
 
         const rarityThresholds = [0, 3, 6, 9, 12];
@@ -37,7 +38,7 @@ export class TacticusIntegrationService {
         // As above, we clamp the rarity stars to the rarest we support. While this is inaccurate, it allows
         // the planner to absorb unsupported values in the period between their appearance in the Tacticus API,
         // and the planner adding support.
-        const rarityStars: RarityStars = (maxSupportedIndex - rarity) as RarityStars;
+        const rarityStars: RarityStars = (progressionIndex - rarity) as RarityStars;
 
         return [rarity, rarityStars];
     }

--- a/src/v2/features/tacticus-integration/tacticus-integration.service.ts
+++ b/src/v2/features/tacticus-integration/tacticus-integration.service.ts
@@ -10,13 +10,23 @@ import { UpgradesService } from 'src/v2/features/goals/upgrades.service';
 
 export class TacticusIntegrationService {
     static convertProgressionIndex(progressionIndex: number): [Rarity, RarityStars] {
-        if (progressionIndex < 0 || progressionIndex > 15) {
-            throw new Error('Invalid progression index');
+        const maxSupportedIndex = 15;
+        if (progressionIndex < 0) {
+            console.error(`API returned invalid progressionIndex ${progressionIndex}, setting to 0 (Common No Stars)`);
+            progressionIndex = 0;
+        }
+        if (progressionIndex > maxSupportedIndex) {
+            console.warn(
+                `API returned unsupported progressionIndex ${progressionIndex}, setting to ${maxSupportedIndex}`
+            );
         }
 
         const rarityThresholds = [0, 3, 6, 9, 12];
         let rarity: Rarity = Rarity.Common;
 
+        // We count down from rarest to most-common, so any progressionIndex values higher than maxSupportedIndex
+        // will be clamped to the rarest we currently support. This is relevant to the 2025 staged rollout of Mythic
+        // rarity, which adds a new rarity with 4 new ranks (but only 1 rank was released initially)
         for (let i = rarityThresholds.length - 1; i >= 0; i--) {
             if (progressionIndex >= rarityThresholds[i]) {
                 rarity = i as Rarity;
@@ -24,7 +34,10 @@ export class TacticusIntegrationService {
             }
         }
 
-        const rarityStars: RarityStars = (progressionIndex - rarity) as RarityStars;
+        // As above, we clamp the rarity stars to the rarest we support. While this is inaccurate, it allows
+        // the planner to absorb unsupported values in the period between their appearance in the Tacticus API,
+        // and the planner adding support.
+        const rarityStars: RarityStars = (maxSupportedIndex - rarity) as RarityStars;
 
         return [rarity, rarityStars];
     }


### PR DESCRIPTION
This PR fixes a crash when Tacticus API sync returns a Mythic `progressionIndex`.

Previously, the app code would intentionally crash. Now, it absorbs the value and clamps the derived result to Legendary Blue Wings.

Also added unit tests for this, since I think increasing test coverage might help us slowly smoke out bugs in the system.

A small change to the Github CI config was also required, to allow checks to succeed on this hotfix branch without deploying.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Bug Fixes
  * Improved handling of out-of-range progression data to prevent errors and ensure consistent rarity display.
* Tests
  * Added comprehensive unit tests covering progression-to-rarity mapping and boundary conditions.
* Chores
  * Updated deployment workflow to skip deploys when required secrets are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->