### PR TITLE
Ensure MoWs display on Teams page

### DIFF
--- a/src/v2/features/teams/components/teams-grid.tsx
+++ b/src/v2/features/teams/components/teams-grid.tsx
@@ -39,7 +39,8 @@ export const TeamsGrid: React.FC<Props> = ({ teams, characters, mows, deleteTeam
         const teamCharacters = team.lineup.map(id => {
             return characters.find(character => NewCharService.matchesAnyCharacterId(id, character));
         });
-        const teamMow = mows.find(x => x.snowprintId === team.mowId);
+        const teamMowId = typeof team.mowId === 'string' ? team.mowId : undefined;
+        const teamMow = teamMowId ? mows.find(x => [x.snowprintId, x.id].includes(teamMowId)) : undefined;
         const withMow = !!teamMow;
         const subModes = team.subModes.map(value => allModes.find(x => x.value === value)?.label ?? '').join(', ');
 


### PR DESCRIPTION
This PR fixes a bug preventing MoWs displaying on the Teams page.

Editing a team's MoW is still bugged - will do a follow-up at some point.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Teams Grid now more reliably links teams to their corresponding MOW entries, handling varied identifier formats to prevent missing or incorrect associations.
  * Reduces occurrences of blank or mismatched MOW data when viewing teams, ensuring accurate display of related details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->