### PR TITLE
Set the upper limit on NumberInputs for MoW abilities to be the maximum level for character abilities.

### DIFF
--- a/src/shared-components/goals/set-goal-dialog.tsx
+++ b/src/shared-components/goals/set-goal-dialog.tsx
@@ -307,6 +307,7 @@ export const SetGoalDialog = ({ onClose }: { onClose?: (goal?: IPersonalGoal) =>
                                         fullWidth
                                         label="Primary target level"
                                         min={unit.primaryAbilityLevel}
+                                        max={CharactersAbilitiesService.getMaximumAbilityLevel()}
                                         value={form.firstAbilityLevel!}
                                         valueChange={primaryAbilityLevel => {
                                             setForm(curr => ({
@@ -320,6 +321,7 @@ export const SetGoalDialog = ({ onClose }: { onClose?: (goal?: IPersonalGoal) =>
                                         fullWidth
                                         label="Secondary target level"
                                         min={unit.secondaryAbilityLevel}
+                                        max={CharactersAbilitiesService.getMaximumAbilityLevel()}
                                         value={form.secondAbilityLevel!}
                                         valueChange={secondaryAbilityLevel => {
                                             setForm(curr => ({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Primary and Secondary target level fields in MoW Abilities now enforce the maximum allowed ability level, preventing entries above the limit and aligning behavior with Character Abilities.
  * Users receive immediate input capping/feedback for out-of-range values, reducing errors during goal setup and ensuring a consistent, predictable experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->