### PR TITLE
BOM encoding breaks `JSON.parse`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "compilerOptions": {
         "target": "ESNext",
         "lib": ["dom", "dom.iterable", "esnext"],


### PR DESCRIPTION
**Description**

Changed the file encoding from "UTF-8 with BOM" to "UTF-8".

**Reason**

I was trying to take a look at the project with a tool called [`knip`](https://knip.dev/).
It was failing when trying to read the `tsconfig.json`.
The code it uses to read the file looks something like this:
```js
import { readFile } from 'node:fs/promises';

const contents = await readFile('./tsconfig.json');
return JSON.parse(contents.toString());
```

This was failing to parse the file because the first three bytes of the file were the "Byte Order Mark" that shows up in "UTF-8 with BOM" encoding. This is forbidden in the [JSON spec](https://datatracker.ietf.org/doc/html/rfc8259#section-8.1), so I figure it'd be best to change the encoding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a hidden byte order mark from the TypeScript configuration file to standardize encoding and avoid potential tooling warnings. This is a housekeeping change only: no changes to configuration values, build outputs, or runtime behavior. Users should not notice any differences in functionality or performance. No action is required after updating.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->