### PR TITLE
Fix a couple bugs

### DIFF
--- a/src/fsd/4-entities/campaign/campaign-location.tsx
+++ b/src/fsd/4-entities/campaign/campaign-location.tsx
@@ -23,14 +23,7 @@ export const CampaignLocation: React.FC<Props> = ({ location, unlocked, short = 
             Campaign.TAEC,
         ];
         if (challengeCampaigns.includes(location.campaign)) {
-            switch (location.nodeNumber) {
-                case 1:
-                    return '3B';
-                case 2:
-                    return '13B';
-                case 3:
-                    return '25B';
-            }
+            return location.nodeNumber + 'B';
         }
         return location.nodeNumber;
     }, []);

--- a/src/fsd/4-entities/campaign/campaigns.service.ts
+++ b/src/fsd/4-entities/campaign/campaigns.service.ts
@@ -11,6 +11,7 @@ import { Campaign, CampaignReleaseType, CampaignType } from './enums';
 import { ICampaignBattle, ICampaignBattleComposed, ICampaignsProgress, ICampaingsFilters, IDropRate } from './model';
 
 export class CampaignsService {
+    public static readonly rawBattleData = battleData;
     public static readonly allCampaigns = campaignsList;
     public static readonly standardCampaigns = campaignsList.filter(
         campaign => campaign.releaseType === CampaignReleaseType.standard
@@ -97,21 +98,12 @@ export class CampaignsService {
                     console.warn('no recipe found', reward, battle);
                 }
             }
-            const useEmbeddedDropRates = true;
             let dropRate = 0;
-            if (useEmbeddedDropRates) {
-                const guaranteed = battle.rewards.guaranteed.find(x => x.id == reward);
-                const potential = battle.rewards.potential.find(x => x.id == reward);
-                if (guaranteed) dropRate = 1;
-                if (potential) {
-                    dropRate += potential.effective_rate;
-                }
-            } else {
-                const dropRateKey: keyof IDropRate = Rarity[
-                    recipe?.rarity as unknown as number
-                ].toLowerCase() as keyof IDropRate;
-                dropRate =
-                    config.dropRate && config.dropRate[dropRateKey] !== undefined ? config.dropRate[dropRateKey] : 0;
+            const guaranteed = battle.rewards.guaranteed.find(x => x.id == reward);
+            const potential = battle.rewards.potential.find(x => x.id == reward);
+            if (guaranteed) dropRate = 1;
+            if (potential) {
+                dropRate += potential.effective_rate;
             }
             dropRate = dropRate.toFixed(3) === 'NaN' ? 0 : parseFloat(dropRate.toFixed(3));
 
@@ -223,7 +215,6 @@ export class CampaignsService {
 
         if (campaignTypes.length) {
             if (!campaignTypes.includes(location.campaignType)) {
-                console.log("doesn't pass campaignTypes filter", campaignTypes, location.campaign);
                 return false;
             }
         }

--- a/src/fsd/4-entities/campaign/data/newBattleData.json
+++ b/src/fsd/4-entities/campaign/data/newBattleData.json
@@ -47995,7 +47995,7 @@
         ]
     },
     "AMSC03B": {
-        "campaign": "Adeptus Mechanicus Standard",
+        "campaign": "Adeptus Mechanicus Standard Challenge",
         "campaignType": "Normal",
         "energyCost": 6,
         "nodeNumber": 3,
@@ -48476,7 +48476,7 @@
         ]
     },
     "AMSC13B": {
-        "campaign": "Adeptus Mechanicus Standard",
+        "campaign": "Adeptus Mechanicus Standard Challenge",
         "campaignType": "Normal",
         "energyCost": 6,
         "nodeNumber": 13,
@@ -49152,7 +49152,7 @@
         ]
     },
     "AMSC25B": {
-        "campaign": "Adeptus Mechanicus Standard",
+        "campaign": "Adeptus Mechanicus Standard Challenge",
         "campaignType": "Normal",
         "energyCost": 6,
         "nodeNumber": 25,
@@ -49647,7 +49647,7 @@
         ]
     },
     "AMEC03B": {
-        "campaign": "Adeptus Mechanicus Extremis",
+        "campaign": "Adeptus Mechanicus Extremis Challenge",
         "campaignType": "Extremis",
         "energyCost": 6,
         "nodeNumber": 3,
@@ -50142,7 +50142,7 @@
         ]
     },
     "AMEC13B": {
-        "campaign": "Adeptus Mechanicus Extremis",
+        "campaign": "Adeptus Mechanicus Extremis Challenge",
         "campaignType": "Extremis",
         "energyCost": 6,
         "nodeNumber": 13,
@@ -50839,7 +50839,7 @@
         ]
     },
     "AMEC25B": {
-        "campaign": "Adeptus Mechanicus Extremis",
+        "campaign": "Adeptus Mechanicus Extremis Challenge",
         "campaignType": "Extremis",
         "energyCost": 6,
         "nodeNumber": 25,
@@ -51340,7 +51340,7 @@
         ]
     },
     "TSC03B": {
-        "campaign": "Tyranids Standard",
+        "campaign": "Tyranids Standard Challenge",
         "campaignType": "Normal",
         "energyCost": 6,
         "nodeNumber": 3,
@@ -51870,7 +51870,7 @@
         ]
     },
     "TSC13B": {
-        "campaign": "Tyranids Standard",
+        "campaign": "Tyranids Standard Challenge",
         "campaignType": "Normal",
         "energyCost": 6,
         "nodeNumber": 13,
@@ -52539,7 +52539,7 @@
         ]
     },
     "TSC25B": {
-        "campaign": "Tyranids Standard",
+        "campaign": "Tyranids Standard Challenge",
         "campaignType": "Normal",
         "energyCost": 6,
         "nodeNumber": 25,
@@ -52979,7 +52979,7 @@
         ]
     },
     "TEC03B": {
-        "campaign": "Tyranids Extremis",
+        "campaign": "Tyranids Extremis Challenge",
         "campaignType": "Extremis",
         "energyCost": 6,
         "nodeNumber": 3,
@@ -53523,7 +53523,7 @@
         ]
     },
     "TEC13B": {
-        "campaign": "Tyranids Extremis",
+        "campaign": "Tyranids Extremis Challenge",
         "campaignType": "Extremis",
         "energyCost": 6,
         "nodeNumber": 13,
@@ -54185,7 +54185,7 @@
         ]
     },
     "TEC25B": {
-        "campaign": "Tyranids Extremis",
+        "campaign": "Tyranids Extremis Challenge",
         "campaignType": "Extremis",
         "energyCost": 6,
         "nodeNumber": 25,
@@ -54660,7 +54660,7 @@
         ]
     },
     "TASC03B": {
-        "campaign": "T'au Empire Standard",
+        "campaign": "T'au Empire Standard Challenge",
         "campaignType": "Normal",
         "energyCost": 6,
         "nodeNumber": 3,
@@ -55155,7 +55155,7 @@
         ]
     },
     "TASC13B": {
-        "campaign": "T'au Empire Standard",
+        "campaign": "T'au Empire Standard Challenge",
         "campaignType": "Normal",
         "energyCost": 6,
         "nodeNumber": 13,
@@ -55852,7 +55852,7 @@
         ]
     },
     "TASC25B": {
-        "campaign": "T'au Empire Standard",
+        "campaign": "T'au Empire Standard Challenge",
         "campaignType": "Normal",
         "energyCost": 6,
         "nodeNumber": 25,
@@ -56400,7 +56400,7 @@
         ]
     },
     "TAEC03B": {
-        "campaign": "T'au Empire Extremis",
+        "campaign": "T'au Empire Extremis Challenge",
         "campaignType": "Extremis",
         "energyCost": 6,
         "nodeNumber": 3,
@@ -56902,7 +56902,7 @@
         ]
     },
     "TAEC13B": {
-        "campaign": "T'au Empire Extremis",
+        "campaign": "T'au Empire Extremis Challenge",
         "campaignType": "Extremis",
         "energyCost": 6,
         "nodeNumber": 13,
@@ -57571,7 +57571,7 @@
         ]
     },
     "TAEC25B": {
-        "campaign": "T'au Empire Extremis",
+        "campaign": "T'au Empire Extremis Challenge",
         "campaignType": "Extremis",
         "energyCost": 6,
         "nodeNumber": 25,

--- a/src/routes/tables/dailyRaids.tsx
+++ b/src/routes/tables/dailyRaids.tsx
@@ -170,7 +170,10 @@ export const DailyRaids = () => {
     }, [shardsGoals, dailyRaidsPreferences, dailyRaids.filters]);
 
     const actualEnergy = useMemo(() => {
-        return dailyRaidsPreferences.dailyEnergy - estimatedShards.energyPerDay - dailyRaidsPreferences.shardsEnergy;
+        return (
+            dailyRaidsPreferences.dailyEnergy -
+            Math.min(estimatedShards.energyPerDay, dailyRaidsPreferences.shardsEnergy)
+        );
     }, [dailyRaidsPreferences.dailyEnergy, dailyRaidsPreferences.shardsEnergy, estimatedShards.energyPerDay]);
 
     const estimatedRanks: IEstimatedUpgrades = useMemo(() => {
@@ -189,9 +192,7 @@ export const DailyRaids = () => {
 
     const hasShardsEnergy = dailyRaidsPreferences.shardsEnergy > 0 || estimatedShards.energyPerDay > 0;
     const energyDescription = hasShardsEnergy
-        ? `${actualEnergy} = ${dailyRaidsPreferences.dailyEnergy} - ${
-              estimatedShards.energyPerDay + dailyRaidsPreferences.shardsEnergy
-          }`
+        ? `${actualEnergy} = ${dailyRaidsPreferences.dailyEnergy} - ${Math.min(estimatedShards.energyPerDay, dailyRaidsPreferences.shardsEnergy)}`
         : actualEnergy.toString();
 
     return (


### PR DESCRIPTION
Correctly label CE challenge battles
Fix energy allocated to shards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Daily energy budgeting for shard farming, including partial allocations; today’s raids reflect only budgeted materials.

- Bug Fixes
  - Daily Raids energy now subtracts the smaller of estimated shards energy and your set budget.
  - Campaign labels updated: challenge nodes display as “<number>B”; campaign names now include “Challenge” where applicable.
  - Drop rates are derived directly from embedded rewards with clearer rounding, improving display accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->