### PR TITLE
Update guild raid to use icons in table

### DIFF
--- a/src/v2/features/tacticus-integration/guild-raid-v2.tsx
+++ b/src/v2/features/tacticus-integration/guild-raid-v2.tsx
@@ -20,7 +20,6 @@ import {
     getTacticusGuildRaidData,
     TacticusGuildRaidUnit,
 } from '@/fsd/5-shared/lib/tacticus-api';
-import { Rarity } from '@/fsd/5-shared/model';
 import { RarityIcon, UnitShardIcon } from '@/fsd/5-shared/ui/icons';
 
 import { CharactersService } from '@/fsd/4-entities/character/characters.service';


### PR DESCRIPTION
https://trello.com/c/885Isg66/10-learn-guild-uses-charid
https://trello.com/c/77u0lusD/15-learn-guild-total-battles-column

http://localhost:3000/learn/guild

https://tacticusplanner.app/learn/guild

Guild table now uses Charcter icons instead of unitId names, filtering still works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unit and Master of War (MoW) icons added across the guild raid interface for clearer visuals.
  * Most-used heroes now show up to 5 icon thumbnails; Most-used MoW displays up to 3 icons and extends the textual list to 5.
  * Total Battles column added to user summaries with per-user counts tracked.

* **Bug Fixes / UX**
  * Column widths and layouts adjusted for improved readability and consistent icon presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->