### PR TITLE
Only apply upgrades in goal calculations if the starting rank of the goal is the current rank of the unit.

### DIFF
--- a/src/fsd/3-features/goals/goals.service.ts
+++ b/src/fsd/3-features/goals/goals.service.ts
@@ -232,7 +232,8 @@ export class GoalsService {
                     rankPoint5: g.rankPoint5!,
                     rankStartPoint5: g.startingRankPoint5 ?? false,
                     upgradesRarity: g.upgradesRarity ?? [],
-                    appliedUpgrades: unit.upgrades,
+                    appliedUpgrades:
+                        Math.max(g.startingRank ?? unit.rank, unit.rank) === unit.rank ? unit.upgrades : [],
                     level: unit.level,
                     xp: unit.xp,
                     rarity: unit.rarity,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved goal upgrade calculation logic. Upgrades are now conditionally applied based on unit rank values, ensuring more accurate goal progression calculations when units reach certain rank thresholds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->