### PR TITLE
Fix a bug where we were mixing faction enums and snowprint IDs in the raid filter.

### DIFF
--- a/src/fsd/1-pages/learn-campaigns/campaigns.tsx
+++ b/src/fsd/1-pages/learn-campaigns/campaigns.tsx
@@ -154,7 +154,9 @@ export const Campaigns = () => {
             valueGetter: (params: ValueGetterParams<ICampaignBattleComposed>) => {
                 const battle = params.data;
                 if (battle) {
-                    return battle.enemiesFactions;
+                    return battle.enemiesFactions.map(x =>
+                        FactionsService.factionToString(FactionsService.snowprintFactionToFaction(x))
+                    );
                 }
             },
             cellRenderer: (params: ICellRendererParams<ICampaignBattleComposed>) => {
@@ -217,6 +219,11 @@ export const Campaigns = () => {
 
     return (
         <div>
+            <div>
+                <table>
+                    <thead></thead>
+                </table>
+            </div>
             <div className="flex-box gap10 wrap">
                 <FormControl style={{ width: 250, margin: 20 }}>
                     <InputLabel>Campaign</InputLabel>

--- a/src/fsd/1-pages/plan-campaign-progression/campaign-progression.service.ts
+++ b/src/fsd/1-pages/plan-campaign-progression/campaign-progression.service.ts
@@ -1,5 +1,7 @@
 import { uniq } from 'lodash';
 
+// eslint-disable-next-line import-x/no-internal-modules
+import { FactionsService } from '@/fsd/5-shared/lib/factions.service';
 import { Rank, Rarity } from '@/fsd/5-shared/model';
 
 import {
@@ -60,8 +62,9 @@ export class CampaignsProgressionService {
         Object.entries(battleData).forEach(([battleId, battle]) => {
             if (!(battleId in CampaignsService.campaignsComposed)) return;
             // Early indomitus battles are sparse.
-            CampaignsService.campaignsComposed[battleId].alliesFactions.forEach(faction => {
+            CampaignsService.campaignsComposed[battleId].alliesFactions.forEach(factionId => {
                 if (!battle.campaign) return; // Early indomitus doesn't have most of this info.
+                const faction = FactionsService.snowprintFactionToFaction(factionId);
                 result.campaignFactions.get(battle.campaign)?.add(faction);
                 if (!result.factionCampaigns.get(faction)) {
                     result.factionCampaigns.set(faction, new Set<string>());

--- a/src/fsd/4-entities/campaign/campaigns.service.ts
+++ b/src/fsd/4-entities/campaign/campaigns.service.ts
@@ -130,7 +130,7 @@ export class CampaignsService {
                 rewards: battle.rewards,
                 slots: battle.slots,
                 enemiesAlliances: (battle.enemiesAlliances ?? [enemies.alliance]) as Alliance[],
-                enemiesFactions: (battle.enemiesFactions ?? enemies.factions) as Faction[],
+                enemiesFactions: battle.enemiesFactions ?? enemies.factions,
                 alliesAlliance: allies.alliance,
                 alliesFactions: allies.factions,
                 enemiesTotal: battle.enemiesTotal ?? 0,
@@ -268,26 +268,11 @@ export class CampaignsService {
      * allies are usable in the campaign when enough deployment slots are available.
      */
     public static getEnemiesAndAllies(campaign: Campaign): {
-        enemies: { alliance: Alliance; factions: Faction[] };
-        allies: { alliance: Alliance; factions: Faction[] };
+        enemies: { alliance: Alliance; factions: string[] };
+        allies: { alliance: Alliance; factions: string[] };
     } {
-        const ImperialFactions: Faction[] = [
-            Faction.Ultramarines,
-            Faction.Astra_militarum,
-            Faction.Black_Templars,
-            Faction.ADEPTA_SORORITAS,
-            Faction.AdeptusMechanicus,
-            Faction.Space_Wolves,
-            Faction.Dark_Angels,
-            Faction.BloodAngels,
-        ];
-
-        const ChaosFactions: Faction[] = [
-            Faction.Black_Legion,
-            Faction.Death_Guard,
-            Faction.Thousand_Sons,
-            Faction.WorldEaters,
-        ];
+        const ImperialFactions: string[] = FactionsService.getFactions(Alliance.Imperial);
+        const ChaosFactions: string[] = FactionsService.getFactions(Alliance.Chaos);
 
         switch (campaign) {
             case Campaign.I:
@@ -295,7 +280,7 @@ export class CampaignsService {
                 return {
                     enemies: {
                         alliance: Alliance.Xenos,
-                        factions: [Faction.Necrons],
+                        factions: [FactionsService.getFactionSnowprintId(Faction.Necrons)],
                     },
                     allies: {
                         alliance: Alliance.Imperial,
@@ -308,11 +293,14 @@ export class CampaignsService {
                 return {
                     enemies: {
                         alliance: Alliance.Imperial,
-                        factions: [Faction.Astra_militarum, Faction.Ultramarines],
+                        factions: [
+                            FactionsService.getFactionSnowprintId(Faction.Astra_militarum),
+                            FactionsService.getFactionSnowprintId(Faction.Ultramarines),
+                        ],
                     },
                     allies: {
                         alliance: Alliance.Xenos,
-                        factions: [Faction.Necrons],
+                        factions: [FactionsService.getFactionSnowprintId(Faction.Necrons)],
                     },
                 };
             }
@@ -321,7 +309,7 @@ export class CampaignsService {
                 return {
                     enemies: {
                         alliance: Alliance.Imperial,
-                        factions: [Faction.Astra_militarum],
+                        factions: [FactionsService.getFactionSnowprintId(Faction.Astra_militarum)],
                     },
                     allies: {
                         alliance: Alliance.Chaos,
@@ -334,7 +322,7 @@ export class CampaignsService {
                 return {
                     enemies: {
                         alliance: Alliance.Chaos,
-                        factions: [Faction.Black_Legion],
+                        factions: [FactionsService.getFactionSnowprintId(Faction.Black_Legion)],
                     },
                     allies: {
                         alliance: Alliance.Imperial,
@@ -347,11 +335,11 @@ export class CampaignsService {
                 return {
                     enemies: {
                         alliance: Alliance.Imperial,
-                        factions: [Faction.Black_Templars],
+                        factions: [FactionsService.getFactionSnowprintId(Faction.Black_Templars)],
                     },
                     allies: {
                         alliance: Alliance.Xenos,
-                        factions: [Faction.Orks],
+                        factions: [FactionsService.getFactionSnowprintId(Faction.Orks)],
                     },
                 };
             }
@@ -360,7 +348,7 @@ export class CampaignsService {
                 return {
                     enemies: {
                         alliance: Alliance.Xenos,
-                        factions: [Faction.Orks],
+                        factions: [FactionsService.getFactionSnowprintId(Faction.Orks)],
                     },
                     allies: {
                         alliance: Alliance.Imperial,
@@ -373,11 +361,11 @@ export class CampaignsService {
                 return {
                     enemies: {
                         alliance: Alliance.Chaos,
-                        factions: [Faction.Thousand_Sons],
+                        factions: [FactionsService.getFactionSnowprintId(Faction.Thousand_Sons)],
                     },
                     allies: {
                         alliance: Alliance.Xenos,
-                        factions: [Faction.Aeldari],
+                        factions: [FactionsService.getFactionSnowprintId(Faction.Aeldari)],
                     },
                 };
             }
@@ -386,7 +374,7 @@ export class CampaignsService {
                 return {
                     enemies: {
                         alliance: Alliance.Xenos,
-                        factions: [Faction.Aeldari],
+                        factions: [FactionsService.getFactionSnowprintId(Faction.Aeldari)],
                     },
                     allies: {
                         alliance: Alliance.Chaos,

--- a/src/fsd/4-entities/campaign/campaigns.service.ts
+++ b/src/fsd/4-entities/campaign/campaigns.service.ts
@@ -1,6 +1,7 @@
 import { groupBy, orderBy, sortBy, uniq } from 'lodash';
 import { X } from 'lucide-react';
 
+import { FactionsService } from '@/fsd/5-shared/lib';
 import { Alliance, Faction, Rarity } from '@/fsd/5-shared/model';
 
 import { recipeDataByName } from '@/fsd/4-entities/upgrade/@x/campaign';
@@ -178,16 +179,19 @@ export class CampaignsService {
         materialRarity?: Rarity
     ): boolean {
         const {
-            alliesFactions,
+            alliesFactions: alliesFactionsRaw,
             alliesAlliance,
             enemiesAlliance,
-            enemiesFactions,
+            enemiesFactions: enemiesFactionsRaw,
             campaignTypes,
             upgradesRarity,
             slotsCount,
             enemiesTypes,
             enemiesCount,
         } = filters;
+
+        const enemiesFactions = enemiesFactionsRaw.map(faction => FactionsService.getFactionSnowprintId(faction));
+        const alliesFactions = alliesFactionsRaw.map(faction => FactionsService.getFactionSnowprintId(faction));
 
         if (enemiesCount?.length) {
             if (!enemiesCount.includes(location.enemiesTotal)) {

--- a/src/fsd/4-entities/campaign/model.ts
+++ b/src/fsd/4-entities/campaign/model.ts
@@ -17,9 +17,9 @@ export interface ICampaignBattleComposed {
     rarityEnum: Rarity;
     rewards: IRewards;
     slots?: number;
-    enemiesFactions: Faction[];
+    enemiesFactions: string[];
     enemiesAlliances: Alliance[];
-    alliesFactions: Faction[];
+    alliesFactions: string[];
     alliesAlliance: Alliance;
     enemiesTotal: number;
     enemiesTypes: string[];

--- a/src/fsd/5-shared/lib/factions.service.ts
+++ b/src/fsd/5-shared/lib/factions.service.ts
@@ -102,4 +102,55 @@ export class FactionsService {
                 throw new Error(`Unknown faction: ${snowprintFaction}`);
         }
     };
+
+    /**
+     * @param faction The Faction enum value.
+     * @returns the snowprint ID of the faction.
+     */
+    public static getFactionSnowprintId = (faction: Faction): string => {
+        switch (faction) {
+            case Faction.Ultramarines:
+                return 'Ultramarines';
+            case Faction.Black_Legion:
+                return 'BlackLegion';
+            case Faction.Orks:
+                return 'Orks';
+            case Faction.ADEPTA_SORORITAS:
+                return 'Sisterhood';
+            case Faction.Necrons:
+                return 'Necrons';
+            case Faction.Astra_militarum:
+                return 'AstraMilitarum';
+            case Faction.Death_Guard:
+                return 'DeathGuard';
+            case Faction.Black_Templars:
+                return 'BlackTemplars';
+            case Faction.Aeldari:
+                return 'Aeldari';
+            case Faction.Space_Wolves:
+                return 'SpaceWolves';
+            case Faction.T_Au:
+                return 'Tau';
+            case Faction.Dark_Angels:
+                return 'DarkAngels';
+            case Faction.Thousand_Sons:
+                return 'ThousandSons';
+            case Faction.Tyranids:
+                return 'Tyranids';
+            case Faction.AdeptusMechanicus:
+                return 'AdeptusMechanicus';
+            case Faction.WorldEaters:
+                return 'WorldEaters';
+            case Faction.BloodAngels:
+                return 'BloodAngels';
+            case Faction.GenestealerCults:
+                return 'Genestealers';
+            case Faction.AdeptusCustodes:
+                return 'Custodes';
+            case Faction.EmperorsChildren:
+                return 'EmperorsChildren';
+            default:
+                throw new Error(`Unknown Faction enum: ${faction}`);
+        }
+    };
 }

--- a/src/fsd/5-shared/lib/factions.service.ts
+++ b/src/fsd/5-shared/lib/factions.service.ts
@@ -1,6 +1,13 @@
-import { Faction } from '../model';
+// eslint-disable-next-line import-x/no-internal-modules
+import factionsData from 'src/v2/data/factions.json';
+
+import { Alliance, Faction } from '../model';
 
 export class FactionsService {
+    /** @returns the snowprint IDs of the factions belonging to the alliance. */
+    public static getFactions(alliance: Alliance): string[] {
+        return factionsData.filter(x => x.alliance === alliance).map(x => x.snowprintId);
+    }
     /**
      * @param faction The faction to convert.
      * @returns the string representation of the faction.
@@ -10,43 +17,43 @@ export class FactionsService {
             case Faction.Ultramarines:
                 return 'Ultramarines';
             case Faction.Black_Legion:
-                return 'BlackLegion';
+                return 'Black Legion';
             case Faction.Orks:
                 return 'Orks';
             case Faction.ADEPTA_SORORITAS:
-                return 'Sisterhood';
+                return 'Adepta Sororitas';
             case Faction.Necrons:
                 return 'Necrons';
             case Faction.Astra_militarum:
-                return 'AstraMilitarum';
+                return 'Astra Militarum';
             case Faction.Death_Guard:
-                return 'DeathGuard';
+                return 'Death Guard';
             case Faction.Black_Templars:
-                return 'BlackTemplars';
+                return 'Black Templars';
             case Faction.Aeldari:
                 return 'Aeldari';
             case Faction.Space_Wolves:
-                return 'SpaceWolves';
+                return 'Space Wolves';
             case Faction.T_Au:
-                return 'Tau';
+                return "T'au";
             case Faction.Dark_Angels:
-                return 'DarkAngels';
+                return 'Dark Angels';
             case Faction.Thousand_Sons:
-                return 'ThousandSons';
+                return 'Thousand Sons';
             case Faction.Tyranids:
                 return 'Tyranids';
             case Faction.AdeptusMechanicus:
-                return 'AdeptusMechanicus';
+                return 'Adeptus Mechanicus';
             case Faction.WorldEaters:
-                return 'WorldEaters';
+                return 'World Eaters';
             case Faction.BloodAngels:
-                return 'BloodAngels';
+                return 'Blood Angels';
             case Faction.GenestealerCults:
-                return 'Genestealers';
+                return 'Genestealer Cults';
             case Faction.AdeptusCustodes:
                 return 'Custodes';
             case Faction.EmperorsChildren:
-                return 'EmperorsChildren';
+                return 'Emperors Children';
             default:
                 return '';
         }

--- a/src/v2/data/factions.json
+++ b/src/v2/data/factions.json
@@ -36,7 +36,7 @@
     },
     {
         "alliance": "Chaos",
-        "name": "Death guard",
+        "name": "Death Guard",
         "snowprintId": "DeathGuard",
         "icon": "Death_Guard.png",
         "color": "#65540C"

--- a/src/v2/features/goals/locations-filter.tsx
+++ b/src/v2/features/goals/locations-filter.tsx
@@ -22,7 +22,7 @@ export const LocationsFilter: React.FC<Props> = ({ filter, filtersChange }) => {
 
     const allFactions = useMemo(
         () => factionsData.map(x => ({ alliance: x.alliance as Alliance, faction: x.name as Faction })),
-        []
+        [factionsData]
     );
 
     const enemiesTypeOptions = useMemo(() => CampaignsService.getPossibleEnemiesTypes(), []);


### PR DESCRIPTION
Long term, we should work to remove the faction enum.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Location filtering by allies/enemies now returns accurate results across all factions.
  * Goals > Locations now updates faction lists when faction data changes—no refresh needed.

* **Refactor**
  * Faction handling standardized across the app for more consistent comparisons and reliability with new/unknown factions.

* **UI**
  * Campaigns listing now shows human-friendly faction names in the Enemies column.

* **Data**
  * Faction name formatting corrected (e.g., "Death Guard").
<!-- end of auto-generated comment: release notes by coderabbit.ai -->