### PR TITLE
Revamp GW defense

### DIFF
--- a/src/fsd/0-app/routing/desktop-routes.tsx
+++ b/src/fsd/0-app/routing/desktop-routes.tsx
@@ -18,6 +18,7 @@ import { mowLookupDesktopLazyRoute } from '@/fsd/1-pages/learn-mow';
 import { campaignProgressionLazyRoute } from '@/fsd/1-pages/plan-campaign-progression';
 import { lreLazyRoute } from '@/fsd/1-pages/plan-lre';
 import { teams2Route } from '@/fsd/1-pages/plan-teams2/teams2.route';
+import { warDefense2Route } from '@/fsd/1-pages/plan-war-defense-2/war-defense2.route';
 import { warOffense2Route } from '@/fsd/1-pages/plan-war-offense2/war-offense2.route';
 import { sharedRosterRoute } from '@/fsd/1-pages/shared-roster/shared-roster.route';
 import { teamsDesktopLazyRoute } from '@/fsd/1-pages/teams/teams.route';
@@ -57,6 +58,7 @@ export const globalPlanRoutes: RouteObject[] = [
         },
     },
     teams2Route,
+    warDefense2Route,
     warOffense2Route,
     guildWarOffenseLazyRoute,
     guildWarDefenseLazyRoute,

--- a/src/fsd/1-pages/guild-war-offense/guild-war-offense.menu-item.tsx
+++ b/src/fsd/1-pages/guild-war-offense/guild-war-offense.menu-item.tsx
@@ -4,7 +4,7 @@ import { MenuItem } from '@/models/menu-item';
 import GuildWarIcon from 'src/assets/images/icons/guildWarMono.png';
 
 export const guildWarOffenseMenuItem = new MenuItem(
-    'Offense',
+    'Offense (End of Life May 2026)',
     <img src={GuildWarIcon} width={24} height={24} alt="Guild War Offense" />,
     '/plan/guildWar/offense'
 );

--- a/src/fsd/1-pages/plan-war-defense-2/deployment-zone.tsx
+++ b/src/fsd/1-pages/plan-war-defense-2/deployment-zone.tsx
@@ -47,26 +47,28 @@ export const DeploymentZone = ({
                     onSelect={onSelectTeam}
                 />
             </div>
-            {team && (
-                <TeamFlow
-                    chars={(
-                        team.chars
-                            .map((id: string) => chars.find(x => x.snowprintId === id))
-                            .filter(x => x !== undefined) ?? []
-                    ).map(x => Teams2Service.capCharacterAtRarity(x, rarityCap))}
-                    mows={
-                        team.mows
-                            ?.map((id: string) => mows.find(x => x.snowprintId === id))
-                            .filter(x => x !== undefined)
-                            .map(x => Teams2Service.capMowAtRarity(x, rarityCap)) ?? []
-                    }
-                    flexIndex={team.flexIndex}
-                    onCharClicked={() => {}}
-                    onMowClicked={() => {}}
-                    sizeMod={sizeMod}
-                    disabledUnits={[]}
-                />
-            )}
+            <div style={{ minHeight: 230 * sizeMod }} className="flex w-full items-center justify-center">
+                {team && (
+                    <TeamFlow
+                        chars={(
+                            team.chars
+                                .map((id: string) => chars.find(x => x.snowprintId === id))
+                                .filter(x => x !== undefined) ?? []
+                        ).map(x => Teams2Service.capCharacterAtRarity(x, rarityCap))}
+                        mows={
+                            team.mows
+                                ?.map((id: string) => mows.find(x => x.snowprintId === id))
+                                .filter(x => x !== undefined)
+                                .map(x => Teams2Service.capMowAtRarity(x, rarityCap)) ?? []
+                        }
+                        flexIndex={team.flexIndex}
+                        onCharClicked={() => {}}
+                        onMowClicked={() => {}}
+                        sizeMod={sizeMod}
+                        disabledUnits={[]}
+                    />
+                )}
+            </div>
         </div>
     );
 };

--- a/src/fsd/1-pages/plan-war-defense-2/deployment-zone.tsx
+++ b/src/fsd/1-pages/plan-war-defense-2/deployment-zone.tsx
@@ -1,0 +1,72 @@
+/* eslint-disable boundaries/element-types */
+/* eslint-disable import-x/no-internal-modules */
+
+import { Rarity } from '@/fsd/5-shared/model';
+import { RarityIcon } from '@/fsd/5-shared/ui/icons';
+
+import { ICharacter2 } from '@/fsd/4-entities/character/@x/unit';
+import { IMow2 } from '@/fsd/4-entities/mow';
+
+import { ITeam2 } from '../plan-teams2/models';
+import { TeamFlow } from '../plan-teams2/team-flow';
+import { Teams2Service } from '../plan-teams2/teams2.service';
+
+import { TeamDropdown } from './team-dropdown';
+
+interface Props {
+    rarityCap: Rarity;
+    chars: ICharacter2[];
+    teams: ITeam2[];
+    disabledTeamNames: string[];
+    mows: IMow2[];
+    team: ITeam2 | undefined;
+    onSelectTeam: (teamName: string) => void;
+    sizeMod?: number;
+}
+
+export const DeploymentZone = ({
+    rarityCap,
+    chars,
+    mows,
+    teams,
+    disabledTeamNames,
+    team,
+    onSelectTeam,
+    sizeMod = 1,
+}: Props) => {
+    return (
+        <div className="flex min-w-[400px] flex-col items-center gap-2 rounded-md border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-800">
+            <div className="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-200">
+                <span>Rarity Cap:</span> <RarityIcon rarity={rarityCap} />
+                <TeamDropdown
+                    teams={teams}
+                    chars={chars}
+                    mows={mows}
+                    selectedTeamName={team?.name}
+                    disabledTeamNames={disabledTeamNames}
+                    onSelect={onSelectTeam}
+                />
+            </div>
+            {team && (
+                <TeamFlow
+                    chars={(
+                        team.chars
+                            .map((id: string) => chars.find(x => x.snowprintId === id))
+                            .filter(x => x !== undefined) ?? []
+                    ).map(x => Teams2Service.capCharacterAtRarity(x, rarityCap))}
+                    mows={
+                        team.mows
+                            ?.map((id: string) => mows.find(x => x.snowprintId === id))
+                            .filter(x => x !== undefined)
+                            .map(x => Teams2Service.capMowAtRarity(x, rarityCap)) ?? []
+                    }
+                    flexIndex={team.flexIndex}
+                    onCharClicked={() => {}}
+                    onMowClicked={() => {}}
+                    sizeMod={sizeMod}
+                    disabledUnits={[]}
+                />
+            )}
+        </div>
+    );
+};

--- a/src/fsd/1-pages/plan-war-defense-2/models.ts
+++ b/src/fsd/1-pages/plan-war-defense-2/models.ts
@@ -1,0 +1,8 @@
+export interface WarDefense2State {
+    zoneLevel?: number;
+    team1Name?: string;
+    team2Name?: string;
+    team3Name?: string;
+    team4Name?: string;
+    team5Name?: string;
+}

--- a/src/fsd/1-pages/plan-war-defense-2/team-dropdown.tsx
+++ b/src/fsd/1-pages/plan-war-defense-2/team-dropdown.tsx
@@ -1,0 +1,113 @@
+/* eslint-disable import-x/no-internal-modules */
+/* eslint-disable boundaries/element-types */
+import { Button, Menu, MenuItem, Box } from '@mui/material';
+import React, { useState } from 'react';
+
+import { UnitShardIcon } from '@/fsd/5-shared/ui/icons/unit-shard.icon';
+
+import { ICharacter2 } from '@/fsd/4-entities/character/@x/unit';
+import { IMow2 } from '@/fsd/4-entities/mow';
+
+import { ITeam2 } from '../plan-teams2/models';
+
+interface Props {
+    teams: ITeam2[];
+    chars: ICharacter2[];
+    mows: IMow2[];
+    disabledTeamNames: string[];
+    selectedTeamName?: string;
+    onSelect: (teamName: string) => void;
+}
+
+export const TeamDropdown: React.FC<Props> = ({
+    teams,
+    chars,
+    mows,
+    disabledTeamNames,
+    selectedTeamName,
+    onSelect,
+}) => {
+    const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+
+    const open = Boolean(anchorEl);
+
+    const handleOpen = (e: React.MouseEvent<HTMLElement>) => setAnchorEl(e.currentTarget);
+    const handleClose = () => setAnchorEl(null);
+
+    const handleSelect = (teamName: string) => {
+        onSelect(teamName);
+        handleClose();
+    };
+
+    const renderTeamIcons = (team: ITeam2) => {
+        const flexIndex = team.flexIndex ?? team.chars.length;
+        const core = team.chars.slice(0, flexIndex);
+        const flex = team.chars.slice(flexIndex);
+
+        return (
+            <Box className="flex items-center">
+                <Box className="flex items-center gap-1">
+                    {core.map(id => {
+                        const c = chars.find(x => x.snowprintId === id);
+                        return <UnitShardIcon key={id} icon={c?.roundIcon ?? ''} name={id} height={28} width={28} />;
+                    })}
+                </Box>
+
+                {flex.length > 0 && <Box className="mx-1" />}
+
+                {flex.length > 0 && (
+                    <Box className="flex items-center gap-1">
+                        {flex.map(id => {
+                            const c = chars.find(x => x.snowprintId === id);
+                            return (
+                                <UnitShardIcon key={id} icon={c?.roundIcon ?? ''} name={id} height={28} width={28} />
+                            );
+                        })}
+                    </Box>
+                )}
+
+                {team.mows && team.mows.length > 0 && <Box className="mx-1" />}
+
+                {team.mows && team.mows.length > 0 && (
+                    <Box className="flex items-center gap-1">
+                        {team.mows.map(mowId => {
+                            const m = mows.find(x => x.snowprintId === mowId);
+                            return (
+                                <UnitShardIcon
+                                    key={mowId}
+                                    icon={m?.roundIcon ?? ''}
+                                    name={mowId}
+                                    height={28}
+                                    width={28}
+                                />
+                            );
+                        })}
+                    </Box>
+                )}
+            </Box>
+        );
+    };
+
+    return (
+        <div className="gap-4">
+            <Button variant="text" onClick={handleOpen}>
+                {selectedTeamName ?? 'SELECT A TEAM'}
+            </Button>
+            <Menu anchorEl={anchorEl} open={open} onClose={handleClose}>
+                {teams.map(team => (
+                    <MenuItem
+                        key={team.name}
+                        onClick={() => handleSelect(team.name)}
+                        disabled={disabledTeamNames.includes(team.name)}>
+                        <Box className="flex w-full items-center justify-between gap-2">
+                            <Box className="text-sm">{team.name}</Box>
+                            <Box>{renderTeamIcons(team)}</Box>
+                        </Box>
+                    </MenuItem>
+                ))}
+            </Menu>
+        </div>
+    );
+};
+
+export default TeamDropdown;

--- a/src/fsd/1-pages/plan-war-defense-2/team-dropdown.tsx
+++ b/src/fsd/1-pages/plan-war-defense-2/team-dropdown.tsx
@@ -94,6 +94,15 @@ export const TeamDropdown: React.FC<Props> = ({
                 {selectedTeamName ?? 'SELECT A TEAM'}
             </Button>
             <Menu anchorEl={anchorEl} open={open} onClose={handleClose}>
+                <MenuItem
+                    onClick={() => {
+                        onSelect(undefined as unknown as string);
+                        handleClose();
+                    }}>
+                    <Box className="flex w-full items-center justify-between gap-2">
+                        <Box className="text-sm text-red-600 dark:text-red-300">CLEAR</Box>
+                    </Box>
+                </MenuItem>
                 {teams.map(team => (
                     <MenuItem
                         key={team.name}

--- a/src/fsd/1-pages/plan-war-defense-2/war-defense2.menu-item.tsx
+++ b/src/fsd/1-pages/plan-war-defense-2/war-defense2.menu-item.tsx
@@ -3,4 +3,4 @@ import GroupsIcon from '@mui/icons-material/Groups';
 // eslint-disable-next-line import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure
 import { MenuItem } from '@/models/menu-item';
 
-export const warOffense2MenuItem = new MenuItem('Offense 2', <GroupsIcon />, '/plan/waroffense2');
+export const warDefense2MenuItem = new MenuItem('Defense 2 (Under Construction)', <GroupsIcon />, '/plan/wardefense2');

--- a/src/fsd/1-pages/plan-war-defense-2/war-defense2.route.tsx
+++ b/src/fsd/1-pages/plan-war-defense-2/war-defense2.route.tsx
@@ -1,0 +1,9 @@
+import { RouteObject } from 'react-router-dom';
+
+export const warDefense2Route: RouteObject = {
+    path: 'plan/wardefense2',
+    async lazy() {
+        const { WarDefense2 } = await import('./war-defense2');
+        return { Component: WarDefense2 };
+    },
+};

--- a/src/fsd/1-pages/plan-war-defense-2/war-defense2.tsx
+++ b/src/fsd/1-pages/plan-war-defense-2/war-defense2.tsx
@@ -1,0 +1,152 @@
+/* eslint-disable boundaries/element-types */
+/* eslint-disable import-x/no-internal-modules */
+import { FormControl, Select, MenuItem, Box } from '@mui/material';
+import { cloneDeep } from 'lodash';
+import { useContext, useEffect, useState } from 'react';
+import { isMobile } from 'react-device-detect';
+import { Link } from 'react-router-dom';
+
+import { DispatchContext, StoreContext } from '@/reducers/store.provider';
+
+import { Rarity } from '@/fsd/5-shared/model';
+import { RarityIcon } from '@/fsd/5-shared/ui/icons';
+
+import { CharactersService, ICharacter2 } from '@/fsd/4-entities/character';
+import { IMow2, MowsService } from '@/fsd/4-entities/mow';
+
+import { RosterSnapshotsAssetsProvider } from '../input-roster-snapshots/roster-snapshots-assets-provider';
+import { RosterSnapshotsMagnificationSlider } from '../input-roster-snapshots/roster-snapshots-magnification-slider';
+
+import { DeploymentZone } from './deployment-zone';
+
+interface Zone {
+    threeSlotRarity: Rarity;
+    twoSlotRarity: Rarity;
+}
+
+const ZONES: Zone[] = [
+    { threeSlotRarity: Rarity.Uncommon, twoSlotRarity: Rarity.Rare },
+    { threeSlotRarity: Rarity.Rare, twoSlotRarity: Rarity.Epic },
+    { threeSlotRarity: Rarity.Epic, twoSlotRarity: Rarity.Legendary },
+    { threeSlotRarity: Rarity.Legendary, twoSlotRarity: Rarity.Mythic },
+];
+
+export const WarDefense2 = () => {
+    const dispatch = useContext(DispatchContext);
+    const { teams2, characters: unresolvedCharacters, mows: unresolvedMows, warDefense2 } = useContext(StoreContext);
+    const [resolvedChars, setResolvedChars] = useState<ICharacter2[]>([]);
+    const [resolvedMows, setResolvedMows] = useState<IMow2[]>([]);
+
+    useEffect(() => {
+        setResolvedChars(CharactersService.resolveStoredCharacters(unresolvedCharacters));
+        setResolvedMows(MowsService.resolveAllFromStorage(unresolvedMows));
+    }, [unresolvedCharacters, unresolvedMows]);
+    const [sizeMod, setSizeMod] = useState(isMobile ? 0.5 : 1);
+
+    const handleSelectedTeam = (index: number, teamName: string) => {
+        const newDefense = cloneDeep(warDefense2);
+        if (index === 0) newDefense.team1Name = teamName;
+        else if (index === 1) newDefense.team2Name = teamName;
+        else if (index === 2) newDefense.team3Name = teamName;
+        else if (index === 3) newDefense.team4Name = teamName;
+        else if (index === 4) newDefense.team5Name = teamName;
+        dispatch.warDefense2({ type: 'Set', value: newDefense });
+    };
+
+    const handleZoneIndexChange = (index: number) => {
+        const newDefense = cloneDeep(warDefense2);
+        newDefense.zoneLevel = index;
+        dispatch.warDefense2({ type: 'Set', value: newDefense });
+    };
+
+    const selectedTeams = [
+        warDefense2.team1Name,
+        warDefense2.team2Name,
+        warDefense2.team3Name,
+        warDefense2.team4Name,
+        warDefense2.team5Name,
+    ];
+
+    return (
+        <RosterSnapshotsAssetsProvider>
+            <div className="gap-4">
+                <div className="mb-4 flex items-center justify-center gap-4">
+                    <Link
+                        to={isMobile ? '/mobile/plan/waroffense2' : '/plan/waroffense2'}
+                        className="rounded-lg bg-blue-600 px-3 py-1.5 text-sm font-semibold text-white no-underline transition hover:bg-blue-700">
+                        Go to Offense
+                    </Link>
+
+                    <Link
+                        to={isMobile ? '/mobile/plan/teams2' : '/plan/teams2'}
+                        className="rounded-lg bg-blue-600 px-3 py-1.5 text-sm font-semibold text-white no-underline transition hover:bg-blue-700">
+                        Go to Teams
+                    </Link>
+
+                    <span className="text-xs font-semibold tracking-wider text-slate-500 uppercase dark:text-slate-400">
+                        Battlefield Zone
+                    </span>
+
+                    <FormControl sx={{ minWidth: 160, width: 'auto' }}>
+                        <Select
+                            size="small"
+                            value={warDefense2.zoneLevel ?? 0}
+                            onChange={e => handleZoneIndexChange(Number(e.target.value))}
+                            renderValue={value => {
+                                const z = ZONES[Number(value)];
+                                return (
+                                    <Box className="flex items-center gap-1">
+                                        <RarityIcon rarity={z.twoSlotRarity} />
+                                        <RarityIcon rarity={z.twoSlotRarity} />
+                                        <RarityIcon rarity={z.threeSlotRarity} />
+                                        <RarityIcon rarity={z.threeSlotRarity} />
+                                        <RarityIcon rarity={z.threeSlotRarity} />
+                                    </Box>
+                                );
+                            }}>
+                            {ZONES.map((zone, index) => (
+                                <MenuItem key={index} value={index}>
+                                    <Box className="flex items-center gap-1">
+                                        <RarityIcon rarity={zone.twoSlotRarity} />
+                                        <RarityIcon rarity={zone.twoSlotRarity} />
+                                        <RarityIcon rarity={zone.threeSlotRarity} />
+                                        <RarityIcon rarity={zone.threeSlotRarity} />
+                                        <RarityIcon rarity={zone.threeSlotRarity} />
+                                    </Box>
+                                </MenuItem>
+                            ))}
+                        </Select>
+                    </FormControl>
+
+                    <div className="flex items-start justify-start">
+                        <RosterSnapshotsMagnificationSlider sizeMod={sizeMod} setSizeMod={setSizeMod} />
+                    </div>
+                </div>
+                <div>
+                    <div className="flex flex-col items-center gap-4">
+                        {[0, 1, 2, 3, 4].map(i => (
+                            <DeploymentZone
+                                key={`war-defense-team-${i}`}
+                                rarityCap={
+                                    i < 2
+                                        ? ZONES[warDefense2.zoneLevel ?? 0].twoSlotRarity
+                                        : ZONES[warDefense2.zoneLevel ?? 0].threeSlotRarity
+                                }
+                                teams={teams2.filter(t => t.warDefense)}
+                                disabledTeamNames={teams2
+                                    .filter(t => t.warDefense)
+                                    .filter(t => t.name !== selectedTeams[i] && selectedTeams.includes(t.name))
+                                    .map(t => t.name)}
+                                team={teams2.find(t => t.name === selectedTeams[i])}
+                                chars={resolvedChars}
+                                mows={resolvedMows}
+                                onSelectTeam={(teamName: string) => handleSelectedTeam(i, teamName)}
+                                sizeMod={sizeMod}
+                            />
+                        ))}
+                    </div>
+                </div>
+            </div>
+        </RosterSnapshotsAssetsProvider>
+    );
+};

--- a/src/fsd/1-pages/plan-war-defense-2/war-defense2.tsx
+++ b/src/fsd/1-pages/plan-war-defense-2/war-defense2.tsx
@@ -123,7 +123,7 @@ export const WarDefense2 = () => {
                     </div>
                 </div>
                 <div>
-                    <div className="flex flex-col items-center gap-4">
+                    <div className="flex flex-wrap items-center justify-center gap-4">
                         {[0, 1, 2, 3, 4].map(i => (
                             <DeploymentZone
                                 key={`war-defense-team-${i}`}

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -264,6 +264,7 @@ export const defaultData: IPersonalData2 = {
     mows: [],
     teams: [],
     teams2: [],
+    warDefense2: {},
     warOffense2: { deployedCharacters: [], deployedMows: [] },
     characters: [
         {

--- a/src/models/global-state.ts
+++ b/src/models/global-state.ts
@@ -13,6 +13,7 @@ import { XpUseState } from '@/fsd/1-pages/input-resources/models';
 import { IRosterSnapshotsState } from '@/fsd/1-pages/input-roster-snapshots/models';
 import { XpIncomeState } from '@/fsd/1-pages/input-xp-income';
 import { ITeam2 } from '@/fsd/1-pages/plan-teams2/models';
+import { WarDefense2State } from '@/fsd/1-pages/plan-war-defense-2/models';
 import { WarOffense2State } from '@/fsd/1-pages/plan-war-offense2/models';
 
 import { defaultData, rankToLevel, rankToRarity } from './constants';
@@ -50,6 +51,7 @@ export class GlobalState implements IGlobalState {
     readonly goals: IPersonalGoal[];
     readonly teams: IPersonalTeam[];
     readonly teams2: ITeam2[];
+    readonly warDefense2: WarDefense2State;
     readonly warOffense2: WarOffense2State;
     readonly leProgress: LegendaryEventData<ILreProgressDto>;
     readonly leSelectedTeams: LegendaryEventData<ILegendaryEventSelectedTeams>;
@@ -92,6 +94,7 @@ export class GlobalState implements IGlobalState {
         this.guild = personalData.guild ?? defaultData.guild;
         this.teams = personalData.teams ?? defaultData.teams;
         this.teams2 = personalData.teams2 ?? defaultData.teams2;
+        this.warDefense2 = personalData.warDefense2 ?? defaultData.warDefense2;
         this.warOffense2 = personalData.warOffense2 ?? defaultData.warOffense2;
         this.xpIncome = personalData.xpIncome ?? defaultData.xpIncome;
         this.xpUse = personalData.xpUse ?? defaultData.xpUse;
@@ -316,6 +319,7 @@ export class GlobalState implements IGlobalState {
             gameModeTokens: value.gameModeTokens,
             teams: value.teams,
             teams2: value.teams2,
+            warDefense2: value.warDefense2,
             warOffense2: value.warOffense2,
         };
     }

--- a/src/models/interfaces.ts
+++ b/src/models/interfaces.ts
@@ -4,6 +4,7 @@ import { GameModeTokensAction } from '@/reducers/game-mode-tokens-reducer';
 import { LeSettingsAction } from '@/reducers/le-settings.reducer';
 import { RosterSnapshotsAction } from '@/reducers/roster-snapshots-reducer';
 import { Teams2Action } from '@/reducers/teams2.reducer';
+import { WarDefense2Action } from '@/reducers/war-defense2.reducer';
 import { XpIncomeAction } from '@/reducers/xp-income-reducer';
 import { XpUseAction } from '@/reducers/xp-use-reducer';
 import { GuildAction } from 'src/reducers/guildReducer';
@@ -36,6 +37,7 @@ import { XpUseState } from '@/fsd/1-pages/input-resources';
 import { IRosterSnapshotsState } from '@/fsd/1-pages/input-roster-snapshots/models';
 import { XpIncomeState } from '@/fsd/1-pages/input-xp-income';
 import { ITeam2 } from '@/fsd/1-pages/plan-teams2/models';
+import { WarDefense2State } from '@/fsd/1-pages/plan-war-defense-2/models';
 import { WarOffense2State } from '@/fsd/1-pages/plan-war-offense2/models';
 
 import { AutoTeamsPreferencesAction } from '../reducers/auto-teams-settings.reducer';
@@ -65,6 +67,7 @@ export interface IPersonalData {
     charactersPriorityList: string[];
     goals: IPersonalGoal[];
     teams2: ITeam2[];
+    warDefense2: WarDefense2State;
     warOffense2: WarOffense2State;
     legendaryEvents: ILegendaryEventsData | undefined;
     legendaryEvents3: ILegendaryEventsData3 | undefined;
@@ -88,6 +91,7 @@ export interface IGlobalState {
     goals: IPersonalGoal[];
     teams: IPersonalTeam[];
     teams2: ITeam2[];
+    warDefense2: WarDefense2State;
     warOffense2: WarOffense2State;
     selectedTeamOrder: ISelectedTeamsOrdering;
     leSelectedTeams: LegendaryEventData<ILegendaryEventSelectedTeams>;
@@ -110,6 +114,7 @@ export interface IDispatchContext {
     mows: React.Dispatch<MowsAction>;
     teams: React.Dispatch<TeamsAction>;
     teams2: React.Dispatch<Teams2Action>;
+    warDefense2: React.Dispatch<WarDefense2Action>;
     warOffense2: React.Dispatch<WarOffense2Action>;
     viewPreferences: React.Dispatch<ViewPreferencesAction>;
     dailyRaidsPreferences: React.Dispatch<DailyRaidsPreferencesAction>;
@@ -146,6 +151,7 @@ export interface IPersonalData2 {
     goals: IPersonalGoal[];
     teams: IPersonalTeam[];
     teams2: ITeam2[];
+    warDefense2: WarDefense2State;
     warOffense2: WarOffense2State;
     leTeams: LegendaryEventData<ILegendaryEventSelectedTeams>;
     leProgress: LegendaryEventData<ILreProgressDto>;

--- a/src/models/menu-items.tsx
+++ b/src/models/menu-items.tsx
@@ -29,6 +29,7 @@ import { mowLookupMenuItem } from '@/fsd/1-pages/learn-mow';
 import { campaignProgressionMenuItem } from '@/fsd/1-pages/plan-campaign-progression';
 import { activeLreMenuItems, inactiveLreMenuItems } from '@/fsd/1-pages/plan-lre';
 import { teams2MenuItem } from '@/fsd/1-pages/plan-teams2/teams2.menu-item';
+import { warDefense2MenuItem } from '@/fsd/1-pages/plan-war-defense-2/war-defense2.menu-item';
 import { warOffense2MenuItem } from '@/fsd/1-pages/plan-war-offense2/war-offense2.menu-item';
 import { teamsMenuItem } from '@/fsd/1-pages/teams/teams.menu-item';
 import { wyoMenuItem } from '@/fsd/1-pages/who-you-own/who-you-own.menu-item';
@@ -68,6 +69,7 @@ export const menuItemById = {
     campaignProgression: campaignProgressionMenuItem,
     rosterSnapshots: rosterSnapshotsMenuItem,
     teams2: teams2MenuItem,
+    warDefense2: warDefense2MenuItem,
     warOffense2: warOffense2MenuItem,
     home: new MenuItemTP('Home', <HomeIcon />, '/home', 'Tacticus Planner'),
     contacts: new MenuItemTP('Contacts', <ContactEmergencyIcon />, '/contacts'),
@@ -103,6 +105,7 @@ export const planSubMenuWeb: MenuItemTP[] = [
     new MenuItemTP('Guild War', menuItemById['defense'].icon, '', '', '', [
         menuItemById['defense'],
         menuItemById['offense'],
+        menuItemById['warDefense2'],
         menuItemById['warOffense2'],
         menuItemById['zones'],
     ]),
@@ -118,6 +121,7 @@ export const planSubMenu: MenuItemTP[] = [
     menuItemById['teams'],
     menuItemById['defense'],
     menuItemById['offense'],
+    menuItemById['warDefense2'],
     menuItemById['warOffense2'],
     menuItemById['zones'],
     menuItemById['leMasterTable'],

--- a/src/reducers/store.provider2.tsx
+++ b/src/reducers/store.provider2.tsx
@@ -10,6 +10,7 @@ import { guildWarReducer } from 'src/reducers/guildWarReducer';
 import { mowsReducer } from 'src/reducers/mows.reducer';
 import { teamsReducer } from 'src/reducers/teams.reducer';
 import { teams2Reducer } from 'src/reducers/teams2.reducer';
+import { warDefense2Reducer } from 'src/reducers/war-defense2.reducer';
 import { warOffense2Reducer } from 'src/reducers/war-offense2.reducer';
 
 import { IErrorResponse } from '@/fsd/5-shared/api';
@@ -63,6 +64,7 @@ export const StoreProvider = ({ children }: React.PropsWithChildren) => {
         gameModeTokensActionReducer,
         globalState.gameModeTokens
     );
+    const [warDefense2, dispatchWarDefense2] = React.useReducer(warDefense2Reducer, globalState.warDefense2);
     const [warOffense2, dispatchWarOffense2] = React.useReducer(warOffense2Reducer, globalState.warOffense2);
     const [viewPreferences, dispatchViewPreferences] = React.useReducer(
         viewPreferencesReducer,
@@ -123,6 +125,7 @@ export const StoreProvider = ({ children }: React.PropsWithChildren) => {
             mows: wrapDispatch(dispatchMows),
             teams: wrapDispatch(dispatchTeams),
             teams2: wrapDispatch(dispatchTeams2),
+            warDefense2: wrapDispatch(dispatchWarDefense2),
             warOffense2: wrapDispatch(dispatchWarOffense2),
             goals: wrapDispatch(dispatchGoals),
             viewPreferences: wrapDispatch(dispatchViewPreferences),
@@ -148,6 +151,7 @@ export const StoreProvider = ({ children }: React.PropsWithChildren) => {
                 dispatchGoals({ type: 'Set', value: data.goals });
                 dispatchTeams({ type: 'Set', value: data.teams });
                 dispatchTeams2({ type: 'Set', value: data.teams2 });
+                dispatchWarDefense2({ type: 'Set', value: data.warDefense2 });
                 dispatchWarOffense2({ type: 'Set', value: data.warOffense2 });
                 dispatchViewPreferences({ type: 'Set', value: data.viewPreferences });
                 dispatchDailyRaidsPreferences({ type: 'Set', value: data.dailyRaidsPreferences });
@@ -194,6 +198,7 @@ export const StoreProvider = ({ children }: React.PropsWithChildren) => {
             dispatchGuild,
             dispatchTeams,
             dispatchTeams2,
+            dispatchWarDefense2,
             dispatchWarOffense2,
             dispatchXpIncome,
             dispatchXpUse,
@@ -213,6 +218,7 @@ export const StoreProvider = ({ children }: React.PropsWithChildren) => {
             mows,
             teams,
             teams2,
+            warDefense2,
             warOffense2,
             viewPreferences,
             autoTeamsPreferences,

--- a/src/reducers/war-defense2.reducer.ts
+++ b/src/reducers/war-defense2.reducer.ts
@@ -1,0 +1,16 @@
+import { WarDefense2State } from '@/fsd/1-pages/plan-war-defense-2/models';
+
+import { SetStateAction } from '../models/interfaces';
+
+export type WarDefense2Action = SetStateAction<WarDefense2State>;
+
+export const warDefense2Reducer = (_state: WarDefense2State, action: WarDefense2Action) => {
+    switch (action.type) {
+        case 'Set': {
+            return action.value;
+        }
+        default: {
+            throw new Error();
+        }
+    }
+};

--- a/src/services/personal-data.service.ts
+++ b/src/services/personal-data.service.ts
@@ -19,6 +19,7 @@ import { XpUseState } from '@/fsd/1-pages/input-resources/models';
 import { IRosterSnapshotsState } from '@/fsd/1-pages/input-roster-snapshots/models';
 import { XpIncomeState } from '@/fsd/1-pages/input-xp-income/models';
 import { ITeam2 } from '@/fsd/1-pages/plan-teams2/models';
+import { WarDefense2State } from '@/fsd/1-pages/plan-war-defense-2/models';
 import { WarOffense2State } from '@/fsd/1-pages/plan-war-offense2/models';
 
 import { defaultData } from '../models/constants';
@@ -79,6 +80,7 @@ export class PersonalDataLocalStorage {
                 mows: this.getItem<IMowDb[]>('mows') ?? defaultData.mows,
                 teams: this.getItem<IPersonalTeam[]>('teams') ?? defaultData.teams,
                 teams2: this.getItem<ITeam2[]>('teams2') ?? defaultData.teams2,
+                warDefense2: this.getItem<WarDefense2State>('warDefense2') ?? defaultData.warDefense2,
                 warOffense2: this.getItem<WarOffense2State>('warOffense2') ?? defaultData.warOffense2,
                 goals: this.getItem<IPersonalGoal[]>('goals') ?? defaultData.goals,
                 selectedTeamOrder:
@@ -258,6 +260,7 @@ export const convertData = (v1Data: IPersonalData | IPersonalData2): IPersonalDa
             xpUse: defaultData.xpUse,
             teams: defaultData.teams,
             teams2: defaultData.teams2,
+            warDefense2: defaultData.warDefense2,
             warOffense2: defaultData.warOffense2,
             rosterSnapshots: defaultData.rosterSnapshots,
             gameModeTokens: defaultData.gameModeTokens,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Defense 2 war planning page featuring five deployment zones with team selection and zone level adjustment controls.

* **Updates**
  * Updated menu labels for clarity ("Offense" now displays end-of-life date; "War Offense 2" renamed to "Offense 2").
  * Added Defense 2 to the Guild War planning menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->