### PR TITLE
Changes to raids and goals

### DIFF
--- a/src/fsd/1-pages/learn-characters/rankLookup.tsx
+++ b/src/fsd/1-pages/learn-characters/rankLookup.tsx
@@ -119,11 +119,7 @@ export const RankLookup = () => {
     }, [upgrades, rankStart]);
 
     const totalMaterials = useMemo<IMaterialEstimated2[]>(() => {
-        return orderBy(
-            RankLookupService.getAllMaterials(campaignsProgress, inventory.upgrades, upgrades),
-            ['rarity', 'count', 'expectedEnergy'],
-            ['desc', 'desc', 'desc']
-        );
+        return orderBy(RankLookupService.getAllMaterials(campaignsProgress, {}, upgrades), ['rarity'], ['desc']);
     }, [upgrades]);
 
     const totalEnergy = useMemo<number>(() => {
@@ -176,6 +172,16 @@ export const RankLookup = () => {
             width: 80,
         },
         {
+            headerName: 'Name',
+            cellRenderer: (params: ICellRendererParams<IMaterialEstimated2>) => {
+                const { data } = params;
+                if (data) return data.label;
+            },
+            equals: () => true,
+            sortable: false,
+            width: 80,
+        },
+        {
             field: 'count',
             maxWidth: 75,
         },
@@ -184,20 +190,6 @@ export const RankLookup = () => {
             maxWidth: 120,
             valueFormatter: (params: ValueFormatterParams<IMaterialEstimated2>) => Rarity[params.data?.rarity ?? 0],
             cellClass: params => Rarity[params.data?.rarity ?? 0].toLowerCase(),
-        },
-        {
-            field: 'expectedEnergy',
-            maxWidth: 120,
-        },
-        {
-            headerName: '# Of Battles',
-            field: 'numberOfBattles',
-            maxWidth: 100,
-        },
-        {
-            headerName: 'Days Of Battles',
-            field: 'daysOfBattles',
-            maxWidth: 100,
         },
         {
             headerName: 'Locations',
@@ -382,16 +374,6 @@ export const RankLookup = () => {
             </div>
 
             <div>
-                <div style={{ display: 'flex' }}>
-                    <h3>Total</h3>
-                    {totalEnergy > 0 ? <h4 style={{ paddingInlineStart: 40 }}>Energy - {totalEnergy}</h4> : undefined}
-                    {totalEnergy > 0 ? (
-                        <h4 style={{ paddingInlineStart: 40 }}>
-                            Battles - {sum(totalMaterials.map(x => x.numberOfBattles))}
-                        </h4>
-                    ) : undefined}
-                </div>
-
                 <div
                     className="ag-theme-material"
                     style={{ height: 50 + totalMaterials.length * 30, maxHeight: '40vh', width: '100%' }}>

--- a/src/fsd/1-pages/plan-lre/points-table.tsx
+++ b/src/fsd/1-pages/plan-lre/points-table.tsx
@@ -329,7 +329,7 @@ const PointsTable = (props: { legendaryEvent: ILegendaryEvent }) => {
             }
             return result;
         }
-    }, [legendaryEvent.id, filter, pointsCalculation]);
+    }, [legendaryEvent.id, filter, pointsCalculation, teams, leProgress]);
 
     const rows = useMemo<ITableRow[]>(() => {
         const chars =
@@ -362,7 +362,7 @@ const PointsTable = (props: { legendaryEvent: ILegendaryEvent }) => {
                 totalPoints: x.legendaryEvents[legendaryEvent.id].totalPoints,
                 totalSlots: x.legendaryEvents[legendaryEvent.id].totalSlots,
             }));
-    }, [selection, filter, pointsCalculation]);
+    }, [selection, filter, legendaryEvent]);
 
     return (
         <div>

--- a/src/routes/goals/goal-card.tsx
+++ b/src/routes/goals/goal-card.tsx
@@ -118,10 +118,8 @@ export const GoalCard: React.FC<Props> = ({ goal, menuItemSelect, goalEstimate: 
             }
             case PersonalGoalType.UpgradeRank: {
                 const { xpEstimate } = goalEstimate;
-                const linkBase = isMobile ? '/mobile/learn/rankLookup' : '/learn/rankLookup';
-                const params = `?character=${goal.unitId}&rankStart=${Rank[goal.rankStart]}&rankEnd=${
-                    Rank[goal.rankEnd]
-                }&rankPoint5=${goal.rankPoint5}`;
+                const linkBase = isMobile ? '/mobile/plan/dailyRaids' : '/plan/dailyRaids';
+                const params = `?charSnowprintId=${goal.unitId}`;
 
                 return (
                     <div>
@@ -157,14 +155,14 @@ export const GoalCard: React.FC<Props> = ({ goal, menuItemSelect, goalEstimate: 
                             component={Link}
                             to={linkBase + params}
                             target={'_self'}>
-                            <LinkIcon /> <span style={{ paddingLeft: 5 }}>Go to Lookup</span>
+                            <LinkIcon /> <span style={{ paddingLeft: 5 }}>Go to Raids Table</span>
                         </Button>
                     </div>
                 );
             }
             case PersonalGoalType.MowAbilities: {
-                const linkBase = isMobile ? '/mobile/learn/mowLookup' : '/learn/mowLookup';
-                const params = `?mow=${goal.unitId}&pStart=${goal.primaryStart}&pEnd=${goal.primaryEnd}&sStart=${goal.secondaryStart}&sEnd=${goal.secondaryEnd}`;
+                const linkBase = isMobile ? '/mobile/plan/dailyRaids' : '/plan/dailyRaids';
+                const params = `?charSnowprintId=${goal.unitId}`;
                 const hasPrimaryGoal = goal.primaryEnd > goal.primaryStart;
                 const hasSecondaryGoal = goal.secondaryEnd > goal.secondaryStart;
                 const targetShards = ShardsService.getTargetShardsForMow(goal);
@@ -227,7 +225,7 @@ export const GoalCard: React.FC<Props> = ({ goal, menuItemSelect, goalEstimate: 
                             component={Link}
                             to={linkBase + params}
                             target={'_self'}>
-                            <LinkIcon /> <span style={{ paddingLeft: 5 }}>Go to Lookup</span>
+                            <LinkIcon /> <span style={{ paddingLeft: 5 }}>Go to Raids Table</span>
                         </Button>
                     </div>
                 );

--- a/src/routes/goals/goals-table.tsx
+++ b/src/routes/goals/goals-table.tsx
@@ -492,15 +492,13 @@ export const GoalsTable: React.FC<Props> = ({ rows, estimate, menuItemSelect }) 
                         let params: string = '';
 
                         if (data.type === PersonalGoalType.UpgradeRank) {
-                            linkBase = isMobile ? '/mobile/learn/rankLookup' : '/learn/rankLookup';
-                            params = `?character=${data.unitId}&rankStart=${Rank[data.rankStart]}&rankEnd=${
-                                Rank[data.rankEnd]
-                            }&rankPoint5=${data.rankPoint5}`;
+                            linkBase = isMobile ? '/mobile/plan/dailyRaids' : '/plan/dailyRaids';
+                            params = `?charSnowprintId=${data.unitId}`;
                         }
 
                         if (data.type === PersonalGoalType.MowAbilities) {
-                            linkBase = isMobile ? '/mobile/learn/mowLookup' : '/learn/mowLookup';
-                            params = `?mow=${data.unitId}&pStart=${data.primaryStart}&pEnd=${data.primaryEnd}&sStart=${data.secondaryStart}&sEnd=${data.secondaryEnd}`;
+                            linkBase = isMobile ? '/mobile/plan/dailyRaids' : '/plan/dailyRaids';
+                            params = `?charSnowprintId=${data.unitId}`;
                         }
                         return (
                             <Button
@@ -509,7 +507,7 @@ export const GoalsTable: React.FC<Props> = ({ rows, estimate, menuItemSelect }) 
                                 component={Link}
                                 to={linkBase + params}
                                 target={'_self'}>
-                                <LinkIcon /> <span style={{ paddingLeft: 5 }}>Go to Lookup</span>
+                                <LinkIcon /> <span style={{ paddingLeft: 5 }}>Go to Raids Table</span>
                             </Button>
                         );
                     }

--- a/src/routes/tables/dailyRaids.tsx
+++ b/src/routes/tables/dailyRaids.tsx
@@ -1,5 +1,6 @@
 ﻿import { enqueueSnackbar } from 'notistack';
-import React, { useContext, useMemo } from 'react';
+import React, { useContext, useEffect, useMemo } from 'react';
+import { useLocation, useSearchParams } from 'react-router-dom';
 
 import { ICampaingsFilters } from 'src/models/interfaces';
 import { DispatchContext, StoreContext } from 'src/reducers/store.provider';
@@ -56,6 +57,14 @@ export const DailyRaids = () => {
     }, [goals, units]);
 
     const hasSync = viewPreferences.apiIntegrationSyncOptions.includes('raidedLocations') && !!userInfo.tacticusApiKey;
+
+    const location = useLocation();
+    const [searchParams] = useSearchParams();
+    const [charSnowprintId, setCharSnowprintId] = React.useState<string | null>(searchParams.get('charSnowprintId'));
+
+    useEffect(() => {
+        setCharSnowprintId(searchParams.get('charSnowprintId'));
+    }, [location]);
 
     const handleUpgradesAdd = (upgradeId: string, value: number, location: IItemRaidLocation | null) => {
         setHasChanges(true);
@@ -210,6 +219,7 @@ export const DailyRaids = () => {
                 upgrades={inventory.upgrades}
                 updateInventory={saveInventoryUpdateChanges}
                 updateInventoryAny={() => setHasChanges(true)}
+                scrollToCharSnowprintId={charSnowprintId ?? undefined}
             />
 
             <TodayRaids

--- a/src/routes/tables/raids-plan.tsx
+++ b/src/routes/tables/raids-plan.tsx
@@ -24,6 +24,7 @@ import { Inventory } from '@/fsd/1-pages/input-inventory';
 interface Props {
     estimatedShards: IEstimatedShards;
     estimatedRanks: IEstimatedUpgrades;
+    scrollToCharSnowprintId?: string;
     upgrades: Record<string, number>;
     updateInventory: (materialId: string, value: number) => void;
     updateInventoryAny: () => void;
@@ -32,6 +33,7 @@ interface Props {
 export const RaidsPlan: React.FC<Props> = ({
     estimatedShards,
     estimatedRanks,
+    scrollToCharSnowprintId,
     updateInventoryAny,
     upgrades,
     updateInventory,
@@ -87,7 +89,7 @@ export const RaidsPlan: React.FC<Props> = ({
     }, [daysTotal]);
 
     return (
-        <Accordion>
+        <Accordion defaultExpanded={scrollToCharSnowprintId !== undefined}>
             <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                 <FlexBox style={{ flexDirection: 'column', alignItems: 'flex-start' }}>
                     <div className="flex gap-2 items-center flex-wrap" style={{ fontSize: isMobile ? 16 : 20 }}>
@@ -123,7 +125,9 @@ export const RaidsPlan: React.FC<Props> = ({
                     </Accordion>
                 )}
                 {!!estimatedRanks.inProgressMaterials.length && (
-                    <Accordion TransitionProps={{ unmountOnExit: !grid1Loaded }}>
+                    <Accordion
+                        defaultExpanded={scrollToCharSnowprintId !== undefined}
+                        TransitionProps={{ unmountOnExit: !grid1Loaded }}>
                         <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                             <div className="flex gap-2 items-center flex-wrap" style={{ fontSize: isMobile ? 16 : 20 }}>
                                 <PendingIcon color={'primary'} />
@@ -136,6 +140,8 @@ export const RaidsPlan: React.FC<Props> = ({
                                 updateMaterialQuantity={updateInventory}
                                 onGridReady={() => setGrid1Loaded(true)}
                                 inventory={upgrades}
+                                scrollToCharSnowprintId={scrollToCharSnowprintId}
+                                alreadyUsedMaterials={estimatedRanks.finishedMaterials}
                             />
                         </AccordionDetails>
                     </Accordion>


### PR DESCRIPTION
1) Fix the raids table to consider previous goals when showing remaining inventory needs.
2) Change the links from the goal page to jump to the appopriate place in the raids table.