### PR TITLE
Editing a goal doesn't show the possible raid locations

### DIFF
--- a/src/shared-components/goals/edit-goal-dialog.tsx
+++ b/src/shared-components/goals/edit-goal-dialog.tsx
@@ -152,7 +152,7 @@ export const EditGoalDialog: React.FC<Props> = ({ isOpen, onClose, goal, unit })
 
     const possibleLocations =
         [PersonalGoalType.Ascend, PersonalGoalType.Unlock].includes(form.type) && !!unit
-            ? StaticDataService.getItemLocations(`shards_${unit.id}`)
+            ? StaticDataService.getItemLocations(`shards_${unit.snowprintId}`)
             : [];
 
     const unlockedLocations = possibleLocations

--- a/src/shared-components/goals/set-goal-dialog.tsx
+++ b/src/shared-components/goals/set-goal-dialog.tsx
@@ -136,14 +136,14 @@ export const SetGoalDialog = ({ onClose }: { onClose?: (goal?: IPersonalGoal) =>
         }
     }, [form.type, ignoreRankRarity]);
 
-    const getAscenscionShardsName = (unit: IUnit | null): string => {
+    const getAscensionShardsName = (unit: IUnit | null): string => {
         if (!unit) return '';
         return 'shards_' + unit.snowprintId;
     };
 
     const possibleLocations =
         [PersonalGoalType.Ascend, PersonalGoalType.Unlock].includes(form.type) && !!unit
-            ? StaticDataService.getItemLocations(getAscenscionShardsName(unit))
+            ? StaticDataService.getItemLocations(getAscensionShardsName(unit))
             : [];
 
     const unlockedLocations = possibleLocations


### PR DESCRIPTION
Due to the wrong unit ID being passed,
when editing an unlock goal, it shows as if no raid locations were available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect shard location mapping for Ascend/Unlock goals, ensuring suggestions and unlocked locations reflect the correct unit.
  * Improved reliability when setting goals by aligning ascension shard identification with the proper unit identifier, preventing missing or wrong locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->