### PR TITLE
Changes to LRE battle requirement status toggle, added prompts for battle and full toggle icons

### DIFF
--- a/src/fsd/1-pages/plan-lre/battle-status-checkbox.tsx
+++ b/src/fsd/1-pages/plan-lre/battle-status-checkbox.tsx
@@ -1,8 +1,9 @@
 import { Popover, TextField } from '@mui/material';
-import { Circle, CircleCheck, CircleFadingPlus, CircleMinus, CircleQuestionMark } from 'lucide-react';
-import React, { ReactNode, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import { RequirementStatus } from '@/fsd/3-features/lre';
+
+import { STATUS_COLORS, STATUS_LABELS } from './requirement-status-constants';
 
 interface Props {
     status: RequirementStatus;
@@ -11,22 +12,6 @@ interface Props {
     maxKillPoints: number;
     onChange: (status: RequirementStatus, killScore?: number) => void;
 }
-
-const STATUS_LABELS: Record<RequirementStatus, ReactNode> = {
-    [RequirementStatus.NotCleared]: <Circle className="size-5 md:size-6" />,
-    [RequirementStatus.Cleared]: <CircleCheck className="size-5 md:size-6" />,
-    [RequirementStatus.MaybeClear]: <CircleQuestionMark className="size-5 md:size-6" />,
-    [RequirementStatus.StopHere]: <CircleMinus className="size-5 md:size-6" />,
-    [RequirementStatus.PartiallyCleared]: <CircleFadingPlus className="size-5 md:size-6" />,
-};
-
-const STATUS_COLORS: Record<RequirementStatus, string> = {
-    [RequirementStatus.NotCleared]: '#6b7280', // Gray
-    [RequirementStatus.Cleared]: '#4caf50', // Green
-    [RequirementStatus.MaybeClear]: '#eab308', // Yellow
-    [RequirementStatus.StopHere]: '#be123c', // Red
-    [RequirementStatus.PartiallyCleared]: '#2196f3', // Blue
-};
 
 export const BattleStatusCheckbox: React.FC<Props> = ({ status, killScore, isKillScore, maxKillPoints, onChange }) => {
     const [showDropdown, setShowDropdown] = useState(false);

--- a/src/fsd/1-pages/plan-lre/requirement-status-constants.tsx
+++ b/src/fsd/1-pages/plan-lre/requirement-status-constants.tsx
@@ -1,0 +1,20 @@
+import { Circle, CircleCheck, CircleFadingPlus, CircleMinus, CircleQuestionMark } from 'lucide-react';
+import { ReactNode } from 'react';
+
+import { RequirementStatus } from '@/fsd/3-features/lre';
+
+export const STATUS_LABELS: Record<RequirementStatus, ReactNode> = {
+    [RequirementStatus.NotCleared]: <Circle className="size-5 md:size-6" />,
+    [RequirementStatus.Cleared]: <CircleCheck className="size-5 md:size-6" />,
+    [RequirementStatus.MaybeClear]: <CircleQuestionMark className="size-5 md:size-6" />,
+    [RequirementStatus.StopHere]: <CircleMinus className="size-5 md:size-6" />,
+    [RequirementStatus.PartiallyCleared]: <CircleFadingPlus className="size-5 md:size-6" />,
+};
+
+export const STATUS_COLORS: Record<RequirementStatus, string> = {
+    [RequirementStatus.NotCleared]: '#6b7280', // Gray
+    [RequirementStatus.Cleared]: '#4caf50', // Green
+    [RequirementStatus.MaybeClear]: '#eab308', // Yellow
+    [RequirementStatus.StopHere]: '#be123c', // Red
+    [RequirementStatus.PartiallyCleared]: '#2196f3', // Blue
+};

--- a/src/fsd/5-shared/ui/confirmation-dialog.tsx
+++ b/src/fsd/5-shared/ui/confirmation-dialog.tsx
@@ -1,0 +1,44 @@
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import React from 'react';
+
+interface ConfirmationDialogProps {
+    open: boolean;
+    title: string;
+    message: string;
+    onConfirm: () => void;
+    onCancel: () => void;
+    confirmText?: string;
+    cancelText?: string;
+}
+
+export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
+    open,
+    title,
+    message,
+    onConfirm,
+    onCancel,
+    confirmText = 'OK',
+    cancelText = 'Cancel',
+}) => {
+    return (
+        <Dialog open={open} onClose={onCancel}>
+            <DialogTitle>{title}</DialogTitle>
+            <DialogContent>
+                <DialogContentText>{message}</DialogContentText>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={onCancel} color="primary">
+                    {cancelText}
+                </Button>
+                <Button onClick={onConfirm} color="primary" variant="contained" autoFocus>
+                    {confirmText}
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+};

--- a/src/fsd/5-shared/ui/index.ts
+++ b/src/fsd/5-shared/ui/index.ts
@@ -11,3 +11,4 @@ export { bmcLink, discordInvitationLink, isTabletOrMobileMediaQuery } from './co
 export { MultipleSelectCheckmarks } from './multiple-select';
 export { RaritySelect } from './rarity-select';
 export { StarsSelect } from './stars-select';
+export { ConfirmationDialog } from './confirmation-dialog';


### PR DESCRIPTION
The PR implements: 

1. Cycling toggling of LRE battles statuses for all battle columns except the Killscore which remains a dropdown in order to permit partial kill score input. 

2. Confirmation dialogs to the full battle progress toggle buttons and for the battle number toggles. 

There's also some cleaning up done in order to remove commented components, create a dedicated dialog component and move all statuses and their icons to a single file to be used across the LRE components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kill scores now enforce maximum limit validation.
  * Confirmation dialogs added when toggling requirement statuses in batch.
  * Status indicators now display with color-coded visual labels.

* **Improvements**
  * Reusable confirmation dialog component added for consistent user interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->