### PR TITLE
Amend LEs to show points and currency for mythic and two blue stars.

### DIFF
--- a/src/fsd/1-pages/plan-lre/le-next-goal-progress.tsx
+++ b/src/fsd/1-pages/plan-lre/le-next-goal-progress.tsx
@@ -154,12 +154,15 @@ export const LeNextGoalProgress: React.FC<Props> = ({ model }) => {
         } else if (currentChests < chestsForBlueStar) {
             return 'blue star';
         } else if (currentChests < chestsForMythic) {
+            if (chestsForMythic === Infinity) {
+                return 'full clear';
+            }
             return 'mythic';
         }
         return 'two blue stars';
     })();
 
-    const currencyForUnlock = useMemo(() => {
+    const currencyForNextMilestone = useMemo(() => {
         return model.chestsMilestones
             .filter(x => x.chestLevel <= chestsForNextGoal)
             .map(x => x.engramCost)
@@ -168,7 +171,8 @@ export const LeNextGoalProgress: React.FC<Props> = ({ model }) => {
 
     const pointsForNextMilestone = useMemo(() => {
         const additionalPayout = premiumMissions > 0 ? 15 : 0;
-        let currencyLeft = currencyForUnlock - regularMissionsCurrency - premiumMissionsCurrency - bundleCurrency;
+        let currencyLeft =
+            currencyForNextMilestone - regularMissionsCurrency - premiumMissionsCurrency - bundleCurrency;
 
         for (const chestMilestone of model.pointsMilestones) {
             currencyLeft -= chestMilestone.engramPayout + additionalPayout;
@@ -178,7 +182,7 @@ export const LeNextGoalProgress: React.FC<Props> = ({ model }) => {
         }
 
         return model.pointsMilestones[model.pointsMilestones.length - 1].cumulativePoints;
-    }, [currencyForUnlock, regularMissionsCurrency, premiumMissionsCurrency, bundleCurrency]);
+    }, [currencyForNextMilestone, regularMissionsCurrency, premiumMissionsCurrency, bundleCurrency]);
 
     const averageBattles = useMemo(() => {
         return (pointsForNextMilestone / 3 / 500).toFixed(2);
@@ -200,7 +204,7 @@ export const LeNextGoalProgress: React.FC<Props> = ({ model }) => {
                 Currency to {goal}:
                 <span style={{ fontWeight: 700 }}>
                     {' '}
-                    {currentCurrency} / {currencyForUnlock}
+                    {currentCurrency} / {currencyForNextMilestone}
                 </span>
                 <Tooltip title={totalCurrency + ' in total'}>
                     <InfoIcon />

--- a/src/fsd/1-pages/plan-lre/le-next-goal-progress.tsx
+++ b/src/fsd/1-pages/plan-lre/le-next-goal-progress.tsx
@@ -111,6 +111,23 @@ export const LeNextGoalProgress: React.FC<Props> = ({ model }) => {
             model.progression.fiveStars +
             model.progression.blueStar) /
         model.shardsPerChest;
+    const chestsForMythic =
+        (model.progression.unlock +
+            model.progression.fourStars +
+            model.progression.fiveStars +
+            model.progression.blueStar +
+            // If we don't have info for mythic, we assume it's unattainable.
+            (model.progression.mythic ?? Infinity)) /
+        model.shardsPerChest;
+    const chestsForTwoBlueStars =
+        (model.progression.unlock +
+            model.progression.fourStars +
+            model.progression.fiveStars +
+            model.progression.blueStar +
+            // If we don't have info for mythic, we assume it's unattainable.
+            (model.progression.mythic ?? Infinity) +
+            (model.progression.twoBlueStars ?? Infinity)) /
+        model.shardsPerChest;
 
     const chestsForNextGoal = useMemo(() => {
         if (currentChests < chestsForUnlock) {
@@ -119,9 +136,12 @@ export const LeNextGoalProgress: React.FC<Props> = ({ model }) => {
             return Math.ceil(chestsFor4Stars);
         } else if (currentChests < chestsFor5Stars) {
             return Math.ceil(chestsFor5Stars);
+        } else if (currentChests < chestsForBlueStar) {
+            return Math.ceil(chestsForBlueStar);
+        } else if (currentChests < chestsForMythic) {
+            return Math.ceil(chestsForMythic);
         }
-
-        return Math.ceil(chestsForBlueStar);
+        return Math.ceil(chestsForTwoBlueStars);
     }, [currentChests]);
 
     const goal = (function () {
@@ -131,9 +151,12 @@ export const LeNextGoalProgress: React.FC<Props> = ({ model }) => {
             return '4 stars';
         } else if (currentChests < chestsFor5Stars) {
             return '5 stars';
+        } else if (currentChests < chestsForBlueStar) {
+            return 'blue star';
+        } else if (currentChests < chestsForMythic) {
+            return 'mythic';
         }
-
-        return 'blue star';
+        return 'two blue stars';
     })();
 
     const currencyForUnlock = useMemo(() => {


### PR DESCRIPTION
<img width="1111" height="595" alt="Screenshot 2025-09-05 at 19 55 12" src="https://github.com/user-attachments/assets/d02a1593-1f25-4742-8caa-530ec53d5472" />
<img width="823" height="178" alt="Screenshot 2025-09-05 at 19 55 46" src="https://github.com/user-attachments/assets/6146b982-b24e-4be6-aa72-d3553a32d42f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Next-goal progress now includes Blue Star, Mythic, and Two Blue Stars milestones.
  * Goal labels and "Currency to ..." displays updated to reflect the next milestone target and its cost.

* **Bug Fixes**
  * Better handling of missing milestone data so unattainable goals aren’t shown as reachable.
  * Prevents incorrect or undefined progress/currency values when milestone data is absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->