### PR TITLE
remove rank and rarity from character name column 

### DIFF
--- a/src/fsd/1-pages/learn-characters/characters-column-defs.tsx
+++ b/src/fsd/1-pages/learn-characters/characters-column-defs.tsx
@@ -14,7 +14,7 @@ import {
 } from '@/fsd/5-shared/model';
 import { RarityIcon } from '@/fsd/5-shared/ui/icons';
 
-import { ICharacter2, CharacterTitle, RankIcon } from '@/fsd/4-entities/character';
+import { ICharacter2, CharacterTitleShort, RankIcon } from '@/fsd/4-entities/character';
 import { StatCell, DamageCell, StatsCalculatorService } from '@/fsd/4-entities/unit';
 
 export const useCharacters = () => {
@@ -118,16 +118,9 @@ export const useCharacters = () => {
                         pinned: !isMobile,
                         cellRenderer: (props: ICellRendererParams<ICharacter2>) => {
                             const character = props.data;
-                            return (
-                                character && (
-                                    <CharacterTitle
-                                        character={character}
-                                        hideName={isMobile}
-                                        short={true}
-                                        imageSize={30}
-                                    />
-                                )
-                            );
+                            return character ? (
+                                <CharacterTitleShort character={character} hideName={isMobile} imageSize={30} />
+                            ) : null;
                         },
                     },
                     {


### PR DESCRIPTION
remove rank and rarity from character name column  in learn>tacticus>characters

used the character-Title-short instead of character-title

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Style
  * Updated the character name display in the Learn Characters table to a shorter, more compact format for improved readability and consistency.
* Refactor
  * Simplified the rendering logic for the name column to reduce complexity and improve maintainability, with no functional changes beyond the visual adjustment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->