### PR TITLE
Change - enable editing completed goals in card view

### DIFF
--- a/src/routes/goals/goal-card.tsx
+++ b/src/routes/goals/goal-card.tsx
@@ -352,11 +352,9 @@ export const GoalCard: React.FC<Props> = ({ goal, menuItemSelect, goalEstimate: 
                 action={
                     menuItemSelect ? (
                         <>
-                            {!isGoalCompleted ? (
-                                <IconButton onClick={() => menuItemSelect('edit')}>
-                                    <Edit fontSize="small" />
-                                </IconButton>
-                            ) : undefined}
+                            <IconButton onClick={() => menuItemSelect('edit')}>
+                                <Edit fontSize="small" />
+                            </IconButton>
                             <IconButton onClick={() => menuItemSelect('delete')}>
                                 <DeleteForever fontSize="small" />
                             </IconButton>


### PR DESCRIPTION
For completed goals, the "Edit goal" icon was not present in card view although it was present in table view.

This PR removes the condition that was hiding the Edit goal icon in card view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now edit completed goals, whereas previously completed goals were locked from editing. The delete functionality remains unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->