### PR TITLE
Fix XP calcs for point 5 upgrade goals

### DIFF
--- a/src/routes/goals/goals.tsx
+++ b/src/routes/goals/goals.tsx
@@ -159,7 +159,7 @@ export const Goals = () => {
 
                 if (goal.type === PersonalGoalType.UpgradeRank) {
                     const rankEnd = goal.rankEnd ?? Rank.Stone1;
-                    const targetRank = (rankEnd - 1) as Rank;
+                    const targetRank = (goal.rankPoint5 ? rankEnd - 1 : rankEnd) as Rank;
                     const targetLevel = rankToLevel[targetRank];
                     const xpEstimate = CharactersXpService.getLegendaryTomesCount(goal.level, goal.xp, targetLevel);
 

--- a/src/routes/goals/goals.tsx
+++ b/src/routes/goals/goals.tsx
@@ -158,7 +158,8 @@ export const Goals = () => {
                 }).length;
 
                 if (goal.type === PersonalGoalType.UpgradeRank) {
-                    const targetLevel = rankToLevel[(goal.rankEnd ?? Rank.Stone2) as Rank];
+                    const targetRank = ((goal.rankEnd ?? 1) - 1) as Rank;
+                    const targetLevel = rankToLevel[targetRank];
                     const xpEstimate = CharactersXpService.getLegendaryTomesCount(goal.level, goal.xp, targetLevel);
 
                     return {

--- a/src/routes/goals/goals.tsx
+++ b/src/routes/goals/goals.tsx
@@ -158,7 +158,8 @@ export const Goals = () => {
                 }).length;
 
                 if (goal.type === PersonalGoalType.UpgradeRank) {
-                    const targetRank = ((goal.rankEnd ?? 1) - 1) as Rank;
+                    const rankEnd = goal.rankEnd ?? Rank.Stone1;
+                    const targetRank = (rankEnd - 1) as Rank;
                     const targetLevel = rankToLevel[targetRank];
                     const xpEstimate = CharactersXpService.getLegendaryTomesCount(goal.level, goal.xp, targetLevel);
 


### PR DESCRIPTION
This PR fixes a bug for Point 5 upgrade goals, currently in staging not production.

The UI was showing more XP books required than truly were. The below example shows characters of level 35 or above, with Gold I Point 5 goals, so zero XP books required

Before
<img width="1100" height="297" alt="before" src="https://github.com/user-attachments/assets/a14b51e0-7c24-4bec-b067-9bcd1fcf59d2" />

After
<img width="1100" height="275" alt="after" src="https://github.com/user-attachments/assets/57154ca3-8b37-4319-be38-6e5c13a100fe" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an off-by-one in rank-to-level mapping used for upgrade estimations.
  * Adjusted default target rank logic and added half-rank (rank+0.5) handling when computing targets.
  * Users will see more accurate XP/tome requirements when planning rank upgrades, improving reliability of upgrade planning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->