### PR TITLE
fix for using snowprint ids in the guildwar planning team potential

### DIFF
--- a/src/v2/pages/guild-war-defense/guild-war-defense.tsx
+++ b/src/v2/pages/guild-war-defense/guild-war-defense.tsx
@@ -94,7 +94,7 @@ export const GuildWarDefense = () => {
     const teamsPotential = useMemo(() => {
         return teamsWithCharacters.map((team, teamIndex) => {
             const lineup = team.lineup.map(x => ({
-                id: x.name,
+                id: x.shortName,
                 potential: CharactersService.calculateCharacterPotential(
                     CharactersService.capCharacterAtRarity(x, team.rarityCap),
                     team.rarityCap


### PR DESCRIPTION
fix for using short name rather than snowprint ID in guild war potential

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Updated team potential breakdown to display character short names instead of full names.
  - Adjusted lineup entry identifiers to align with short name labels in the breakdown.
  - No changes to potential calculations; totals and character potential remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->