### PR TITLE
fixed light mode for tokenomics and battles components

### DIFF
--- a/src/fsd/0-app/index.css
+++ b/src/fsd/0-app/index.css
@@ -4,6 +4,8 @@
 /*@import 'tailwindcss';*/
 @plugin 'tailwindcss-animate';
 
+@variant dark (&:where(.dark, .dark *));
+
 @theme {
     --color-border: var(--border);
     --color-input: var(--input);


### PR DESCRIPTION
After adding the light/dark/system theme button, the tokenomics and battles pages were not picking up the correct light mode classes. 
Adding @variant dark (&:where(.dark, .dark *)) in the main css file tells Tailwind v4 to use class-based dark mode where the dark class is applied to the parent element (this is what theme provider is doing).

More info here:
https://tailwindcss.com/docs/dark-mode
https://dev.to/tene/dark-mode-using-tailwindcss-v40-2lc6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added dark mode styling variant support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->