### PR TITLE
Make sure to return the active LRE when multiple are scheduled

### DIFF
--- a/src/fsd/1-pages/home/desktop-home.tsx
+++ b/src/fsd/1-pages/home/desktop-home.tsx
@@ -17,41 +17,20 @@ import { getImageUrl } from '@/fsd/5-shared/ui';
 import { MiscIcon, UnitShardIcon } from '@/fsd/5-shared/ui/icons';
 
 import { CharactersService } from '@/fsd/4-entities/character';
-import { LegendaryEventEnum, LegendaryEventService } from '@/fsd/4-entities/lre';
+import { ILegendaryEventStatic, LegendaryEventEnum, LegendaryEventService } from '@/fsd/4-entities/lre';
 
 import { Thanks } from '@/fsd/3-features/thank-you';
 
 import { useBmcWidget } from './useBmcWidget';
 
-export const DesktopHome = () => {
-    useBmcWidget();
+function formatMonthAndDay(date: Date): string {
+    const options: Intl.DateTimeFormatOptions = { month: 'long', day: 'numeric' };
+    return date.toLocaleDateString('en-US', options);
+}
+
+function LreSection({ nextEvent }: { nextEvent: ILegendaryEventStatic }) {
     const navigate = useNavigate();
-    const { userInfo } = useAuth();
-    const { goals, dailyRaids } = useContext(StoreContext);
-    const nextLeMenuItem = LegendaryEventService.getActiveEvent();
-    const nextLeUnit = CharactersService.charactersData.find(x => x.snowprintId === nextLeMenuItem.unitSnowprintId);
-    const goalsMenuItem = menuItemById['goals'];
-    const dailyRaidsMenuItem = menuItemById['dailyRaids'];
-
-    const calendarUrls: { current?: string; next?: string } = {
-        current: getImageUrl('calendar/calendar_20250817.png'),
-        next: getImageUrl('calendar/calendar_20250921.png'),
-    };
-
-    const topPriorityGoal = goals[0];
-    const unlockGoals = goals.filter(x => x.type === PersonalGoalType.Unlock).length;
-    const ascendGoals = goals.filter(x => x.type === PersonalGoalType.Ascend).length;
-    const upgradeRankGoals = goals.filter(x => x.type === PersonalGoalType.UpgradeRank).length;
-
-    const navigateToNextLre = () => {
-        const route = `/plan/lre?character=${LegendaryEventEnum[LegendaryEventService.getActiveEvent().id]}`;
-        navigate(isMobile ? '/mobile' + route : route);
-    };
-
-    function formatMonthAndDay(date: Date): string {
-        const options: Intl.DateTimeFormatOptions = { month: 'long', day: 'numeric' };
-        return date.toLocaleDateString('en-US', options);
-    }
+    const nextLeUnit = CharactersService.charactersData.find(x => x.snowprintId === nextEvent.unitSnowprintId);
 
     function timeLeftToFutureDate(targetDate: Date): string {
         const currentDate = new Date();
@@ -67,11 +46,65 @@ export const DesktopHome = () => {
         return timeDifference >= 0 ? result : 'Finished';
     }
 
-    const nextLeDateStart = new Date(nextLeMenuItem.nextEventDateUtc!);
-    const nextLeDateEnd = new Date(new Date(nextLeMenuItem.nextEventDateUtc!).setDate(nextLeDateStart.getDate() + 7));
+    const navigateToNextLre = () => {
+        const route = `/plan/lre?character=${LegendaryEventEnum[nextEvent.id]}`;
+        navigate(isMobile ? '/mobile' + route : route);
+    };
+
+    const nextLeDateStart = new Date(nextEvent.nextEventDateUtc!);
+    const nextLeDateEnd = new Date(new Date(nextEvent.nextEventDateUtc!).setDate(nextLeDateStart.getDate() + 7));
     const timeToStart = timeLeftToFutureDate(nextLeDateStart);
     const timeToEnd = timeLeftToFutureDate(nextLeDateEnd);
     const isEventStarted = timeToStart === 'Finished';
+
+    return (
+        <div>
+            <h3 style={{ textAlign: 'center' }}>{isEventStarted ? 'Ongoing ' : 'Upcoming '}Legendary Event</h3>
+            <Card
+                variant="outlined"
+                classes="dark:bg-dark-navy"
+                onClick={navigateToNextLre}
+                sx={{
+                    width: 350,
+                    minHeight: 200,
+                    cursor: 'pointer',
+                }}>
+                <CardHeader
+                    title={
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                            <UnitShardIcon icon={nextLeUnit?.roundIcon ?? ''} height={50} width={50} />
+                            {nextLeUnit?.shortName}
+                        </div>
+                    }
+                    subheader={formatMonthAndDay(isEventStarted ? nextLeDateEnd : nextLeDateStart)}
+                />
+                <CardContent style={{ display: 'flex', flexDirection: 'column' }}>
+                    {isEventStarted ? timeToEnd : timeToStart}
+                </CardContent>
+            </Card>
+        </div>
+    );
+}
+
+export const DesktopHome = () => {
+    useBmcWidget();
+    const navigate = useNavigate();
+    const { userInfo } = useAuth();
+    const { goals, dailyRaids } = useContext(StoreContext);
+    const nextLeMenuItem = LegendaryEventService.getActiveEvent();
+
+    const goalsMenuItem = menuItemById['goals'];
+    const dailyRaidsMenuItem = menuItemById['dailyRaids'];
+
+    const calendarUrls: { current?: string; next?: string } = {
+        current: getImageUrl('calendar/calendar_20250817.png'),
+        next: getImageUrl('calendar/calendar_20250921.png'),
+    };
+
+    const topPriorityGoal = goals[0];
+    const unlockGoals = goals.filter(x => x.type === PersonalGoalType.Unlock).length;
+    const ascendGoals = goals.filter(x => x.type === PersonalGoalType.Ascend).length;
+    const upgradeRankGoals = goals.filter(x => x.type === PersonalGoalType.UpgradeRank).length;
 
     const announcements = () => {
         if (userInfo.tacticusApiKey) {
@@ -148,31 +181,7 @@ export const DesktopHome = () => {
                     </Card>
                 </div>
 
-                <div>
-                    <h3 style={{ textAlign: 'center' }}>{isEventStarted ? 'Ongoing ' : 'Upcoming '}Legendary Event</h3>
-                    <Card
-                        variant="outlined"
-                        classes="dark:bg-dark-navy"
-                        onClick={navigateToNextLre}
-                        sx={{
-                            width: 350,
-                            minHeight: 200,
-                            cursor: 'pointer',
-                        }}>
-                        <CardHeader
-                            title={
-                                <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-                                    <UnitShardIcon icon={nextLeUnit?.roundIcon ?? ''} height={50} width={50} />
-                                    {nextLeUnit?.shortName}
-                                </div>
-                            }
-                            subheader={formatMonthAndDay(isEventStarted ? nextLeDateEnd : nextLeDateStart)}
-                        />
-                        <CardContent style={{ display: 'flex', flexDirection: 'column' }}>
-                            {isEventStarted ? timeToEnd : timeToStart}
-                        </CardContent>
-                    </Card>
-                </div>
+                {nextLeMenuItem && <LreSection nextEvent={nextLeMenuItem} />}
 
                 {!!goals.length && (
                     <div>

--- a/src/fsd/4-entities/character/characters.service.ts
+++ b/src/fsd/4-entities/character/characters.service.ts
@@ -40,7 +40,6 @@ export class CharactersService {
             const event = LegendaryEventService.getEventByCharacterSnowprintId(unit.snowprintId!);
             return event?.id === id;
         });
-        return undefined;
     }
 
     /**

--- a/src/fsd/4-entities/lre/legendary-event-service.spec.ts
+++ b/src/fsd/4-entities/lre/legendary-event-service.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { allLegendaryEvents, aunshi, LegendaryEventService } from '@/fsd/4-entities/lre';
+
+describe('LegendaryEventService', () => {
+    describe('getActiveEvent', () => {
+        it('Should return the current active event', () => {
+            const today = new Date();
+            const events = [
+                {
+                    ...aunshi,
+                    id: 1,
+                    unitSnowprintId: 'alice',
+                    name: 'Alice',
+                    eventStage: 3,
+                    finished: true,
+                },
+                {
+                    ...aunshi,
+                    id: 2,
+                    unitSnowprintId: 'Bob',
+                    name: 'Bob',
+                    eventStage: 2,
+                    nextEventDateUtc: new Date(today.getTime() + 30 * 24 * 60 * 60 * 1000).toDateString(),
+                    finished: false,
+                },
+                {
+                    ...aunshi,
+                    id: 3,
+                    unitSnowprintId: 'charlie',
+                    name: 'Charlie',
+                    eventStage: 1,
+                    nextEventDateUtc: new Date(today.getTime() - 40 * 24 * 60 * 60 * 1000).toDateString(),
+                    finished: false,
+                },
+                {
+                    ...aunshi,
+                    id: 4,
+                    unitSnowprintId: 'dave',
+                    name: 'Dave',
+                    eventStage: 1,
+                    nextEventDateUtc: new Date(today.getTime() - 5 * 24 * 60 * 60 * 1000).toDateString(),
+                    finished: false,
+                },
+            ];
+            const activeEvent = LegendaryEventService.getActiveEvent(events);
+            expect(activeEvent).toBeDefined();
+            expect(activeEvent?.name).toEqual('Dave');
+        });
+    });
+});

--- a/src/fsd/4-entities/lre/legendary-event-service.ts
+++ b/src/fsd/4-entities/lre/legendary-event-service.ts
@@ -1,21 +1,27 @@
 import { allLegendaryEvents } from './data';
 import { ILegendaryEventStatic } from './static-data.model';
 
+type UnfinishedScheduledEvent = Required<Pick<ILegendaryEventStatic, 'nextEventDateUtc'>> & ILegendaryEventStatic;
+
+function unfishedScheduledEvent(e: ILegendaryEventStatic): e is UnfinishedScheduledEvent {
+    return !e.finished && e.nextEventDateUtc !== undefined;
+}
+
 export class LegendaryEventService {
-    public static getActiveEvent(): ILegendaryEventStatic {
-        let ret: ILegendaryEventStatic | undefined = undefined;
-        for (const event of allLegendaryEvents.filter(e => !e.finished)) {
-            if (event.finished) continue;
-            if (event.nextEventDateUtc) {
-                const nextEventDate = new Date(event.nextEventDateUtc);
-                if (nextEventDate > new Date()) {
-                    if (!ret || nextEventDate < new Date(ret.nextEventDateUtc!)) {
-                        ret = event;
-                    }
-                }
-            }
+    public static getActiveEvent(events?: ILegendaryEventStatic[]): ILegendaryEventStatic | undefined {
+        const now = new Date();
+        const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+        const sortedEvents = (events ?? allLegendaryEvents)
+            .filter(unfishedScheduledEvent)
+            // Consider events which have started in the last 7 days or will start in the future
+            .filter(e => new Date(e.nextEventDateUtc) > sevenDaysAgo)
+            .sort((a, b) => {
+                return new Date(a.nextEventDateUtc).getTime() - new Date(b.nextEventDateUtc).getTime();
+            });
+        if (sortedEvents.length > 0) {
+            return sortedEvents[0];
         }
-        return ret!;
+        return undefined;
     }
 
     public static getUnfinishedEvents(): ILegendaryEventStatic[] {
@@ -35,6 +41,6 @@ export class LegendaryEventService {
     }
 
     public static getActiveLreUnitId(): string | undefined {
-        return this.getActiveEvent().unitSnowprintId;
+        return this.getActiveEvent()?.unitSnowprintId;
     }
 }


### PR DESCRIPTION
The previous logic was not easy to read.
The return value depended on the order of introduction of the characters into the game. This now sorts by date, and return the first one which started less than 7 days ago, or will start in the future.

The Patermine event is shown instead of the currently running Dante event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Legendary Event card moved into a dedicated LreSection and rendered via prop-driven data for clearer UI and routing.

* **Bug Fixes**
  * More reliable selection of the current legendary event, prioritizing the earliest upcoming within a recent 7‑day window.
  * Safer behavior when no active event exists, preventing potential errors.

* **Refactor**
  * Simplified event selection logic for clarity and maintainability.

* **Tests**
  * Added unit tests covering mixed past/future/finished events to validate active event selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->