### PR TITLE
Two changes to the campaign-progression page:

### DIFF
--- a/src/fsd/1-pages/plan-campaign-progression/campaign-progression-material-goals.tsx
+++ b/src/fsd/1-pages/plan-campaign-progression/campaign-progression-material-goals.tsx
@@ -36,26 +36,6 @@ export const CampaignProgressionMaterialGoals: React.FC<Props> = ({ campaignData
         return progression.materialFarmData.get(material)?.count ?? 0;
     }
 
-    function campaignTypeToNumber(type: CampaignType): number {
-        switch (type) {
-            case CampaignType.Elite:
-                return 0;
-            case CampaignType.Early:
-                return 1;
-            case CampaignType.Mirror:
-                return 2;
-            case CampaignType.Normal:
-                return 3;
-            default:
-                return 4;
-        }
-    }
-
-    /** @returns true iff typeA is more cost-efficient at farming than typeB.  */
-    function isCampaignTypeMoreEfficient(typeA: CampaignType, typeB: CampaignType): boolean {
-        return campaignTypeToNumber(typeA) < campaignTypeToNumber(typeB);
-    }
-
     /**
      * @param material The material to farm.
      * @returns The battle representing the best node to farm (picked
@@ -63,13 +43,14 @@ export const CampaignProgressionMaterialGoals: React.FC<Props> = ({ campaignData
      *          material.
      */
     function getCheapestNode(material: string): ICampaignBattleComposed | undefined {
-        let result: ICampaignBattleComposed | undefined = undefined;
-        for (const loc of progression.materialFarmData.get(material)?.farmableLocations ?? []) {
-            if (!result || isCampaignTypeMoreEfficient(loc.campaignType, result.campaignType)) {
-                result = loc;
-            }
+        const count = getRequiredMaterialCount(material);
+        const farmable = progression.materialFarmData.get(material)?.farmableLocations ?? [];
+        let best: { node: ICampaignBattleComposed; cost: number } | undefined;
+        for (const loc of farmable) {
+            const cost = CampaignsProgressionService.getCostToFarmMaterial(loc, count);
+            if (!best || cost < best.cost) best = { node: loc, cost };
         }
-        return result;
+        return best?.node;
     }
 
     /**

--- a/src/fsd/1-pages/plan-campaign-progression/campaign-progression-material-goals.tsx
+++ b/src/fsd/1-pages/plan-campaign-progression/campaign-progression-material-goals.tsx
@@ -86,11 +86,7 @@ export const CampaignProgressionMaterialGoals: React.FC<Props> = ({ campaignData
             '. You need ' +
             getRequiredMaterialCount(material) +
             ' to complete your goals, which costs ' +
-            CampaignsProgressionService.getCostToFarmMaterial(
-                node.campaignType,
-                getRequiredMaterialCount(material),
-                node.rarityEnum
-            ) +
+            CampaignsProgressionService.getCostToFarmMaterial(node, getRequiredMaterialCount(material)) +
             ' energy, before beating this node.'
         );
     }

--- a/src/fsd/1-pages/plan-campaign-progression/campaign-progression.tsx
+++ b/src/fsd/1-pages/plan-campaign-progression/campaign-progression.tsx
@@ -8,9 +8,11 @@ import { isMobile } from 'react-device-detect';
 // eslint-disable-next-line import-x/no-internal-modules
 import { ICharacter2 } from '@/models/interfaces';
 // eslint-disable-next-line import-x/no-internal-modules
-import { StoreContext } from 'src/reducers/store.provider';
+import { DispatchContext, StoreContext } from 'src/reducers/store.provider';
 
-import { CampaignImage } from '@/fsd/4-entities/campaign';
+import { useAuth } from '@/fsd/5-shared/model';
+
+import { CampaignImage, ICampaingsFilters } from '@/fsd/4-entities/campaign';
 // eslint-disable-next-line boundaries/element-types
 import { CharactersService } from '@/fsd/4-entities/character/@x/npc';
 import {
@@ -20,7 +22,12 @@ import {
     ICharacterAscendGoal,
 } from '@/fsd/4-entities/goal';
 import { IMow2, MowsService } from '@/fsd/4-entities/mow';
+import { IUnit } from '@/fsd/4-entities/unit';
 
+// eslint-disable-next-line import-x/no-internal-modules
+import { ActiveGoalsDialog } from '@/v2/features/goals/active-goals-dialog';
+// eslint-disable-next-line import-x/no-internal-modules
+import { CharacterRaidGoalSelect, IItemRaidLocation } from '@/v2/features/goals/goals.models';
 // eslint-disable-next-line import-x/no-internal-modules
 import { GoalsService } from 'src/v2/features/goals/goals.service';
 
@@ -33,23 +40,43 @@ import { CampaignData } from './campaign-progression.models';
 import { CampaignsProgressionService } from './campaign-progression.service';
 
 export const CampaignProgression = () => {
-    const { goals, characters, mows, campaignsProgress } = useContext(StoreContext);
+    const dispatch = useContext(DispatchContext);
+    const { characters: storeCharacters, mows: storeMows, goals, campaignsProgress } = useContext(StoreContext);
 
-    const resolvedMows = useMemo(() => MowsService.resolveAllFromStorage(mows), [mows]);
+    const resolvedMows = useMemo(() => MowsService.resolveAllFromStorage(storeMows), [storeMows]);
 
-    const resolvedCharacters = useMemo(() => CharactersService.resolveStoredCharacters(characters), [characters]);
+    const resolvedCharacters = useMemo(
+        () => CharactersService.resolveStoredCharacters(storeCharacters),
+        [storeCharacters]
+    );
+
+    const [units] = React.useState<IUnit[]>([...resolvedCharacters, ...resolvedMows]);
 
     const { allGoals, shardsGoals, upgradeRankOrMowGoals } = useMemo(() => {
-        return GoalsService.prepareGoals(goals, [...resolvedCharacters, ...resolvedMows], false);
+        const { allGoals, shardsGoals, upgradeRankOrMowGoals } = GoalsService.prepareGoals(
+            goals,
+            [...resolvedCharacters, ...resolvedMows],
+            false
+        );
+        const filteredShardsGoals = shardsGoals.filter(goal => goal.include);
+        const filteredUpgradeRankOrMowGoals = upgradeRankOrMowGoals.filter(goal => goal.include);
+        return { allGoals, shardsGoals: filteredShardsGoals, upgradeRankOrMowGoals: filteredUpgradeRankOrMowGoals };
     }, [goals, resolvedCharacters, resolvedMows]);
+
+    const handleGoalsSelectionChange = (selection: CharacterRaidGoalSelect[]) => {
+        dispatch.goals({
+            type: 'UpdateDailyRaids',
+            value: selection.map(x => ({ goalId: x.goalId, include: x.include })),
+        });
+    };
 
     const progression = useMemo(() => {
         const allGoals: Array<
             ICharacterUpgradeMow | ICharacterUpgradeRankGoal | ICharacterUnlockGoal | ICharacterAscendGoal
-        > = shardsGoals;
-        for (const goal of upgradeRankOrMowGoals) {
-            allGoals.push(goal);
-        }
+        > = shardsGoals.filter(goal => goal.include);
+        upgradeRankOrMowGoals.forEach(goal => {
+            if (goal.include) allGoals.push(goal);
+        });
         return CampaignsProgressionService.computeCampaignsProgress(allGoals, campaignsProgress);
     }, [allGoals, campaignsProgress]);
 
@@ -159,6 +186,7 @@ export const CampaignProgression = () => {
     return (
         <div key="root">
             <CampaignProgressionHeader />
+            <ActiveGoalsDialog units={units} goals={allGoals} onGoalsSelectChange={handleGoalsSelectionChange} />
             <CampaignProgressionUnfarmableMaterials progression={progression} campaignDataArray={campaignDataArray} />
             <h1>Campaign Progression</h1>
             {campaignDataArray.map((entry, ignored) => {

--- a/src/fsd/1-pages/plan-campaign-progression/campaign-progression.tsx
+++ b/src/fsd/1-pages/plan-campaign-progression/campaign-progression.tsx
@@ -6,13 +6,9 @@ import React, { useContext, useMemo } from 'react';
 import { isMobile } from 'react-device-detect';
 
 // eslint-disable-next-line import-x/no-internal-modules
-import { ICharacter2 } from '@/models/interfaces';
-// eslint-disable-next-line import-x/no-internal-modules
 import { DispatchContext, StoreContext } from 'src/reducers/store.provider';
 
-import { useAuth } from '@/fsd/5-shared/model';
-
-import { CampaignImage, ICampaingsFilters } from '@/fsd/4-entities/campaign';
+import { CampaignImage } from '@/fsd/4-entities/campaign';
 // eslint-disable-next-line boundaries/element-types
 import { CharactersService } from '@/fsd/4-entities/character/@x/npc';
 import {
@@ -21,13 +17,13 @@ import {
     ICharacterUnlockGoal,
     ICharacterAscendGoal,
 } from '@/fsd/4-entities/goal';
-import { IMow2, MowsService } from '@/fsd/4-entities/mow';
+import { MowsService } from '@/fsd/4-entities/mow';
 import { IUnit } from '@/fsd/4-entities/unit';
 
 // eslint-disable-next-line import-x/no-internal-modules
 import { ActiveGoalsDialog } from '@/v2/features/goals/active-goals-dialog';
 // eslint-disable-next-line import-x/no-internal-modules
-import { CharacterRaidGoalSelect, IItemRaidLocation } from '@/v2/features/goals/goals.models';
+import { CharacterRaidGoalSelect } from '@/v2/features/goals/goals.models';
 // eslint-disable-next-line import-x/no-internal-modules
 import { GoalsService } from 'src/v2/features/goals/goals.service';
 
@@ -78,7 +74,7 @@ export const CampaignProgression = () => {
             if (goal.include) allGoals.push(goal);
         });
         return CampaignsProgressionService.computeCampaignsProgress(allGoals, campaignsProgress);
-    }, [allGoals, campaignsProgress]);
+    }, [shardsGoals, upgradeRankOrMowGoals, allGoals, campaignsProgress]);
 
     const campaignDataArray = useMemo(() => {
         const result: CampaignData[] = [];


### PR DESCRIPTION
1) Take into account filtered goals from raids. Show the raids filter as well.
2) Use effective drop rates in saving calculations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Active Goals dialog to review and select daily raid goals.

- Improvements
  - Goal selections now update daily raid recommendations in real time.
  - Progression only includes goals you’ve marked as included.
  - Farming recommendations now pick the lowest-energy battle across all locations.
  - Material farming tooltips and energy estimates updated to reflect the new per-battle cost model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->