### PR TITLE
Persist mythicShards value for units and MoWs

### DIFF
--- a/src/fsd/3-features/character-details/character-details.tsx
+++ b/src/fsd/3-features/character-details/character-details.tsx
@@ -166,7 +166,7 @@ export const CharacterDetails = ({
                             inputProps={{
                                 step: 1,
                                 min: 0,
-                                max: 10000,
+                                max: 500,
                                 type: 'number',
                                 'aria-labelledby': 'input-slider',
                             }}

--- a/src/fsd/3-features/character-details/character-details.tsx
+++ b/src/fsd/3-features/character-details/character-details.tsx
@@ -27,6 +27,7 @@ export const CharacterDetails = ({
         bias: character.bias,
         level: character.level,
         shards: character.shards,
+        mythicShards: character.mythicShards,
         xp: character.xp,
         activeAbilityLevel: character.activeAbilityLevel,
         passiveAbilityLevel: character.passiveAbilityLevel,
@@ -121,11 +122,13 @@ export const CharacterDetails = ({
             </Grid>
 
             <Grid container spacing={2} alignItems="center">
-                <Grid item xs={6}>
+                <Grid item xs={12}>
                     {getNativeSelectControl(formData.rank, 'Rank', 'rank', rankEntries, rankToString, value => (
                         <RankIcon rank={value} />
                     ))}
                 </Grid>
+            </Grid>
+            <Grid container spacing={2} alignItems="center">
                 <Grid item xs={6}>
                     <FormControl variant={'outlined'} fullWidth>
                         <InputLabel>Shards</InputLabel>
@@ -134,6 +137,28 @@ export const CharacterDetails = ({
                             onChange={event =>
                                 handleInputChange(
                                     'shards',
+                                    event.target.value === '' ? '' : (Number(event.target.value) as any),
+                                    Number(event.target.value)
+                                )
+                            }
+                            inputProps={{
+                                step: 1,
+                                min: 0,
+                                max: 10000,
+                                type: 'number',
+                                'aria-labelledby': 'input-slider',
+                            }}
+                        />
+                    </FormControl>
+                </Grid>
+                <Grid item xs={6}>
+                    <FormControl variant={'outlined'} fullWidth>
+                        <InputLabel>Mythic Shards</InputLabel>
+                        <Input
+                            value={formData.mythicShards}
+                            onChange={event =>
+                                handleInputChange(
+                                    'mythicShards',
                                     event.target.value === '' ? '' : (Number(event.target.value) as any),
                                     Number(event.target.value)
                                 )

--- a/src/fsd/4-entities/character/characters.service.ts
+++ b/src/fsd/4-entities/character/characters.service.ts
@@ -214,6 +214,7 @@ export class CharactersService {
         return (
             id === character.snowprintId ||
             lowered === character.id.toLowerCase() ||
+            lowered === character.name.toLowerCase() ||
             lowered === character.shortName.toLowerCase() ||
             lowered === character.fullName.toLowerCase()
         );

--- a/src/fsd/4-entities/character/model.ts
+++ b/src/fsd/4-entities/character/model.ts
@@ -2,7 +2,6 @@ import {
     Alliance,
     DamageType,
     DynamicProps,
-    Equipment,
     Faction,
     Rank,
     Rarity,
@@ -28,6 +27,7 @@ export interface IPersonalCharacterData2 {
     activeAbilityLevel: number;
     passiveAbilityLevel: number;
     shards: number;
+    mythicShards: number;
 }
 
 export interface IDamageTypes {

--- a/src/fsd/4-entities/mow/model.ts
+++ b/src/fsd/4-entities/mow/model.ts
@@ -58,6 +58,7 @@ export interface IMowDb {
     primaryAbilityLevel: number;
     secondaryAbilityLevel: number;
     shards: number;
+    mythicShards: number;
 }
 
 export interface IMow extends IMowStatic, IMowDb, DynamicProps {

--- a/src/fsd/5-shared/lib/tacticus-api/tacticus-api.models.ts
+++ b/src/fsd/5-shared/lib/tacticus-api/tacticus-api.models.ts
@@ -72,6 +72,11 @@ export interface TacticusUnit {
      * Owned shards of the unit.
      */
     shards: number;
+
+    /**
+     * Owned mythic shards of the unit.
+     */
+    mythicShards: number;
 }
 
 export interface TacticusUpgrade {

--- a/src/models/global-state.ts
+++ b/src/models/global-state.ts
@@ -2,7 +2,7 @@
 
 import { ICampaignsProgress } from '@/fsd/4-entities/campaign';
 import { CharacterBias, CharactersService, ICharacter2 } from '@/fsd/4-entities/character';
-import { IMow, IMow2, IMowDb, IMowStatic, mows2Data, mowsData, MowsService } from '@/fsd/4-entities/mow';
+import { IMow, IMow2, IMowDb, mowsData, MowsService } from '@/fsd/4-entities/mow';
 import { CharactersPowerService } from '@/fsd/4-entities/unit/characters-power.service';
 import { UpgradesService } from '@/fsd/4-entities/upgrade';
 
@@ -110,6 +110,7 @@ export class GlobalState implements IGlobalState {
                 level: level,
                 xp: personalCharData?.xp ?? 0,
                 shards: personalCharData?.shards ?? 0,
+                mythicShards: personalCharData?.mythicShards ?? 0,
             };
 
             const result: ICharacter2 = {
@@ -150,6 +151,7 @@ export class GlobalState implements IGlobalState {
                 secondaryAbilityLevel: dbMow?.secondaryAbilityLevel ?? 1,
                 unlocked: dbMow?.unlocked ?? false,
                 shards: dbMow?.shards ?? 0,
+                mythicShards: dbMow?.mythicShards ?? 0,
                 numberOfUnlocked:
                     totalUsers && dbMow?.numberOfUnlocked
                         ? Math.ceil((dbMow.numberOfUnlocked / totalUsers) * 100)
@@ -196,7 +198,8 @@ export class GlobalState implements IGlobalState {
                     x.stars !== RarityStars.None ||
                     x.level !== 1 ||
                     x.xp !== 0 ||
-                    x.shards !== 0
+                    x.shards !== 0 ||
+                    x.mythicShards !== 0
             )
             .map(x => ({
                 name: x.name,
@@ -210,6 +213,7 @@ export class GlobalState implements IGlobalState {
                 level: x.level,
                 xp: x.xp,
                 shards: x.shards,
+                mythicShards: x.mythicShards,
             }));
 
         const mowsToDb: IMowDb[] = value.mows.map(x => ({
@@ -219,6 +223,7 @@ export class GlobalState implements IGlobalState {
             secondaryAbilityLevel: x.secondaryAbilityLevel,
             stars: x.stars,
             shards: x.shards,
+            mythicShards: x.mythicShards ?? 0,
             unlocked: x.unlocked,
         }));
 

--- a/src/models/interfaces.ts
+++ b/src/models/interfaces.ts
@@ -5,7 +5,7 @@ import { GuildWarAction } from 'src/reducers/guildWarReducer';
 import { MowsAction } from 'src/reducers/mows.reducer';
 import { TeamsAction } from 'src/reducers/teams.reducer';
 
-import { Alliance, Faction, Rank, Rarity, RarityStars } from '@/fsd/5-shared/model';
+import { Rank, Rarity, RarityStars } from '@/fsd/5-shared/model';
 
 import {
     ICampaignsProgress,
@@ -16,7 +16,7 @@ import {
     IDetailedEnemy,
 } from '@/fsd/4-entities/campaign';
 import { CharacterBias, ICharacter2, ICharLegendaryEvent } from '@/fsd/4-entities/character';
-import { LegendaryEventEnum, LreTrackId } from '@/fsd/4-entities/lre';
+import { LegendaryEventEnum } from '@/fsd/4-entities/lre';
 import { IMow, IMow2, IMowDb } from '@/fsd/4-entities/mow';
 import { IMaterialFull, IMaterialRecipeIngredientFull, IMaterialEstimated2 } from '@/fsd/4-entities/upgrade';
 
@@ -218,6 +218,7 @@ export interface IPersonalCharacterData2 {
     activeAbilityLevel: number;
     passiveAbilityLevel: number;
     shards: number;
+    mythicShards: number;
 }
 
 export interface IInsightsData {

--- a/src/v2/features/characters/dialogs/edit-mow-dialog.tsx
+++ b/src/v2/features/characters/dialogs/edit-mow-dialog.tsx
@@ -97,7 +97,7 @@ export const EditMowDialog: React.FC<Props> = ({
                         />
                     </Grid>
 
-                    <Grid item xs={6}>
+                    <Grid item xs={12}>
                         <FormControlLabel
                             label="Unlocked"
                             control={
@@ -115,6 +115,15 @@ export const EditMowDialog: React.FC<Props> = ({
                             max={1000}
                             value={editedMow.shards}
                             valueChange={value => handleInputChange('shards', value)}
+                        />
+                    </Grid>
+                    <Grid item xs={6}>
+                        <NumberInput
+                            fullWidth
+                            label="Mythic Shards"
+                            max={1000}
+                            value={editedMow.mythicShards}
+                            valueChange={value => handleInputChange('mythicShards', value)}
                         />
                     </Grid>
 


### PR DESCRIPTION
This PR adds a `mythicShards` attribute to the data models for units and MoWs.

The attribute is persisted to the Planner API and, currently, can be manually edited. Once the Planner API's `GET /playerData` endpoint forwards the `mythicShards` value from the Tacticus API, these values will overwrite manually-edited values.

To make UI space for the new Mythic Shards field, the Rank dropdowns were given their own grid row.
<img width="456" height="458" alt="new_layout" src="https://github.com/user-attachments/assets/9016afa8-34eb-43cc-9871-faa3a2ea9fa8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added Mythic Shards support across the app: view, edit, and persist values for characters and mows.
  - Sync now imports Mythic Shards from external data where available.

- Improvements
  - Character and Mow edit dialogs updated: clearer layout with full-width Rank/Unlocked/Shards rows and a dedicated Mythic Shards input with numeric validation.
  - More reliable character matching by also recognizing character names during sync.
  - Sync applies broader updates (rarity, stars, rank, XP, shards, levels) for unlocked units while preserving manual overrides where appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->