### PR TITLE
"Total resources missing" dropdown light theme fix

### DIFF
--- a/src/routes/goals/goals.tsx
+++ b/src/routes/goals/goals.tsx
@@ -362,7 +362,7 @@ export const Goals = () => {
             <div style={{ width: '350px' }} className="my-2 flex-box gap20">
                 <Accordion
                     defaultExpanded={false}
-                    className="!shadow-none !bg-transparent border border-gray-700 px-2 hover:!bg-[var(--secondary)]">
+                    className="!shadow-none !bg-transparent border border-[var(--border)] px-2 hover:!bg-[var(--secondary)]">
                     <AccordionSummary
                         expandIcon={<ExpandMoreIcon className="text-[var(--muted-fg)]" />}
                         className="!p-0 min-h-0 !bg-transparent rounded-lg"


### PR DESCRIPTION
This is a fix for the display of "Total resources missing" dropdown on light theme.

Problem: font color was white and wasn't visible on the white background of the light theme.
Fix: added theme variables instead of hardcoded values in order to go with the current selected theme

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined visual styling and theming across the Goals interface for consistent appearance.
  * Reworked spacing, alignment and responsive wrapping to improve layout stability.
  * Updated color scheme, borders, hover backgrounds and badges to use themed tokens for better contrast.
  * Improved visual hierarchy of headers, totals and resource/ability sections for clearer readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->