### PR TITLE
Tighten up character and MoW tile styling

### DIFF
--- a/src/v2/features/characters/components/character-tile.tsx
+++ b/src/v2/features/characters/components/character-tile.tsx
@@ -91,12 +91,12 @@ const CharacterTileFn = ({
 
     const renderCharacterLevel = useMemo(() => {
         return isUnlocked ? (
-            <div className="relative top-[-15px] flex items-center justify-center border text-[white] text-xs border-solid border-[gold] bg-[#012a41]">
+            <div className="relative top-[-20px] flex items-center justify-center border text-[white] text-xs border-solid border-[gold] bg-[#012a41]">
                 {character.level}
             </div>
         ) : (
             <div
-                className="relative top-[-15px] flex items-center justify-center border text-[white] text-xs border-solid border-[gold] bg-[#012a41]"
+                className="relative top-[-20px] flex items-center justify-center border text-[white] text-xs border-solid border-[gold] bg-[#012a41]"
                 style={{
                     background: `linear-gradient(to right, green ${unlockProgress}%, #012A41 ${unlockProgress}%)`,
                 }}>
@@ -133,7 +133,7 @@ const CharacterTileFn = ({
                 </Tooltip>
 
                 <div
-                    className="relative top-[-7px] flex items-center justify-between z-10"
+                    className="relative top-[-10px] flex items-center justify-between z-10"
                     style={{ visibility: hasAbilities && viewContext.showAbilitiesLevel ? 'visible' : 'hidden' }}>
                     <div className="relative top-[-10px] w-5 h-5 flex items-center justify-center bg-[#012a41] border text-[white] text-xs border-solid border-[gold] rounded-full">
                         {character.activeAbilityLevel}

--- a/src/v2/features/characters/components/mow-tile.tsx
+++ b/src/v2/features/characters/components/mow-tile.tsx
@@ -54,21 +54,21 @@ export const MowTile: React.FC<Props> = ({ mow, disableClick, onClick }) => {
                 <div
                     className="relative top-[-7px] flex items-center justify-between z-10"
                     style={{ visibility: hasAbilities && viewContext.showAbilitiesLevel ? 'visible' : 'hidden' }}>
-                    <div className="relative top-[-10px] w-5 h-5 flex items-center justify-center bg-[#012a41] border text-[white] text-xs border-solid border-[gold] rounded-full">
+                    <div className="relative top-[-16px] w-5 h-5 flex items-center justify-center bg-[#012a41] border text-[white] text-xs border-solid border-[gold] rounded-full">
                         {mow.primaryAbilityLevel}
                     </div>
-                    <div className="relative top-[-10px] w-5 h-5 flex items-center justify-center bg-[#012a41] border text-[white] text-xs border-solid border-[gold] rounded-full">
+                    <div className="relative top-[-16px] w-5 h-5 flex items-center justify-center bg-[#012a41] border text-[white] text-xs border-solid border-[gold] rounded-full">
                         {mow.secondaryAbilityLevel}
                     </div>
                 </div>
                 <Conditional condition={viewContext.showCharacterLevel}>
                     {mow.unlocked ? (
-                        <div className="relative top-[-15px] flex items-center justify-center bg-[#012a41] border text-[white] text-xs border-solid border-[gold]">
+                        <div className="relative top-[-24px] flex items-center justify-center bg-[#012a41] border text-[white] text-xs border-solid border-[gold]">
                             {mow.shards}
                         </div>
                     ) : (
                         <div
-                            className="relative top-[-15px] flex items-center justify-center bg-[#012a41] border text-[white] text-xs border-solid border-[gold]"
+                            className="relative top-[-23px] flex items-center justify-center bg-[#012a41] border text-[white] text-xs border-solid border-[gold]"
                             style={{
                                 background: `linear-gradient(to right, green ${unlockProgress}%, #012A41 ${unlockProgress}%)`,
                             }}>
@@ -77,7 +77,7 @@ export const MowTile: React.FC<Props> = ({ mow, disableClick, onClick }) => {
                     )}
                 </Conditional>
             </div>
-            <div className="min-h-[30px] flex items-center mt-[-15px] justify-center">
+            <div className="min-h-[30px] flex items-center mt-[-19px] justify-center">
                 {viewContext.showCharacterRarity && <RarityIcon rarity={mow.rarity} />}
                 <MiscIcon icon={'mow'} width={22} height={25} />
             </div>


### PR DESCRIPTION
Removes gaps and inconsistent margins

#### Before (prod)
<img width="383" height="163" alt="before" src="https://github.com/user-attachments/assets/6fb2dcdc-c053-42d8-ab6b-7b789036f32d" />

#### After
<img width="376" height="154" alt="after" src="https://github.com/user-attachments/assets/16b6f248-3953-432e-bbf3-f840366bcd43" />
