### PR TITLE
Fix an error in MoW badge calculation

### DIFF
--- a/src/fsd/1-pages/learn-mow/mow-lookup.service.ts
+++ b/src/fsd/1-pages/learn-mow/mow-lookup.service.ts
@@ -19,8 +19,8 @@ export class MowLookupService {
         const badges = new Map<Rarity, number>();
         const forgeBadges = new Map<Rarity, number>();
         for (const material of materials) {
-            badges.set(material.rarity, badges.get(material.rarity) ?? 0 + material.badges);
-            forgeBadges.set(material.rarity, forgeBadges.get(material.rarity) ?? 0 + material.forgeBadges);
+            badges.set(material.rarity, (badges.get(material.rarity) ?? 0) + material.badges);
+            forgeBadges.set(material.rarity, (forgeBadges.get(material.rarity) ?? 0) + material.forgeBadges);
         }
 
         return {


### PR DESCRIPTION
parentheses are your friend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Fixed inaccurate per‑rarity totals in the Learn MoW lookup, ensuring badge and forge badge counts accumulate correctly.
  * Missing rarities now initialize to zero and existing counts increment properly, resolving undercounting.
  * Users will see accurate per‑rarity summaries across the UI, including totals, progress indicators, and related displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->