### PR TITLE
Negative savings in campaign progression fix

### DIFF
--- a/src/fsd/1-pages/plan-campaign-progression/campaign-progression.service.ts
+++ b/src/fsd/1-pages/plan-campaign-progression/campaign-progression.service.ts
@@ -222,16 +222,15 @@ export class CampaignsProgressionService {
                 // If we need X instances of an upgrade material, only suggest beating a node if we
                 // save at least X/2 energy by doing so (or if we can't farm the item).
                 if (oldEnergy - farmData.count / 2 > newEnergyCost || !farmData.canFarm) {
-                    cumulativeSavings += farmData.totalEnergy - newEnergyCost;
+                    const individualSavings = farmData.totalEnergy - newEnergyCost;
+                    // Only add to cumulative savings if this is actually a savings (not an unlock)
+                    if (farmData.canFarm) {
+                        cumulativeSavings += individualSavings;
+                    }
                     result.data
                         .get(campaign)
                         ?.savings.push(
-                            new BattleSavings(
-                                battle,
-                                farmData.totalEnergy - newEnergyCost,
-                                cumulativeSavings,
-                                farmData.canFarm
-                            )
+                            new BattleSavings(battle, individualSavings, cumulativeSavings, farmData.canFarm)
                         );
                     newMaterialEnergy.set(this.getReward(battle), newEnergyCost);
                 }


### PR DESCRIPTION
### This fixes the negative savings that could appear in Plan / Campaign Progression when there is a material to unlock.

The Issue(s):

Negative energy savings could appear if the previous material in the campaign list needed unlock. 
This is because energy savings for non-farmable nodes (locked) was calculated as the energy needed to unlock the node x the amount of material needed in total, which is not correct since that would be total cost of farming.

The Fix:

Added a check to see if the node is unlocked or not (farmData.canFarm flag). If it is locked, then no energy cost or savings are taken into consideration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected campaign progression savings calculation to accurately count only farmable items, excluding non-farmable unlocks from the cumulative savings total.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->