### PR TITLE
Fix Guild War team display

### DIFF
--- a/src/v2/pages/guild-war-defense/guild-war-defense.tsx
+++ b/src/v2/pages/guild-war-defense/guild-war-defense.tsx
@@ -14,6 +14,8 @@ import { Rarity, Rank } from '@/fsd/5-shared/model';
 import { AccessibleTooltip, FlexBox, Conditional } from '@/fsd/5-shared/ui';
 import { RarityIcon } from '@/fsd/5-shared/ui/icons/rarity.icon';
 
+import { CharactersService as CharacterEntityService } from '@/fsd/4-entities/character';
+
 import { CharacterItemDialog } from '@/fsd/3-features/character-details/character-item-dialog';
 import { CharactersViewContext } from 'src/v2/features/characters/characters-view.context';
 import { CharactersService } from 'src/v2/features/characters/characters.service';
@@ -86,7 +88,9 @@ export const GuildWarDefense = () => {
         return guildWar.teams
             .filter(x => x.type === GuildWarTeamType.Defense)
             .map(team => {
-                const teamWithChars = team.lineup.map(name => characters.find(char => char.name === name)!);
+                const teamWithChars = team.lineup.map(name =>
+                    characters.find(char => CharacterEntityService.matchesAnyCharacterId(name, char))
+                );
                 return { ...team, lineup: teamWithChars.filter(x => !!x) };
             });
     }, [guildWar.teams, characters]);

--- a/src/v2/pages/guild-war-defense/guild-war-defense.tsx
+++ b/src/v2/pages/guild-war-defense/guild-war-defense.tsx
@@ -2,7 +2,7 @@
 import { Card, CardActions, CardContent, CardHeader } from '@mui/material';
 import Button from '@mui/material/Button';
 import { orderBy, sum } from 'lodash';
-import React, { useContext, useEffect, useMemo } from 'react';
+import React, { useContext, useEffect, useMemo, useState } from 'react';
 import { isMobile } from 'react-device-detect';
 import { Link } from 'react-router-dom';
 
@@ -31,11 +31,11 @@ export const GuildWarDefense = () => {
     const { guildWar, characters, viewPreferences } = useContext(StoreContext);
     const dispatch = useContext(DispatchContext);
 
-    const [openSelectTeamDialog, setOpenSelectTeamDialog] = React.useState(false);
-    const [editedTeam, setEditedTeam] = React.useState<IGWTeamWithCharacters | null>(null);
+    const [openSelectTeamDialog, setOpenSelectTeamDialog] = useState(false);
+    const [editedTeam, setEditedTeam] = useState<IGWTeamWithCharacters | null>(null);
 
-    const [openCharacterItemDialog, setOpenCharacterItemDialog] = React.useState(false);
-    const [editedCharacter, setEditedCharacter] = React.useState<ICharacter2 | null>(null);
+    const [openCharacterItemDialog, setOpenCharacterItemDialog] = useState(false);
+    const [editedCharacter, setEditedCharacter] = useState<ICharacter2 | null>(null);
 
     useEffect(() => {
         const rarityCaps = GuildWarService.getDifficultyRarityCaps(guildWar.zoneDifficulty);
@@ -96,7 +96,7 @@ export const GuildWarDefense = () => {
     }, [guildWar.teams, characters]);
 
     const teamsPotential = useMemo(() => {
-        return teamsWithCharacters.map((team, teamIndex) => {
+        return teamsWithCharacters.map(team => {
             const lineup = team.lineup.map(x => ({
                 id: x.shortName,
                 potential: CharactersService.calculateCharacterPotential(

--- a/src/v2/pages/guild-war-offense/guild-war-offense.tsx
+++ b/src/v2/pages/guild-war-offense/guild-war-offense.tsx
@@ -2,7 +2,7 @@
 import { Card, CardActions, CardContent, CardHeader, Input } from '@mui/material';
 import Button from '@mui/material/Button';
 import { groupBy, mapValues, orderBy, sum } from 'lodash';
-import React, { useContext, useMemo } from 'react';
+import React, { useContext, useMemo, useState } from 'react';
 import { isMobile } from 'react-device-detect';
 import { Link } from 'react-router-dom';
 
@@ -35,11 +35,11 @@ export const GuildWarOffense = () => {
     const { guild, guildWar, characters, viewPreferences } = useContext(StoreContext);
     const dispatch = useContext(DispatchContext);
 
-    const [openSelectTeamDialog, setOpenSelectTeamDialog] = React.useState(false);
-    const [editedTeam, setEditedTeam] = React.useState<IGWTeamWithCharacters | null>(null);
+    const [openSelectTeamDialog, setOpenSelectTeamDialog] = useState(false);
+    const [editedTeam, setEditedTeam] = useState<IGWTeamWithCharacters | null>(null);
 
-    const [openCharacterItemDialog, setOpenCharacterItemDialog] = React.useState(false);
-    const [editedCharacter, setEditedCharacter] = React.useState<ICharacter2 | null>(null);
+    const [openCharacterItemDialog, setOpenCharacterItemDialog] = useState(false);
+    const [editedCharacter, setEditedCharacter] = useState<ICharacter2 | null>(null);
 
     const { data, loading } = useGetGuildRosters({ members: guild.members });
 
@@ -123,7 +123,7 @@ export const GuildWarOffense = () => {
     }, [guildWar.teams, characters, guildWar.deployedCharacters]);
 
     const teamsPotential = useMemo(() => {
-        return teamsWithCharacters.map((team, teamIndex) => {
+        return teamsWithCharacters.map(team => {
             const lineup = team.lineup.map(x => ({
                 id: x.name,
                 potential: CharactersService.calculateCharacterPotential(

--- a/src/v2/pages/guild-war-offense/guild-war-offense.tsx
+++ b/src/v2/pages/guild-war-offense/guild-war-offense.tsx
@@ -15,6 +15,8 @@ import { AccessibleTooltip, Conditional, FlexBox } from '@/fsd/5-shared/ui';
 import { MiscIcon } from '@/fsd/5-shared/ui/icons';
 import { RarityIcon } from '@/fsd/5-shared/ui/icons/rarity.icon';
 
+import { CharactersService as CharacterEntityService } from '@/fsd/4-entities/character';
+
 import { CharacterItemDialog } from '@/fsd/3-features/character-details/character-item-dialog';
 import { CharactersViewContext } from 'src/v2/features/characters/characters-view.context';
 import { CharactersService } from 'src/v2/features/characters/characters.service';
@@ -104,7 +106,9 @@ export const GuildWarOffense = () => {
         const teams = guildWar.teams
             .filter(x => x.type === GuildWarTeamType.Offense)
             .map(team => {
-                const teamWithChars = team.lineup.map(name => characters.find(char => char.name === name)!);
+                const teamWithChars = team.lineup.map(name =>
+                    characters.find(char => CharacterEntityService.matchesAnyCharacterId(name, char))
+                );
                 return { ...team, lineup: teamWithChars.filter(x => !!x) };
             });
         return orderBy(


### PR DESCRIPTION
This PR fixes the display of Guild War team lineups, for the Defence and Offense pages.

A couple of lint warnings were fixed along the way.

### Before
<img width="871" height="642" alt="before" src="https://github.com/user-attachments/assets/7b19b549-0133-40df-81d9-023b3b7910d3" />

### After
<img width="900" height="649" alt="after" src="https://github.com/user-attachments/assets/d505ff2e-4b9e-4e9b-af7d-700257f66ce6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved character matching in Guild War Defense and Offense team lineups, correctly resolving characters by ID/aliases rather than exact name matches.
  * Prevented missing or incorrect characters from appearing in team compositions.
  * Ensured team potential is calculated from accurate, filtered lineups for more reliable results.

* **Refactor**
  * Streamlined internal state handling without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->