### PR TITLE
Display next LRE unit's name on homepage

### DIFF
--- a/src/fsd/1-pages/home/desktop-home.tsx
+++ b/src/fsd/1-pages/home/desktop-home.tsx
@@ -29,6 +29,7 @@ export const DesktopHome = () => {
     const { userInfo } = useAuth();
     const { goals, dailyRaids } = useContext(StoreContext);
     const nextLeMenuItem = LegendaryEventService.getActiveEvent();
+    const nextLeUnit = CharactersService.charactersData.find(x => x.snowprintId === nextLeMenuItem.unitSnowprintId);
     const goalsMenuItem = menuItemById['goals'];
     const dailyRaidsMenuItem = menuItemById['dailyRaids'];
 
@@ -162,15 +163,8 @@ export const DesktopHome = () => {
                         <CardHeader
                             title={
                                 <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-                                    <UnitShardIcon
-                                        icon={
-                                            CharactersService.charactersData.find(
-                                                x => x.snowprintId === LegendaryEventService.getActiveLreUnitId()
-                                            )?.roundIcon ?? ''
-                                        }
-                                        height={50}
-                                        width={50}
-                                    />{' '}
+                                    <UnitShardIcon icon={nextLeUnit?.roundIcon ?? ''} height={50} width={50} />
+                                    {nextLeUnit?.shortName}
                                 </div>
                             }
                             subheader={formatMonthAndDay(isEventStarted ? nextLeDateEnd : nextLeDateStart)}


### PR DESCRIPTION
'Twas annoying me every time I refreshed during dev :)

Before
<img width="370" height="275" alt="before" src="https://github.com/user-attachments/assets/a147d176-ed7e-4803-aa0c-215e9a06fce8" />

After
<img width="369" height="258" alt="after" src="https://github.com/user-attachments/assets/8f587132-1005-44fa-a1a0-d51367e0e35c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Legendary Event card header now shows the featured unit’s short name alongside its icon, improving quick recognition during event browsing.

* **Style**
  * Updated the unit icon in the Legendary Event header to use the round portrait for improved visual clarity and consistency with other UI elements.  
  * Refined header presentation for a cleaner, more informative layout without altering existing behavior elsewhere.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->