### PR TITLE
Fix - Change goal target doesn't get updated until you close and open the goals dialog again

### DIFF
--- a/src/v2/features/goals/active-goals-dialog.tsx
+++ b/src/v2/features/goals/active-goals-dialog.tsx
@@ -27,10 +27,15 @@ export const ActiveGoalsDialog: React.FC<Props> = ({ goals, units, onGoalsSelect
     // Sync currentGoalsSelect with goals prop when goals change while dialog is open
     useEffect(() => {
         if (openGoals) {
-            setCurrentGoalsSelect(goals);
+            setCurrentGoalsSelect(prevGoals =>
+                goals.map(goal => {
+                    const prevGoal = prevGoals.find(g => g.goalId === goal.goalId);
+                    // Preserve include state if goal exists, otherwise use the new goal's include value
+                    return prevGoal ? { ...goal, include: prevGoal.include } : goal;
+                })
+            );
         }
     }, [goals, openGoals]);
-
     const handleSelectAll = (event: React.ChangeEvent<HTMLInputElement>) => {
         setCurrentGoalsSelect(value => value.map(x => ({ ...x, include: event.target.checked })));
     };


### PR DESCRIPTION
### This fixes the bug where the active goals dialog list is not updated after editing goals for a character.

The Issue(s):

Active goals dialog list is not updated after editing goals for a character.

If goals prop changes (when editing goals for a character), we need to be able to trigger a refresh of the dialog to pick up those changes.

The Fix:

Adding an useEffect hook with "goals" prop as dependency (and "openGoals" in order to sync when dialog state changes) solves this issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the Active Goals dialog could show outdated selections if goals changed while the dialog was open. The dialog now stays synchronized with external goal updates so selections reflect the current state, preventing confusion and ensuring any changes made elsewhere are immediately visible when the dialog is open.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->