### PR TITLE
when diffing snapshots for all purposes except display, diff everything

### DIFF
--- a/src/fsd/1-pages/input-roster-snapshots/roster-snapshots-service.ts
+++ b/src/fsd/1-pages/input-roster-snapshots/roster-snapshots-service.ts
@@ -402,9 +402,9 @@ export class RosterSnapshotsService {
     public static diffSnapshots(
         base: IRosterSnapshot,
         compare: IRosterSnapshot,
-        diffShards: boolean = false,
-        diffMythicShards: boolean = false,
-        diffXpLevel: boolean = false
+        diffShards: boolean,
+        diffMythicShards: boolean,
+        diffXpLevel: boolean
     ): IRosterSnapshotDiff {
         const name = compare.name;
         const dateMillisUtc = compare.dateMillisUtc;
@@ -535,7 +535,13 @@ export class RosterSnapshotsService {
         state.base = toKeep[0];
         let current = state.base;
         for (let i = 1; i < toKeep.length; i++) {
-            const diff = this.diffSnapshots(current, toKeep[i]);
+            const diff = this.diffSnapshots(
+                current,
+                toKeep[i],
+                /*diffShards=*/ true,
+                /*diffMythicShards=*/ true,
+                /*diffXpLevel=*/ true
+            );
             current = toKeep[i];
 
             state.diffs.push(diff);

--- a/src/fsd/1-pages/input-roster-snapshots/roster-snapshots.tsx
+++ b/src/fsd/1-pages/input-roster-snapshots/roster-snapshots.tsx
@@ -324,7 +324,15 @@ export const RosterSnapshots = () => {
             };
             resolved.forEach((snap, index) => {
                 if (index == 0) return;
-                newSnapshots.diffs.push(RosterSnapshotsService.diffSnapshots(resolved[index - 1], snap));
+                newSnapshots.diffs.push(
+                    RosterSnapshotsService.diffSnapshots(
+                        resolved[index - 1],
+                        snap,
+                        /*diffShards=*/ true,
+                        /*diffMythicShards=*/ true,
+                        /*diffXpLevel=*/ true
+                    )
+                );
             });
             if (newSnapshots.diffs.length > RosterSnapshotsService.MAX_SNAPSHOTS - 1) {
                 newSnapshots.diffs.splice(0, newSnapshots.diffs.length - (RosterSnapshotsService.MAX_SNAPSHOTS - 1));
@@ -423,7 +431,15 @@ export const RosterSnapshots = () => {
         };
         snapshots.forEach((snap, index) => {
             if (index == 0) return;
-            state.diffs.push(RosterSnapshotsService.diffSnapshots(snapshots[index - 1], snap));
+            state.diffs.push(
+                RosterSnapshotsService.diffSnapshots(
+                    snapshots[index - 1],
+                    snap,
+                    /*diffShards=*/ true,
+                    /*diffMythicShards=*/ true,
+                    /*diffXpLevel=*/ true
+                )
+            );
         });
         dispatch.rosterSnapshots({ type: 'Set', value: state });
     };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Roster snapshot comparisons now consistently include complete details on unit shards, mythic shards, and experience levels.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->