### PR TITLE
Add back the option to select only the ad refresh

### DIFF
--- a/src/shared-components/daily-raids-settings.tsx
+++ b/src/shared-components/daily-raids-settings.tsx
@@ -60,6 +60,10 @@ const defaultCustomSettings: ICustomDailyRaidsSettings = {
 
 const energyMarks = [
     {
+        value: 288 + 30 + 60,
+        label: 'Ad Only',
+    },
+    {
         value: 288 + 30 + 60 + 60,
         label: '25 BS',
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Ad Only" energy option to daily raids settings, providing an additional choice for energy management in your raid configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->