### PR TITLE
Roster Snapshots Improvements

### DIFF
--- a/src/fsd/1-pages/input-roster-snapshots/roster-snapshot-character.tsx
+++ b/src/fsd/1-pages/input-roster-snapshots/roster-snapshot-character.tsx
@@ -276,45 +276,19 @@ export const RosterSnapshotCharacter = ({
         );
     };
 
-    const AbilityBadge = ({
-        name,
-        val,
-        x,
-        y,
-    }: {
-        name: keyof typeof abilityIcons;
-        val: number;
-        x: number;
-        y: number;
-    }) => {
+    const AbilityBadge = ({ val, x, y, pos }: { val: number; x: number; y: number; pos: 'left' | 'right' }) => {
         const badgeRadius = 12;
         return (
             <>
                 <div
-                    className="absolute text-black shadow-md dark:text-white"
+                    className="absolute flex items-center justify-center rounded-[4px] border border-white bg-[#272424] text-white shadow-md"
                     style={{
-                        left: x - badgeRadius - 2,
-                        top: y - badgeRadius + 6,
-                        width: badgeRadius * 2 - 8,
-                        height: badgeRadius * 2 - 8,
+                        left: x - badgeRadius - (pos === 'left' ? 4 : -2),
+                        top: y - badgeRadius,
+                        width: badgeRadius * 2 + 2,
+                        height: badgeRadius * 2,
                     }}>
-                    <img
-                        src={abilityIcons[name]?.file}
-                        className="absolute drop-shadow-[0_0_2px_black] dark:drop-shadow-[0_0_2px_white]"
-                        style={{
-                            width: badgeRadius * 2 - 6,
-                            height: badgeRadius * 2 - 6,
-                        }}
-                    />
-                </div>
-                <div
-                    className="justify-right absolute text-[13px] font-bold text-black shadow-md dark:text-white"
-                    style={{
-                        left: x,
-                        top: y - badgeRadius * 2 + 6,
-                        width: badgeRadius * 2,
-                    }}>
-                    {val}
+                    <span className="text-[18px] text-white">{val}</span>
                 </div>
             </>
         );
@@ -331,13 +305,13 @@ export const RosterSnapshotCharacter = ({
         const rightX = 78; // Right side of the 96px frame
 
         if (!(firstName in abilityIcons) || !(secondName in abilityIcons)) {
-            console.log('firstName secondName first second', firstName, secondName, first, second);
+            console.error('Unknown abilities: firstName secondName first second', firstName, secondName, first, second);
         }
 
         return (
             <>
-                <AbilityBadge name={firstName} val={first} x={leftX} y={yPos} />
-                <AbilityBadge name={secondName} val={second} x={rightX} y={yPos} />
+                <AbilityBadge val={first} x={leftX} y={yPos} pos="left" />
+                <AbilityBadge val={second} x={rightX} y={yPos} pos="right" />
             </>
         );
     };

--- a/src/fsd/1-pages/input-roster-snapshots/roster-snapshot-character.tsx
+++ b/src/fsd/1-pages/input-roster-snapshots/roster-snapshot-character.tsx
@@ -410,7 +410,10 @@ export const RosterSnapshotCharacter = ({
                     <img src={charIcon} className={`absolute top-[17px] left-[3px] h-[120px] w-[90px]`} />
                     <img src={frame[0]?.src} className="absolute top-[14px] z-10 h-[126px] w-[96px]" />
                     {rankIcon && rankIcon[0] && char !== undefined && !isLocked && (
-                        <img src={rankIcon[0]?.src} className={`absolute top-[110px] left-0 z-20 h-[30px] w-[30px]`} />
+                        <img
+                            src={rankIcon[0]?.src}
+                            className={`absolute top-[100px] left-[-10px] z-20 h-[40px] w-auto`}
+                        />
                     )}
                     {shouldShowAbilities() &&
                         char &&

--- a/src/fsd/1-pages/input-roster-snapshots/roster-snapshot-character.tsx
+++ b/src/fsd/1-pages/input-roster-snapshots/roster-snapshot-character.tsx
@@ -212,7 +212,7 @@ export const RosterSnapshotCharacter = ({
                         }}
                     />
                 )}
-                <div className="absolute top-0 right-0 text-[13px] font-bold text-white">
+                <div className="absolute top-0 right-0 text-[16px] font-bold text-black dark:text-white">
                     {Math.min(11, Math.max(1, level ?? 1)).toString()}
                 </div>
             </div>
@@ -293,27 +293,26 @@ export const RosterSnapshotCharacter = ({
                 <div
                     className="absolute text-black shadow-md dark:text-white"
                     style={{
-                        left: x - badgeRadius,
-                        top: y - badgeRadius,
-                        width: badgeRadius * 2,
-                        height: badgeRadius * 2,
+                        left: x - badgeRadius - 2,
+                        top: y - badgeRadius + 6,
+                        width: badgeRadius * 2 - 8,
+                        height: badgeRadius * 2 - 8,
                     }}>
                     <img
                         src={abilityIcons[name]?.file}
-                        className="absolute top-1 left-1"
-                        style={{ left: -1, top: -1, width: badgeRadius * 2, height: badgeRadius * 2 }}
+                        className="absolute drop-shadow-[0_0_2px_black] dark:drop-shadow-[0_0_2px_white]"
+                        style={{
+                            width: badgeRadius * 2 - 6,
+                            height: badgeRadius * 2 - 6,
+                        }}
                     />
                 </div>
                 <div
-                    className="absolute text-black shadow-md dark:text-white"
+                    className="justify-right absolute text-[13px] font-bold text-black shadow-md dark:text-white"
                     style={{
-                        left: x - 8,
+                        left: x,
                         top: y - badgeRadius * 2 + 6,
                         width: badgeRadius * 2,
-                        textAlign: 'right',
-                        fontSize: 11,
-                        fontWeight: 'bold',
-                        textShadow: '0 0 1px rgba(0, 0, 0, 0.8)',
                     }}>
                     {val}
                 </div>

--- a/src/fsd/1-pages/input-roster-snapshots/roster-snapshots-service.ts
+++ b/src/fsd/1-pages/input-roster-snapshots/roster-snapshots-service.ts
@@ -144,6 +144,10 @@ export class RosterSnapshotsService {
         return RarityStars.None;
     }
 
+    /**
+     * Some old snapshots had things like abilities at level 0 or rarity/stars that didn't make
+     * sense. This function is a band aid to sanitize those diffs.
+     */
     public static fixSnapshot(snapshot: IRosterSnapshot): IRosterSnapshot {
         const ret = cloneDeep(snapshot);
         for (const char of ret.chars) {

--- a/src/fsd/1-pages/input-roster-snapshots/roster-snapshots-unit-diff-detailed.tsx
+++ b/src/fsd/1-pages/input-roster-snapshots/roster-snapshots-unit-diff-detailed.tsx
@@ -224,7 +224,7 @@ export const RosterSnapshotsUnitDiffDetailed: React.FC<Props> = ({
                             }}
                         />
                     )}
-                    <div className="absolute top-0 right-0 text-[13px] font-bold text-white">
+                    <div className="absolute top-0 right-0 text-[15px] font-bold text-black dark:text-white">
                         {Math.min(11, Math.max(1, level ?? 1))}
                     </div>
                 </div>

--- a/src/fsd/1-pages/input-roster-snapshots/roster-snapshots-unit-diff-detailed.tsx
+++ b/src/fsd/1-pages/input-roster-snapshots/roster-snapshots-unit-diff-detailed.tsx
@@ -277,13 +277,13 @@ export const RosterSnapshotsUnitDiffDetailed: React.FC<Props> = ({
     };
 
     return (
-        <div className="flex flex-col gap-2 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-lg transition duration-300 hover:border-blue-500 hover:shadow-xl dark:border-gray-700 dark:bg-gray-800">
-            <div className="flex h-28 w-82">
+        <div className="flex flex-col justify-start gap-2 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-lg transition duration-300 hover:border-blue-500 hover:shadow-xl dark:border-gray-700 dark:bg-gray-800">
+            <div className="flex min-h-30 w-82 justify-start">
                 <div className="relative flex h-full w-18 flex-shrink-0 items-center justify-center bg-gray-100 p-1 dark:bg-gray-900">
                     {(staticChar || staticMow) && <CharacterPortraitImage icon={(staticChar || staticMow)!.icon} />}
                 </div>
 
-                <div className="flex flex-grow justify-between p-3 text-gray-900 dark:text-white">
+                <div className="flex flex-grow justify-start p-3 text-gray-900 dark:text-white">
                     <div className="justify-center space-y-1">
                         <ProgressionRow
                             diffFlag={rarityDiff}
@@ -306,19 +306,8 @@ export const RosterSnapshotsUnitDiffDetailed: React.FC<Props> = ({
 
                     <div className="mx-2 w-px bg-gray-200 dark:bg-gray-700"></div>
 
-                    <div className="flex flex-col justify-center space-y-1 text-sm">
-                        <div className="grid grid-cols-[auto_auto_auto_auto] items-center gap-x-1">
-                            {/* Headers */}
-                            <div />
-                            <div />
-                            <div />
-                            <div />
-
-                            {/* Active/Primary Ability Row */}
-                            <div className="h-[18px]" />
-                            <div />
-                            <div />
-                            <div />
+                    <div className="flex flex-col items-start justify-start space-y-1 text-sm">
+                        <div className="grid grid-cols-[auto_auto_auto_auto] items-start gap-x-1">
                             <span
                                 className="w-6 text-right font-medium text-gray-600 dark:text-gray-400"
                                 style={{ opacity: shouldShowAbilities() ? 1 : 0 }}>
@@ -451,7 +440,7 @@ export const RosterSnapshotsUnitDiffDetailed: React.FC<Props> = ({
                     </div>
                 </div>
             </div>
-            {shouldShowEquipment() && char && <div className="px-3 py-3">{renderEquipment()}</div>}
+            {shouldShowEquipment() && char && <div className="px-3">{renderEquipment()}</div>}
         </div>
     );
 };

--- a/src/fsd/1-pages/input-roster-snapshots/roster-snapshots-unit.tsx
+++ b/src/fsd/1-pages/input-roster-snapshots/roster-snapshots-unit.tsx
@@ -16,6 +16,7 @@ interface Props {
     showTooltip: boolean;
     char?: ISnapshotCharacter;
     mow?: ISnapshotMachineOfWar;
+    isEnabled: boolean;
 }
 
 export const RosterSnapshotsUnit: React.FC<Props> = ({
@@ -27,6 +28,7 @@ export const RosterSnapshotsUnit: React.FC<Props> = ({
     char,
     mow,
     showTooltip,
+    isEnabled,
 }: Props) => {
     const staticChar = char ? CharactersService.resolveCharacter(char.id) : undefined;
     const staticMow = mow ? MowsService.resolveToStatic(mow.id) : undefined;
@@ -44,6 +46,7 @@ export const RosterSnapshotsUnit: React.FC<Props> = ({
                         showAbilities={showAbilities}
                         char={char}
                         charData={staticChar}
+                        isDisabled={!isEnabled}
                     />
                 )}
                 {mow !== undefined && staticMow !== undefined && (
@@ -56,6 +59,7 @@ export const RosterSnapshotsUnit: React.FC<Props> = ({
                         showAbilities={showAbilities}
                         mow={mow}
                         mowData={staticMow}
+                        isDisabled={!isEnabled}
                     />
                 )}
             </div>

--- a/src/fsd/1-pages/input-roster-snapshots/roster-snapshots.tsx
+++ b/src/fsd/1-pages/input-roster-snapshots/roster-snapshots.tsx
@@ -78,6 +78,7 @@ function getDisplay(
                                 showTooltip={true}
                                 char={'rank' in unit ? unit : undefined}
                                 mow={'rank' in unit ? undefined : unit}
+                                isEnabled={'rank' in unit ? unit.rank !== Rank.Locked : !unit.locked}
                             />
                         </RosterSnapshotsAssetsProvider>
                     </div>

--- a/src/fsd/1-pages/input-roster-snapshots/roster-snapshots.tsx
+++ b/src/fsd/1-pages/input-roster-snapshots/roster-snapshots.tsx
@@ -143,8 +143,28 @@ function getDisplay(
         if (fullChar === undefined) return;
 
         if (diffChar !== undefined && baseChar !== undefined) {
-            const beforeChar = { ...fullChar, ...baseChar, level: baseChar.xpLevel, id: fullChar.id };
-            const afterChar = { ...fullChar, ...compareChar, level: compareChar.xpLevel, id: fullChar.id };
+            const beforeChar = {
+                ...fullChar,
+                ...baseChar,
+                level: baseChar.xpLevel,
+                id: fullChar.id,
+                equipment: [
+                    { id: baseChar.equip0?.id ?? '', level: baseChar.equip0Level ?? 0 },
+                    { id: baseChar.equip1?.id ?? '', level: baseChar.equip1Level ?? 0 },
+                    { id: baseChar.equip2?.id ?? '', level: baseChar.equip2Level ?? 0 },
+                ],
+            };
+            const afterChar = {
+                ...fullChar,
+                ...compareChar,
+                level: compareChar.xpLevel,
+                id: fullChar.id,
+                equipment: [
+                    { id: compareChar.equip0?.id ?? '', level: compareChar.equip0Level ?? 0 },
+                    { id: compareChar.equip1?.id ?? '', level: compareChar.equip1Level ?? 0 },
+                    { id: compareChar.equip2?.id ?? '', level: compareChar.equip2Level ?? 0 },
+                ],
+            };
             const powerBefore =
                 beforeChar.rank === Rank.Locked ? 0 : CharactersPowerService.getCharacterPower(beforeChar);
             const powerAfter = afterChar.rank === Rank.Locked ? 0 : CharactersPowerService.getCharacterPower(afterChar);

--- a/src/fsd/1-pages/input-roster-snapshots/roster-snapshots.tsx
+++ b/src/fsd/1-pages/input-roster-snapshots/roster-snapshots.tsx
@@ -289,6 +289,7 @@ function getDisplay(
             showEquipment={showEquipment}
             showTooltip={true}
             char={unit}
+            isEnabled={unit.rank !== Rank.Locked}
         />
     ));
 
@@ -302,6 +303,7 @@ function getDisplay(
             showEquipment={showEquipment}
             showTooltip={true}
             mow={unit}
+            isEnabled={!unit.locked}
         />
     ));
 
@@ -313,8 +315,10 @@ function getDisplay(
                     {renderedMowDiffs}
                 </div>
                 <div style={{ zoom: sizeMod }} className="flex flex-wrap gap-5 p-4">
-                    {renderedChars}
-                    {renderedMows}
+                    {renderedChars.filter(char => char.props.isEnabled)}
+                    {renderedMows.filter(mow => mow.props.isEnabled)}
+                    {renderedChars.filter(char => !char.props.isEnabled)}
+                    {renderedMows.filter(mow => !mow.props.isEnabled)}
                 </div>
             </RosterSnapshotsAssetsProvider>
         </>


### PR DESCRIPTION
Fix equipment diffing
Remove ability icons. They look cool, but they're distracting and make the text illegible.
Increase the size of the rank icon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Units now grouped by enabled/disabled status; unit components accept an enabled flag and equipment levels are surfaced in diffs.

* **Bug Fixes**
  * Improved error reporting for unrecognized ability indicators.

* **Style**
  * Unified, simplified numeric badges for abilities/equipment with tighter positioning.
  * Enlarged shard/equipment counters with better contrast; adjusted rank badge placement and several layout refinements.

* **Documentation**
  * Added description of snapshot field sanitization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->