### PR TITLE
fix(units-autocomplete): include shortName in Enter selection and sho…

### DIFF
--- a/src/fsd/4-entities/unit/ui/units-autocomplete.tsx
+++ b/src/fsd/4-entities/unit/ui/units-autocomplete.tsx
@@ -51,6 +51,7 @@ export const UnitsAutocomplete = <T extends IUnit>({
             const char = options.find(
                 x =>
                     x.name.toLowerCase().includes(value.toLowerCase()) ||
+                    ('shortName' in x ? (x as any).shortName.toLowerCase().includes(value.toLowerCase()) : false) ||
                     ('fullName' in x ? x.fullName.toLowerCase().includes(value.toLowerCase()) : false)
             );
             if (char) {
@@ -75,6 +76,14 @@ export const UnitsAutocomplete = <T extends IUnit>({
             open={openAutocomplete}
             onFocus={() => handleAutocompleteChange(true)}
             onBlur={() => handleAutocompleteChange(false)}
+            filterOptions={(opts, state) => {
+                const q = state.inputValue?.toLowerCase?.().trim() ?? '';
+                if (!q) return opts;
+                return opts.filter(x => {
+                    const short = 'shortName' in x ? ((x as any).shortName?.toLowerCase?.() ?? '') : '';
+                    return short.includes(q);
+                });
+            }}
             getOptionLabel={option => getOptionText(option)}
             isOptionEqualToValue={(option, value) => option.snowprintId === value.snowprintId}
             renderOption={(props, option) => (


### PR DESCRIPTION
include shortName in Enter selection and shortName-only dropdown filtering for Add Goal dialog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Unit autocomplete now recognizes and matches unit short names/abbreviations when searching (including Enter-key lookup).
  * Typing in the autocomplete filters options by short name (case-insensitive) for quicker, more relevant matches.
  * If the input is empty, all original options are shown.
  * Existing display labels and selection behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->