### PR TITLE
Add battle locations to raid cards.

### DIFF
--- a/src/routes/tables/raid-upgrade-material-card.tsx
+++ b/src/routes/tables/raid-upgrade-material-card.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 import { RarityMapper } from '@/fsd/5-shared/model/mappers/rarity.mapper';
 import { UnitShardIcon } from '@/fsd/5-shared/ui/icons';
 
+import { ICampaignBattleComposed } from '@/fsd/4-entities/campaign/@x/upgrade';
+import { CampaignLocation } from '@/fsd/4-entities/campaign/campaign-location';
 import { CharactersService } from '@/fsd/4-entities/character';
 import { UpgradeImage, UpgradesService } from '@/fsd/4-entities/upgrade';
 
@@ -12,6 +14,7 @@ interface Props {
     currentQuantity: number;
     desiredQuantity: number;
     relatedCharacterSnowprintIds: string[];
+    locations: ICampaignBattleComposed[];
 }
 
 export const RaidUpgradeMaterialCard: React.FC<Props> = ({
@@ -19,6 +22,7 @@ export const RaidUpgradeMaterialCard: React.FC<Props> = ({
     currentQuantity,
     desiredQuantity,
     relatedCharacterSnowprintIds,
+    locations,
 }) => {
     const rewardIcon = () => {
         const upgrade = UpgradesService.getUpgrade(upgradeMaterialSnowprintId);
@@ -46,21 +50,30 @@ export const RaidUpgradeMaterialCard: React.FC<Props> = ({
     };
 
     return (
-        <div className="flex-box item-start">
-            <div className="flex-box column">
-                {rewardIcon()}
-                <span>
-                    {currentQuantity}/{desiredQuantity}
-                </span>
-            </div>
-            <div className="flex flex-col gap-2">
-                <div className="flex flex-wrap gap-1">
-                    {relatedCharacterSnowprintIds.map(id => (
-                        <div key={id}>
-                            <UnitShardIcon icon={CharactersService.getUnit(id)?.roundIcon ?? id} height={30} />
-                        </div>
-                    ))}
+        <div className="w-full max-w-[400px] overflow-hidden p-[5px] [box-shadow:1px_2px_3px_rgba(0,_0,_0,_0.6)]">
+            <div className="flex-box item-start">
+                <div className="flex-box column">
+                    {rewardIcon()}
+                    <span>
+                        {currentQuantity}/{desiredQuantity}
+                    </span>
                 </div>
+                <div className="flex flex-col gap-2">
+                    <div className="flex flex-wrap gap-1">
+                        {relatedCharacterSnowprintIds.map(id => (
+                            <div key={id}>
+                                <UnitShardIcon icon={CharactersService.getUnit(id)?.roundIcon ?? id} height={30} />
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            </div>
+            <div className="flex-box gap2 wrap">
+                {locations
+                    .filter(x => x.isSuggested && x.isUnlocked)
+                    .map(loc => {
+                        return <CampaignLocation key={loc.id} location={loc} short={true} unlocked={true} />;
+                    })}
             </div>
         </div>
     );

--- a/src/routes/tables/raids-header.tsx
+++ b/src/routes/tables/raids-header.tsx
@@ -1,17 +1,13 @@
 ﻿import ClearIcon from '@mui/icons-material/Clear';
-import GridViewIcon from '@mui/icons-material/GridView';
 import LinkIcon from '@mui/icons-material/Link';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import SettingsIcon from '@mui/icons-material/Settings';
 import SyncIcon from '@mui/icons-material/Sync';
-import TableRowsIcon from '@mui/icons-material/TableRows';
-import { FormControlLabel, Switch } from '@mui/material';
 import Button from '@mui/material/Button';
-import React, { useContext, useState } from 'react';
+import React, { useState } from 'react';
 import { isMobile } from 'react-device-detect';
 import { Link } from 'react-router-dom';
 
-import { DispatchContext, StoreContext } from '@/reducers/store.provider';
 import DailyRaidsSettings from 'src/shared-components/daily-raids-settings';
 
 import { MiscIcon } from '@/fsd/5-shared/ui/icons';
@@ -36,13 +32,7 @@ export const RaidsHeader: React.FC<Props> = ({
     hasSync,
     syncHandle,
 }) => {
-    const { viewPreferences } = useContext(StoreContext);
-    const dispatch = useContext(DispatchContext);
     const [openSettings, setOpenSettings] = useState<boolean>(false);
-
-    const updateView = (tableView: boolean): void => {
-        dispatch.viewPreferences({ type: 'Update', setting: 'raidsTableView', value: tableView });
-    };
 
     return (
         <>
@@ -63,25 +53,6 @@ export const RaidsHeader: React.FC<Props> = ({
                         <MiscIcon icon={'energy'} height={15} width={15} /> {actualDailyEnergy}
                     </span>
                 </div>
-
-                <FormControlLabel
-                    control={
-                        <Switch
-                            checked={viewPreferences.raidsTableView}
-                            onChange={event => updateView(event.target.checked)}
-                        />
-                    }
-                    label={
-                        <div className="flex-box gap5">
-                            {viewPreferences.raidsTableView ? (
-                                <TableRowsIcon color="primary" />
-                            ) : (
-                                <GridViewIcon color="primary" />
-                            )}{' '}
-                            view
-                        </div>
-                    }
-                />
 
                 <div className="flex-box gap10" style={{ paddingBottom: 10 }}>
                     {hasSync && (

--- a/src/routes/tables/raids-plan.tsx
+++ b/src/routes/tables/raids-plan.tsx
@@ -1,15 +1,17 @@
 ﻿import { Warning } from '@mui/icons-material';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import GridViewIcon from '@mui/icons-material/GridView';
 import InfoIcon from '@mui/icons-material/Info';
 import InventoryIcon from '@mui/icons-material/Inventory';
 import PendingIcon from '@mui/icons-material/Pending';
-import { Accordion, AccordionDetails, AccordionSummary, Box } from '@mui/material';
+import TableRowsIcon from '@mui/icons-material/TableRows';
+import { Accordion, AccordionDetails, AccordionSummary, Box, FormControlLabel, Switch } from '@mui/material';
 import Button from '@mui/material/Button';
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { isMobile } from 'react-device-detect';
 
-import { StoreContext } from '@/reducers/store.provider';
+import { DispatchContext, StoreContext } from '@/reducers/store.provider';
 import { formatDateWithOrdinal } from 'src/shared-logic/functions';
 
 import { AccessibleTooltip, FlexBox } from '@/fsd/5-shared/ui';
@@ -47,6 +49,7 @@ export const RaidsPlan: React.FC<Props> = ({
     updateInventory,
 }) => {
     const { viewPreferences } = useContext(StoreContext);
+    const dispatch = useContext(DispatchContext);
     const [upgradesPaging, setUpgradesPaging] = useState<{
         start: number;
         end: number;
@@ -66,6 +69,10 @@ export const RaidsPlan: React.FC<Props> = ({
     );
 
     type CharacterToMaterialIndexMap = Record<string, number>;
+
+    const updateView = (tableView: boolean): void => {
+        dispatch.viewPreferences({ type: 'Update', setting: 'raidsTableView', value: tableView });
+    };
 
     const characterToMaterialMap: CharacterToMaterialIndexMap = useMemo(() => {
         const characterIndexMap: CharacterToMaterialIndexMap = {};
@@ -195,6 +202,27 @@ export const RaidsPlan: React.FC<Props> = ({
                             <div className="flex gap-2 items-center flex-wrap" style={{ fontSize: isMobile ? 16 : 20 }}>
                                 <PendingIcon color={'primary'} />
                                 <b>{estimatedRanks.inProgressMaterials.length}</b> in progress upgrades
+                                <FormControlLabel
+                                    control={
+                                        <Switch
+                                            checked={viewPreferences.raidsTableView}
+                                            onChange={event => updateView(event.target.checked)}
+                                        />
+                                    }
+                                    label={
+                                        <div className="flex-box gap5">
+                                            {viewPreferences.raidsTableView ? (
+                                                <div className="flex-box gap5">
+                                                    <TableRowsIcon color="primary" /> <span>Table View</span>
+                                                </div>
+                                            ) : (
+                                                <div className="flex-box gap5">
+                                                    <GridViewIcon color="primary" /> <span>Cards View</span>
+                                                </div>
+                                            )}
+                                        </div>
+                                    }
+                                />
                             </div>
                         </AccordionSummary>
                         <AccordionDetails>
@@ -218,18 +246,21 @@ export const RaidsPlan: React.FC<Props> = ({
                                         gap: 1,
                                         width: '100%',
                                     }}>
-                                    {estimatedRanks.inProgressMaterials.length > 0 &&
-                                        estimatedRanks.inProgressMaterials.map((material, index) => (
-                                            <div className="item-raids w-64" key={index} ref={setCardRef(index)}>
-                                                <RaidUpgradeMaterialCard
-                                                    index={index}
-                                                    upgradeMaterialSnowprintId={material.id}
-                                                    currentQuantity={material.acquiredCount}
-                                                    desiredQuantity={material.requiredCount}
-                                                    relatedCharacterSnowprintIds={material.relatedCharacters}
-                                                />
-                                            </div>
-                                        ))}
+                                    <div className="flex flex-wrap gap-x-4 gap-y-4">
+                                        {estimatedRanks.inProgressMaterials.length > 0 &&
+                                            estimatedRanks.inProgressMaterials.map((material, index) => (
+                                                <div className="item-raids w-64" key={index} ref={setCardRef(index)}>
+                                                    <RaidUpgradeMaterialCard
+                                                        index={index}
+                                                        upgradeMaterialSnowprintId={material.id}
+                                                        currentQuantity={material.acquiredCount}
+                                                        desiredQuantity={material.requiredCount}
+                                                        relatedCharacterSnowprintIds={material.relatedCharacters}
+                                                        locations={material.locations}
+                                                    />
+                                                </div>
+                                            ))}
+                                    </div>
                                 </Box>
                             )}
                         </AccordionDetails>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added view toggle feature allowing users to switch between Card and Table views when viewing raids
  * Enhanced raid upgrade material cards with campaign locations display, showing suggested and unlocked locations

* **Refactors**
  * Reorganized view preference controls within the interface
  * Improved responsive layout for raid materials list

<!-- end of auto-generated comment: release notes by coderabbit.ai -->