### PR TITLE
Add support for hero quests

### DIFF
--- a/src/fsd/0-app/routing/desktop-routes.tsx
+++ b/src/fsd/0-app/routing/desktop-routes.tsx
@@ -17,6 +17,7 @@ import { dirtyDozenLazyRoute } from '@/fsd/1-pages/learn-dirty-dozen';
 import { mowLookupDesktopLazyRoute } from '@/fsd/1-pages/learn-mow';
 import { campaignProgressionLazyRoute } from '@/fsd/1-pages/plan-campaign-progression';
 import { lreLazyRoute } from '@/fsd/1-pages/plan-lre';
+import { questsRoute } from '@/fsd/1-pages/plan-quests/quests.route';
 import { teams2Route } from '@/fsd/1-pages/plan-teams2/teams2.route';
 import { warDefense2Route } from '@/fsd/1-pages/plan-war-defense-2/war-defense2.route';
 import { warOffense2Route } from '@/fsd/1-pages/plan-war-offense2/war-offense2.route';
@@ -73,6 +74,7 @@ export const globalPlanRoutes: RouteObject[] = [
         },
     },
     campaignProgressionLazyRoute,
+    questsRoute,
 ];
 
 export const globalLearnRoutes: RouteObject[] = [

--- a/src/fsd/1-pages/learn-campaigns/campaign-battle-enemies.tsx
+++ b/src/fsd/1-pages/learn-campaigns/campaign-battle-enemies.tsx
@@ -101,6 +101,7 @@ export const CampaignBattleEnemies: React.FC<Props> = ({ keyPrefix, battleId, en
         let left = horizontalMargin;
         let top = verticalMargin;
         let enemiesInRow = 0;
+        let enemyIndex = 0;
         const elems: JSX.Element[] = [];
         enemies.forEach(enemy => {
             // Pre-resolve NPC data for the click handler
@@ -113,7 +114,7 @@ export const CampaignBattleEnemies: React.FC<Props> = ({ keyPrefix, battleId, en
             for (let i = 0; i < enemy.count; i++) {
                 elems.push(
                     <button
-                        key={keyPrefix + battleId + '-' + (row * maxPerRow + i) + '-' + enemyId}
+                        key={keyPrefix + battleId + '-' + enemyIndex++ + '-' + enemyId}
                         className="absolute cursor-pointer border-none bg-transparent p-0 transition-all hover:brightness-110 focus:outline-none"
                         style={{ left, top, width: frameWidth, height: frameHeight }}
                         onClick={() =>

--- a/src/fsd/1-pages/plan-quests/quests.menu-item.tsx
+++ b/src/fsd/1-pages/plan-quests/quests.menu-item.tsx
@@ -1,0 +1,6 @@
+import GroupsIcon from '@mui/icons-material/Groups';
+
+// eslint-disable-next-line import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure
+import { MenuItem } from '@/models/menu-item';
+
+export const questsMenuItem = new MenuItem('Quests', <GroupsIcon />, '/plan/quests');

--- a/src/fsd/1-pages/plan-quests/quests.route.tsx
+++ b/src/fsd/1-pages/plan-quests/quests.route.tsx
@@ -1,0 +1,9 @@
+import { RouteObject } from 'react-router-dom';
+
+export const questsRoute: RouteObject = {
+    path: 'plan/quests',
+    async lazy() {
+        const { Quests } = await import('./quests');
+        return { Component: Quests };
+    },
+};

--- a/src/fsd/1-pages/plan-quests/quests.tsx
+++ b/src/fsd/1-pages/plan-quests/quests.tsx
@@ -1,0 +1,285 @@
+/* eslint-disable import-x/no-internal-modules */
+import { ChevronDown, ChevronRight, Users } from 'lucide-react';
+import { useContext, useMemo, useState } from 'react';
+
+import { StoreContext } from '@/reducers/store.provider';
+
+import { Rarity, RarityMapper, RarityString } from '@/fsd/5-shared/model';
+import { UnitShardIcon } from '@/fsd/5-shared/ui/icons';
+
+import { CharactersService, ICharacter2 } from '@/fsd/4-entities/character';
+import { FactionImage } from '@/fsd/4-entities/faction';
+import { IMow2, MowsService } from '@/fsd/4-entities/mow';
+import { INpcData, INpcStats } from '@/fsd/4-entities/npc/model';
+import { NpcPortrait } from '@/fsd/4-entities/npc/npc-portrait';
+import { NpcService } from '@/fsd/4-entities/npc/npc-service';
+import questJson from '@/fsd/4-entities/quests/data/heroQuests.json';
+import { IUnit, UnitsAutocomplete } from '@/fsd/4-entities/unit';
+import { UpgradesService as FsdUpgradesService, UpgradeImage } from '@/fsd/4-entities/upgrade';
+
+import { GoalsService } from '@/fsd/3-features/goals/goals.service';
+import { UpgradesService } from '@/fsd/3-features/goals/upgrades.service';
+
+// Type definition for the data we extract from the string
+interface ResolvedEnemyData {
+    id: string;
+    npc: INpcData;
+    stats: INpcStats; // The specific stats for this level
+}
+
+export const Quests = () => {
+    const {
+        characters: unresolvedCharacters,
+        campaignsProgress,
+        dailyRaids,
+        dailyRaidsPreferences,
+        goals,
+        inventory,
+        mows: unresolvedMows,
+    } = useContext(StoreContext);
+
+    const [questId, setQuestId] = useState<string>(questJson[0].unitId);
+    const [expandedTiers, setExpandedTiers] = useState<Record<number, boolean>>({});
+    const [expandedBattles, setExpandedBattles] = useState<Record<string, boolean>>({});
+
+    // Memoize resolution to avoid heavy logic on every render
+    const chars = useMemo(
+        () => CharactersService.resolveStoredCharacters(unresolvedCharacters),
+        [unresolvedCharacters]
+    );
+    const mows = useMemo(() => MowsService.resolveAllFromStorage(unresolvedMows), [unresolvedMows]);
+    const quest = useMemo(() => questJson.find(q => q.unitId === questId), [questId]);
+    const char = useMemo(
+        () => chars.find(c => c.snowprintId === questId) ?? mows.find(m => m.snowprintId === questId),
+        [chars, mows, questId]
+    );
+
+    const { shardsGoals, upgradeRankOrMowGoals } = GoalsService.prepareGoals(goals, [...chars, ...mows], false);
+
+    const estimatedUpgradesTotal = UpgradesService.getUpgradesEstimatedDays(
+        {
+            dailyEnergy: dailyRaidsPreferences.dailyEnergy,
+            campaignsProgress: campaignsProgress,
+            preferences: {
+                ...dailyRaidsPreferences,
+            },
+            upgrades: inventory.upgrades,
+            completedLocations: dailyRaids.raidedLocations,
+        },
+        chars,
+        mows,
+        ...[upgradeRankOrMowGoals, shardsGoals].flat().filter(x => x.include)
+    );
+
+    // Toggles
+    const toggleTier = (tierIndex: number) => setExpandedTiers(prev => ({ ...prev, [tierIndex]: !prev[tierIndex] }));
+    const toggleBattle = (battleKey: string) =>
+        setExpandedBattles(prev => ({ ...prev, [battleKey]: !prev[battleKey] }));
+
+    const getUpgradeRarity = (upgradeId: string): RarityString => {
+        const upgrade = FsdUpgradesService.getUpgrade(upgradeId);
+        if (!upgrade || upgrade.rarity === 'Shard' || upgrade.rarity === 'Mythic Shard') {
+            return RarityMapper.rarityToRarityString(Rarity.Common);
+        }
+        return RarityMapper.rarityToRarityString(upgrade.rarity as unknown as Rarity);
+    };
+
+    const unitsNeedingUpgrade = (
+        upgradeId: string
+    ): { acquired: number; required: number; units: Array<ICharacter2 | IMow2> } => {
+        const inProgressMat = estimatedUpgradesTotal.inProgressMaterials.find(upgrade => upgrade.id === upgradeId);
+        const blockedMat = estimatedUpgradesTotal.blockedMaterials.find(upgrade => upgrade.id === upgradeId);
+        const acquired = (inProgressMat?.acquiredCount ?? 0) + (blockedMat?.acquiredCount ?? 0);
+        const required = (inProgressMat?.requiredCount ?? 0) + (blockedMat?.requiredCount ?? 0);
+        if (required === 0) return { acquired, required, units: [] };
+        const units = [
+            estimatedUpgradesTotal.inProgressMaterials.find(upgrade => upgrade.id === upgradeId)?.relatedCharacters,
+            estimatedUpgradesTotal.blockedMaterials.find(upgrade => upgrade.id === upgradeId)?.relatedCharacters,
+        ]
+            .flat()
+            .filter(x => x !== undefined);
+        const resolvedChars = units
+            .flat()
+            .filter(x => x !== undefined)
+            .map(charName => chars.find(c => c.shortName === charName))
+            .filter(x => x !== undefined);
+        const resolvedMows = units
+            .flat()
+            .filter(x => x !== undefined)
+            .map(mowName => mows.find(m => m.name === mowName))
+            .filter(x => x !== undefined);
+        return { acquired, required, units: [...resolvedChars, ...resolvedMows] as Array<ICharacter2 | IMow2> };
+    };
+
+    return (
+        <div className="flex flex-col gap-4 p-2 text-slate-900 dark:text-slate-100">
+            {/* Header / Selector */}
+            <div className="flex flex-wrap items-center justify-between gap-4 rounded-lg bg-slate-100 p-4 dark:bg-slate-800">
+                <UnitsAutocomplete<IUnit>
+                    unit={char ?? null}
+                    label="Active Quest"
+                    options={questJson
+                        .map(
+                            q =>
+                                chars.find(c => c.snowprintId === q.unitId) ??
+                                mows.find(m => m.snowprintId === q.unitId)
+                        )
+                        .filter(x => !!x)}
+                    onUnitChange={value => setQuestId(value?.snowprintId ?? '')}
+                />
+
+                {quest && (
+                    <div className="flex items-center gap-4">
+                        <div className="flex flex-col items-end">
+                            <span className="text-xs font-bold uppercase opacity-60">Allowed</span>
+                            <div className="flex gap-1">
+                                {quest.allowedFactions.map(f => (
+                                    <FactionImage key={f} faction={f} />
+                                ))}
+                            </div>
+                        </div>
+                        <div className="flex flex-col items-end border-l border-slate-300 pl-4 dark:border-slate-700">
+                            <span className="text-xs font-bold uppercase opacity-60">Enemies</span>
+                            <div className="flex gap-1">
+                                {quest.enemyFactions.map(f => (
+                                    <FactionImage key={f} faction={f} />
+                                ))}
+                            </div>
+                        </div>
+                    </div>
+                )}
+            </div>
+
+            {/* Tiers List */}
+            <div className="space-y-4">
+                {quest?.tiers.toReversed().map(tier => {
+                    const isTierExpanded = !!expandedTiers[tier.index];
+                    return (
+                        <div
+                            key={tier.index}
+                            className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900">
+                            <button
+                                onClick={() => toggleTier(tier.index)}
+                                className="flex w-full items-center justify-between p-4 transition-colors hover:bg-slate-50 dark:hover:bg-slate-800">
+                                <div className="flex items-center gap-3">
+                                    <div className="rounded-md bg-blue-600 px-3 py-1 text-sm font-bold text-white">
+                                        {RarityMapper.rarityToRarityString(tier.index as unknown as Rarity)} Tier
+                                    </div>
+                                    <span className="text-sm opacity-70">{tier.battles.length} Battles</span>
+                                </div>
+                                {isTierExpanded ? <ChevronDown size={20} /> : <ChevronRight size={20} />}
+                            </button>
+
+                            {/* Battles Content */}
+                            {isTierExpanded && (
+                                <div className="divide-y divide-slate-100 border-t border-slate-200 dark:divide-slate-800 dark:border-slate-700">
+                                    {tier.battles.map(battle => {
+                                        const battleKey = `${quest.unitId}-${tier.index}-${battle.battleNr}`;
+                                        const isBattleExpanded = !!expandedBattles[battleKey];
+                                        const needing = unitsNeedingUpgrade(battle.loot.reward.upgradeId);
+
+                                        return (
+                                            <div key={battleKey} className="flex flex-col">
+                                                {/* Battle Summary Row */}
+                                                <div className="flex flex-wrap items-center justify-between gap-2 p-3">
+                                                    <div className="flex items-center gap-4">
+                                                        <span className="min-w-[70px] text-sm font-medium">
+                                                            Battle {battle.battleNr}
+                                                        </span>
+                                                        <div className="flex items-center gap-2 rounded-md bg-slate-100 px-2 py-1 dark:bg-slate-800">
+                                                            <UpgradeImage
+                                                                material={battle.loot.reward.upgradeId}
+                                                                iconPath={
+                                                                    FsdUpgradesService.getUpgrade(
+                                                                        battle.loot.reward.upgradeId
+                                                                    )?.iconPath ?? ''
+                                                                }
+                                                                rarity={getUpgradeRarity(battle.loot.reward.upgradeId)}
+                                                            />
+                                                            <span
+                                                                className={`text-xs font-bold ${needing.acquired >= needing.required ? 'text-green-500' : ''}`}>
+                                                                {needing.acquired} / {needing.required}
+                                                            </span>
+                                                        </div>
+                                                        <div className="mr-4 flex gap-2">
+                                                            {needing.units.slice(0, 3).map(unit => (
+                                                                <UnitShardIcon
+                                                                    key={unit.snowprintId}
+                                                                    icon={unit?.roundIcon ?? ''}
+                                                                />
+                                                            ))}
+                                                        </div>
+                                                    </div>
+
+                                                    <div className="flex items-center gap-2">
+                                                        <button
+                                                            onClick={() => toggleBattle(battleKey)}
+                                                            className="flex items-center gap-1 text-xs font-semibold tracking-wider text-blue-500 uppercase hover:text-blue-600">
+                                                            <Users size={14} />
+                                                            {isBattleExpanded ? 'Hide Enemies' : 'Show Enemies'}
+                                                        </button>
+                                                    </div>
+                                                </div>
+
+                                                {/* Expandable Enemy Section */}
+                                                {isBattleExpanded && (
+                                                    <div className="bg-slate-50 px-4 pt-2 pb-4 dark:bg-black/20">
+                                                        <div className="flex flex-wrap gap-2 rounded-lg border-2 border-dashed border-slate-200 p-3 dark:border-slate-700">
+                                                            <div className="mb-3 flex flex-wrap items-start gap-x-3 gap-y-6">
+                                                                {battle.enemies.map((enemy, idx) => {
+                                                                    const npc = NpcService.getNpcById(enemy.name);
+                                                                    const index =
+                                                                        (enemy.progressionIndex ?? 1) > 0
+                                                                            ? (enemy.progressionIndex ?? 1) - 1
+                                                                            : 0;
+                                                                    if (
+                                                                        npc === undefined ||
+                                                                        npc.stats.length <= index
+                                                                    ) {
+                                                                        return (
+                                                                            <div
+                                                                                key={idx}
+                                                                                className="text-xs text-red-500">
+                                                                                Error: {enemy.name}
+                                                                            </div>
+                                                                        );
+                                                                    }
+                                                                    const data: ResolvedEnemyData = {
+                                                                        id: enemy.name,
+                                                                        npc,
+                                                                        stats: npc.stats[index],
+                                                                    };
+                                                                    return (
+                                                                        <button
+                                                                            key={idx}
+                                                                            onClick={() => {}}
+                                                                            className="relative h-[75px] w-[60px] cursor-pointer rounded transition-all hover:brightness-110 focus:ring-2 focus:ring-blue-500 focus:outline-none"
+                                                                            style={{
+                                                                                transform: 'scale(0.3)',
+                                                                                transformOrigin: 'top left',
+                                                                            }}
+                                                                            title="Click for details">
+                                                                            <NpcPortrait
+                                                                                id={data.id}
+                                                                                rank={data.stats.rank}
+                                                                                stars={data.stats.rarityStars}
+                                                                            />
+                                                                        </button>
+                                                                    );
+                                                                })}
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                )}
+                                            </div>
+                                        );
+                                    })}
+                                </div>
+                            )}
+                        </div>
+                    );
+                })}
+            </div>
+        </div>
+    );
+};

--- a/src/fsd/4-entities/quests/data/heroQuests.json
+++ b/src/fsd/4-entities/quests/data/heroQuests.json
@@ -1,0 +1,4663 @@
+[
+    {
+        "unitId": "astraDreir",
+        "allowedFactions": ["AstraMilitarum", "Sisterhood", "Ultramarines", "BlackTemplars"],
+        "enemyFactions": ["Tau"],
+        "tiers": [
+            {
+                "index": 0,
+                "battles": [
+                    {
+                        "battleNr": "1",
+                        "lightningVictory": 1,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgArmC003",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 4
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 4
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 4
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 4
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 4
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 4
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 4
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotDamageType",
+                                "ObjectiveTarget": "Flame",
+                                "Score": 100
+                            },
+                            {
+                                "ObjectiveType": "NotTrait",
+                                "ObjectiveTarget": "Flying",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "2",
+                        "lightningVictory": 2,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgHpC017",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "tauNpc3DroneShield",
+                                "progressionIndex": 5
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 4
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 4
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 4
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 4
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 4
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 5
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 5
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotDamageType",
+                                "ObjectiveTarget": "Blast",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "3",
+                        "lightningVictory": 2,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgArmC001",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "tauBossMarksmanLHE",
+                                "progressionIndex": 1
+                            },
+                            {
+                                "name": "tauNpc2DroneSniper",
+                                "progressionIndex": 4
+                            },
+                            {
+                                "name": "tauNpc2DroneSniper",
+                                "progressionIndex": 4
+                            },
+                            {
+                                "name": "tauNpc3DroneShield",
+                                "progressionIndex": 4
+                            },
+                            {
+                                "name": "tauNpc3DroneShield",
+                                "progressionIndex": 4
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 5
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 5
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 5
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 5
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotTrait",
+                                "ObjectiveTarget": "FinalJustice",
+                                "Score": 100
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "index": 1,
+                "battles": [
+                    {
+                        "battleNr": "4",
+                        "lightningVictory": 2,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgArmU002",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 7
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 7
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 7
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 7
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 9
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 9
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 9
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 9
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 9
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 9
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "MaxHits",
+                                "ObjectiveTarget": 3,
+                                "Score": 100
+                            },
+                            {
+                                "ObjectiveType": "NotDamageType",
+                                "ObjectiveTarget": "Bolter",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "5",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgArmU009",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "tauNpc5StealthSuit",
+                                "progressionIndex": 8
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 9
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 9
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 9
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 9
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 9
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 9
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 10
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 10
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotDamageType",
+                                "ObjectiveTarget": "Psychic",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "6",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgHpU017",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "tauBossDarkstriderLHE",
+                                "progressionIndex": 1
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 11
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 11
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 11
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 11
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 11
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 11
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotDamageType",
+                                "ObjectiveTarget": "Physical",
+                                "Score": 100
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "index": 2,
+                "battles": [
+                    {
+                        "battleNr": "7",
+                        "lightningVictory": 4,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgHpR007",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "tauNpc5StealthSuit",
+                                "progressionIndex": 13
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 14
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 14
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 14
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 14
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 15
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 15
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 15
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotDamageType",
+                                "ObjectiveTarget": "Piercing",
+                                "Score": 100
+                            },
+                            {
+                                "ObjectiveType": "NotDamageType",
+                                "ObjectiveTarget": "Chain",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "8",
+                        "lightningVictory": 2,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgDmgR025",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "tauNpc5StealthSuit",
+                                "progressionIndex": 12
+                            },
+                            {
+                                "name": "tauNpc5StealthSuit",
+                                "progressionIndex": 12
+                            },
+                            {
+                                "name": "tauNpc5StealthSuit",
+                                "progressionIndex": 12
+                            },
+                            {
+                                "name": "tauNpc5StealthSuit",
+                                "progressionIndex": 12
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "DamageType",
+                                "ObjectiveTarget": "Power",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "9",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgArmR025",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 16
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotDamageType",
+                                "ObjectiveTarget": "Psychic",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "10",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgHpR005",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "tauNpc3DroneShield",
+                                "progressionIndex": 14
+                            },
+                            {
+                                "name": "tauNpc3DroneShield",
+                                "progressionIndex": 14
+                            },
+                            {
+                                "name": "tauNpc5StealthSuit",
+                                "progressionIndex": 16
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "MinHits",
+                                "ObjectiveTarget": 3,
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "11",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgArmR006",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "tauBossCrisisLHE",
+                                "progressionIndex": 1
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 15
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 15
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 15
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 15
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 15
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 15
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 15
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 15
+                            },
+                            {
+                                "name": "tauNpc3DroneShield",
+                                "progressionIndex": 14
+                            },
+                            {
+                                "name": "tauNpc3DroneShield",
+                                "progressionIndex": 14
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotDamageType",
+                                "ObjectiveTarget": "Blast",
+                                "Score": 100
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "index": 3,
+                "battles": [
+                    {
+                        "battleNr": "12",
+                        "lightningVictory": 2,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgArmE009",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 22
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 22
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 22
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 22
+                            },
+                            {
+                                "name": "tauNpc3DroneShield",
+                                "progressionIndex": 24
+                            },
+                            {
+                                "name": "tauNpc3DroneShield",
+                                "progressionIndex": 24
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotDamageType",
+                                "ObjectiveTarget": "Bolter",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "13",
+                        "lightningVictory": 4,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgHpE012",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 21
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 21
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 21
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 21
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 21
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 21
+                            },
+                            {
+                                "name": "tauNpc5StealthSuit",
+                                "progressionIndex": 20
+                            },
+                            {
+                                "name": "tauNpc5StealthSuit",
+                                "progressionIndex": 20
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotDamageType",
+                                "ObjectiveTarget": "Piercing",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "14",
+                        "lightningVictory": 4,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgHpE015",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "tauBossAunShiLHE",
+                                "progressionIndex": 1
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 23
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 23
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 23
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 23
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 23
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 23
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotTrait",
+                                "ObjectiveTarget": "Flying",
+                                "Score": 100
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "index": 4,
+                "battles": [
+                    {
+                        "battleNr": "15",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgHpL105",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "tauNpc5StealthSuit",
+                                "progressionIndex": 25
+                            },
+                            {
+                                "name": "tauNpc5StealthSuit",
+                                "progressionIndex": 25
+                            },
+                            {
+                                "name": "tauNpc5StealthSuit",
+                                "progressionIndex": 25
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 28
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 28
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 28
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 28
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 28
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotDamageType",
+                                "ObjectiveTarget": "Piercing",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "16",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgArmL203",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "tauBossShadowsunLHE",
+                                "progressionIndex": 1
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 30
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 30
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 30
+                            },
+                            {
+                                "name": "tauNpc6Carnivore",
+                                "progressionIndex": 30
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 30
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 30
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 30
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 30
+                            },
+                            {
+                                "name": "tauNpc5StealthSuit",
+                                "progressionIndex": 28
+                            },
+                            {
+                                "name": "tauNpc5StealthSuit",
+                                "progressionIndex": 28
+                            },
+                            {
+                                "name": "tauNpc3DroneShield",
+                                "progressionIndex": 30
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotDamageType",
+                                "ObjectiveTarget": "Bolter",
+                                "Score": 100
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "index": 5,
+                "battles": [
+                    {
+                        "battleNr": "17",
+                        "lightningVictory": 4,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgHpM004",
+                                "num": 1,
+                                "denom": 6
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "tauBossFarsightLHE",
+                                "progressionIndex": 1
+                            },
+                            {
+                                "name": "tauBossCrisisLHE",
+                                "progressionIndex": 2
+                            },
+                            {
+                                "name": "tauBossMarksmanLHE",
+                                "progressionIndex": 3
+                            },
+                            {
+                                "name": "tauNpc5StealthSuit",
+                                "progressionIndex": 30
+                            },
+                            {
+                                "name": "tauNpc5StealthSuit",
+                                "progressionIndex": 30
+                            },
+                            {
+                                "name": "tauNpc2DroneSniper",
+                                "progressionIndex": 35
+                            },
+                            {
+                                "name": "tauNpc2DroneSniper",
+                                "progressionIndex": 35
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 34
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 34
+                            },
+                            {
+                                "name": "tauNpc1FireWarrior",
+                                "progressionIndex": 34
+                            },
+                            {
+                                "name": "tauNpc3DroneShield",
+                                "progressionIndex": 36
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "MaxHits",
+                                "ObjectiveTarget": 3,
+                                "Score": 100
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "unitId": "votanIronmaster",
+        "allowedFactions": ["LeaguesOfVotann", "AdeptusMechanicus", "Ultramarines"],
+        "enemyFactions": ["Necrons"],
+        "tiers": [
+            {
+                "index": 0,
+                "battles": [
+                    {
+                        "battleNr": "1",
+                        "lightningVictory": 2,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgDmgC015",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 1
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 1
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 1
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 1
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 1
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 1
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 1
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NoDamageTakenByAnyHero",
+                                "Score": 100
+                            },
+                            {
+                                "ObjectiveType": "DamageType",
+                                "ObjectiveTarget": "Physical",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "2",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgDmgC007",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 2
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 2
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 2
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 2
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 2
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 3
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 3
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 3
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NoDamageTakenByAnyHero",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "3",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgArmC011",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "necroBossWardenLHE",
+                                "progressionIndex": 1
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 3
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 3
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 3
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 3
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 3
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 3
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 2
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 2
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 2
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NoDamageTakenByAnyHero",
+                                "Score": 100
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "index": 1,
+                "battles": [
+                    {
+                        "battleNr": "4",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgArmU014",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 6
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotTrait",
+                                "ObjectiveTarget": "Overwatch",
+                                "Score": 100
+                            },
+                            {
+                                "ObjectiveType": "NotDamageType",
+                                "ObjectiveTarget": "Psychic",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "5",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgDmgU009",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "necroNpc5Swarm",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "necroNpc5Swarm",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "necroNpc5Swarm",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 6
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotDamageType",
+                                "ObjectiveTarget": "Toxic",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "6",
+                        "lightningVictory": 4,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgDmgU004",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "necroBossDestroyerLHE",
+                                "progressionIndex": 1
+                            },
+                            {
+                                "name": "necroBossWardenLHE",
+                                "progressionIndex": 2
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 6
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotTrait",
+                                "ObjectiveTarget": "Unstoppable",
+                                "Score": 100
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "index": 2,
+                "battles": [
+                    {
+                        "battleNr": "7",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgHpR040",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "necroNpc4Destroyer",
+                                "progressionIndex": 12
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 11
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 11
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 12
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 12
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 12
+                            },
+                            {
+                                "name": "powupDamage",
+                                "progressionIndex": null
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotDamageType",
+                                "ObjectiveTarget": "Bolter",
+                                "Score": 100
+                            },
+                            {
+                                "ObjectiveType": "NotDamageType",
+                                "ObjectiveTarget": "Energy",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "8",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgDmgR040",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "necroNpc4Destroyer",
+                                "progressionIndex": 10
+                            },
+                            {
+                                "name": "necroNpc4Destroyer",
+                                "progressionIndex": 10
+                            },
+                            {
+                                "name": "necroNpc4Destroyer",
+                                "progressionIndex": 10
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 13
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 13
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 13
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotDamageType",
+                                "ObjectiveTarget": "Psychic",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "9",
+                        "lightningVictory": 4,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgArmR040",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 15
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 15
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 15
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 15
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 15
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotTrait",
+                                "ObjectiveTarget": "Flying",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "10",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgHpR014",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "necroNpc3Deathmark",
+                                "progressionIndex": 12
+                            },
+                            {
+                                "name": "necroNpc3Deathmark",
+                                "progressionIndex": 12
+                            },
+                            {
+                                "name": "necroNpc3Deathmark",
+                                "progressionIndex": 12
+                            },
+                            {
+                                "name": "necroNpc3Deathmark",
+                                "progressionIndex": 12
+                            },
+                            {
+                                "name": "necroNpc3Deathmark",
+                                "progressionIndex": 12
+                            },
+                            {
+                                "name": "necroNpc3Deathmark",
+                                "progressionIndex": 12
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 13
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 13
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 13
+                            },
+                            {
+                                "name": "necroNpc5Swarm",
+                                "progressionIndex": 12
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "HasNoRangedAttack",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "11",
+                        "lightningVictory": 4,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgDmgR005",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "necroBossSpyderLHE",
+                                "progressionIndex": 1
+                            },
+                            {
+                                "name": "necroBossWardenLHE",
+                                "progressionIndex": 3
+                            },
+                            {
+                                "name": "necroNpc5Swarm",
+                                "progressionIndex": 12
+                            },
+                            {
+                                "name": "necroNpc5Swarm",
+                                "progressionIndex": 12
+                            },
+                            {
+                                "name": "necroNpc3Deathmark",
+                                "progressionIndex": 13
+                            },
+                            {
+                                "name": "necroNpc3Deathmark",
+                                "progressionIndex": 13
+                            },
+                            {
+                                "name": "necroNpc3Deathmark",
+                                "progressionIndex": 13
+                            },
+                            {
+                                "name": "necroNpc3Deathmark",
+                                "progressionIndex": 13
+                            },
+                            {
+                                "name": "necroNpc3Deathmark",
+                                "progressionIndex": 13
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "MaxHits",
+                                "ObjectiveTarget": 3,
+                                "Score": 100
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "index": 3,
+                "battles": [
+                    {
+                        "battleNr": "12",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgArmE010",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "necroNpc4Destroyer",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "necroNpc3Deathmark",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "necroNpc3Deathmark",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 18
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 18
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 18
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotDamageType",
+                                "ObjectiveTarget": "Energy",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "13",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgHpE012",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "necroNpc4Destroyer",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 19
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 19
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 19
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 19
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 19
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 19
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 20
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 20
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "MinHits",
+                                "ObjectiveTarget": 2,
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "14",
+                        "lightningVictory": 4,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgDmgE004",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "necroBossPlasmancerLHE",
+                                "progressionIndex": 1
+                            },
+                            {
+                                "name": "necroBossWardenLHE",
+                                "progressionIndex": 4
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 17
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 17
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 17
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 17
+                            },
+                            {
+                                "name": "necroNpc3Deathmark",
+                                "progressionIndex": 18
+                            },
+                            {
+                                "name": "necroNpc3Deathmark",
+                                "progressionIndex": 18
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 18
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 18
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 18
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 18
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotDamageType",
+                                "ObjectiveTarget": "Bolter",
+                                "Score": 100
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "index": 4,
+                "battles": [
+                    {
+                        "battleNr": "15",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgHpL099",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "necroNpc5Swarm",
+                                "progressionIndex": 21
+                            },
+                            {
+                                "name": "necroNpc5Swarm",
+                                "progressionIndex": 21
+                            },
+                            {
+                                "name": "necroNpc4Destroyer",
+                                "progressionIndex": 19
+                            },
+                            {
+                                "name": "necroNpc3Deathmark",
+                                "progressionIndex": 23
+                            },
+                            {
+                                "name": "necroNpc3Deathmark",
+                                "progressionIndex": 23
+                            },
+                            {
+                                "name": "necroNpc3Deathmark",
+                                "progressionIndex": 23
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 23
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 23
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 24
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 24
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 22
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 22
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotTrait",
+                                "ObjectiveTarget": "Unstoppable",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "16",
+                        "lightningVictory": 4,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgDmgL204",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "necroBossOverlordLHE",
+                                "progressionIndex": 1
+                            },
+                            {
+                                "name": "necroNpc4Destroyer",
+                                "progressionIndex": 23
+                            },
+                            {
+                                "name": "necroNpc4Destroyer",
+                                "progressionIndex": 23
+                            },
+                            {
+                                "name": "necroNpc3Deathmark",
+                                "progressionIndex": 25
+                            },
+                            {
+                                "name": "necroNpc3Deathmark",
+                                "progressionIndex": 25
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 26
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 26
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 26
+                            },
+                            {
+                                "name": "necroNpc2FlayedOne",
+                                "progressionIndex": 26
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotTrait",
+                                "ObjectiveTarget": "Flying",
+                                "Score": 100
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "index": 5,
+                "battles": [
+                    {
+                        "battleNr": "17",
+                        "lightningVictory": 4,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgHpM004",
+                                "num": 1,
+                                "denom": 6
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "necroBossOverlordLHE",
+                                "progressionIndex": 2
+                            },
+                            {
+                                "name": "necroBossWardenLHE",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "necroNpc5Swarm",
+                                "progressionIndex": 33
+                            },
+                            {
+                                "name": "necroNpc5Swarm",
+                                "progressionIndex": 33
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 33
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 33
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 33
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 33
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 33
+                            },
+                            {
+                                "name": "necroNpc1Warrior",
+                                "progressionIndex": 33
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotTrait",
+                                "ObjectiveTarget": "Overwatch",
+                                "Score": 100
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "unitId": "emperExultant",
+        "allowedFactions": ["EmperorsChildren", "ThousandSons", "DeathGuard", "BlackLegion", "WorldEaters"],
+        "enemyFactions": ["Ultramarines"],
+        "tiers": [
+            {
+                "index": 0,
+                "battles": [
+                    {
+                        "battleNr": "1",
+                        "lightningVictory": 1,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgArmC003",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "ultraNpc4HeavyIntercessor",
+                                "progressionIndex": 3
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 4
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 4
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 4
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 4
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "UseNoSummons",
+                                "Score": 100
+                            },
+                            {
+                                "ObjectiveType": "MaxHits",
+                                "ObjectiveTarget": 3,
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "2",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgHpC007",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 4
+                            },
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 4
+                            },
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 4
+                            },
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 4
+                            },
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 4
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 5
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 5
+                            },
+                            {
+                                "name": "ultraNpc2Eliminator",
+                                "progressionIndex": 3
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotDamageType",
+                                "ObjectiveTarget": "Psychic",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "3",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgHpC010",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "ultraBossInceptorSgtLHE",
+                                "progressionIndex": 1
+                            },
+                            {
+                                "name": "ultraNpc4HeavyIntercessor",
+                                "progressionIndex": 2
+                            },
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 4
+                            },
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 4
+                            },
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 4
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 5
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 5
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 5
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 5
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "DamageType",
+                                "ObjectiveTarget": "Power",
+                                "Score": 100
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "index": 1,
+                "battles": [
+                    {
+                        "battleNr": "4",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgHpU012",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "ultraNpc2Eliminator",
+                                "progressionIndex": 11
+                            },
+                            {
+                                "name": "ultraNpc2Eliminator",
+                                "progressionIndex": 11
+                            },
+                            {
+                                "name": "ultraNpc2Eliminator",
+                                "progressionIndex": 11
+                            },
+                            {
+                                "name": "powupHealing",
+                                "progressionIndex": null
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotTrait",
+                                "ObjectiveTarget": "Flying",
+                                "Score": 100
+                            },
+                            {
+                                "ObjectiveType": "NotTrait",
+                                "ObjectiveTarget": "Resilient",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "5",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgArmU007",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 9
+                            },
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 9
+                            },
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 9
+                            },
+                            {
+                                "name": "ultraNpc2Eliminator",
+                                "progressionIndex": 9
+                            },
+                            {
+                                "name": "ultraNpc2Eliminator",
+                                "progressionIndex": 9
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 11
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 11
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 11
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 11
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "MaxHits",
+                                "ObjectiveTarget": 2,
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "6",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgDmgU014",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "ultraBossEliminatorSgtLHE",
+                                "progressionIndex": 2
+                            },
+                            {
+                                "name": "ultraNpc2Eliminator",
+                                "progressionIndex": 10
+                            },
+                            {
+                                "name": "ultraNpc2Eliminator",
+                                "progressionIndex": 10
+                            },
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 9
+                            },
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 9
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 11
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 11
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 11
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 11
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 11
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotDamageType",
+                                "ObjectiveTarget": "Flame",
+                                "Score": 100
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "index": 2,
+                "battles": [
+                    {
+                        "battleNr": "7",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgHpR039",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "ultraNpc4HeavyIntercessor",
+                                "progressionIndex": 14
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 14
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 14
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 14
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 14
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 14
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 14
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 14
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "UseNoSummons",
+                                "Score": 100
+                            },
+                            {
+                                "ObjectiveType": "NotTrait",
+                                "ObjectiveTarget": "TeleportStrike",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "8",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgDmgR039",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "ultraNpc2Eliminator",
+                                "progressionIndex": 14
+                            },
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 14
+                            },
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 14
+                            },
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 14
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "MaxHits",
+                                "ObjectiveTarget": 1,
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "9",
+                        "lightningVictory": 2,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgArmR039",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "ultraNpc2Eliminator",
+                                "progressionIndex": 15
+                            },
+                            {
+                                "name": "ultraNpc2Eliminator",
+                                "progressionIndex": 15
+                            },
+                            {
+                                "name": "ultraNpc2Eliminator",
+                                "progressionIndex": 15
+                            },
+                            {
+                                "name": "ultraNpc2Eliminator",
+                                "progressionIndex": 15
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotDamageType",
+                                "ObjectiveTarget": "Physical",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "10",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgHpR018",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "ultraNpc4HeavyIntercessor",
+                                "progressionIndex": 14
+                            },
+                            {
+                                "name": "ultraNpc4HeavyIntercessor",
+                                "progressionIndex": 14
+                            },
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 15
+                            },
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 15
+                            },
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 15
+                            },
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 15
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotTrait",
+                                "ObjectiveTarget": "Flying",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "11",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgHpR008",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "ultraBossInceptorSgtLHE",
+                                "progressionIndex": 2
+                            },
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 16
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "HasNoRangedAttack",
+                                "Score": 100
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "index": 3,
+                "battles": [
+                    {
+                        "battleNr": "12",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgDmgE004",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "ultraNpc2Eliminator",
+                                "progressionIndex": 20
+                            },
+                            {
+                                "name": "ultraNpc2Eliminator",
+                                "progressionIndex": 20
+                            },
+                            {
+                                "name": "ultraNpc2Eliminator",
+                                "progressionIndex": 20
+                            },
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 20
+                            },
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 20
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 20
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 20
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 20
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 20
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 20
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "MaxHits",
+                                "ObjectiveTarget": 3,
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "13",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgDmgE011",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "ultraNpc4HeavyIntercessor",
+                                "progressionIndex": 21
+                            },
+                            {
+                                "name": "ultraNpc4HeavyIntercessor",
+                                "progressionIndex": 21
+                            },
+                            {
+                                "name": "ultraNpc4HeavyIntercessor",
+                                "progressionIndex": 21
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 22
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 22
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 22
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 22
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 22
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 22
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotTrait",
+                                "ObjectiveTarget": "RapidAssault",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "14",
+                        "lightningVictory": 4,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgHpE003",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "ultraBossTitusLHE",
+                                "progressionIndex": 1
+                            },
+                            {
+                                "name": "ultraNpc2Eliminator",
+                                "progressionIndex": 22
+                            },
+                            {
+                                "name": "ultraNpc2Eliminator",
+                                "progressionIndex": 22
+                            },
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 23
+                            },
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 23
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 24
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 24
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 24
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 24
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 24
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 24
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 24
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "UseNoSummons",
+                                "Score": 100
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "index": 4,
+                "battles": [
+                    {
+                        "battleNr": "15",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgHpL119",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "ultraNpc2Eliminator",
+                                "progressionIndex": 26
+                            },
+                            {
+                                "name": "ultraNpc2Eliminator",
+                                "progressionIndex": 26
+                            },
+                            {
+                                "name": "ultraNpc2Eliminator",
+                                "progressionIndex": 26
+                            },
+                            {
+                                "name": "ultraNpc2Eliminator",
+                                "progressionIndex": 26
+                            },
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 28
+                            },
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 28
+                            },
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 28
+                            },
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 28
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotDamageType",
+                                "ObjectiveTarget": "Flame",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "16",
+                        "lightningVictory": 5,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgDmgL001",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "ultraBossTiguriusLHE",
+                                "progressionIndex": 2
+                            },
+                            {
+                                "name": "ultraNpc4HeavyIntercessor",
+                                "progressionIndex": 30
+                            },
+                            {
+                                "name": "ultraNpc4HeavyIntercessor",
+                                "progressionIndex": 30
+                            },
+                            {
+                                "name": "ultraNpc4HeavyIntercessor",
+                                "progressionIndex": 30
+                            },
+                            {
+                                "name": "ultraNpc4HeavyIntercessor",
+                                "progressionIndex": 30
+                            },
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 32
+                            },
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 32
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotTrait",
+                                "ObjectiveTarget": "Flying",
+                                "Score": 100
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "index": 5,
+                "battles": [
+                    {
+                        "battleNr": "17",
+                        "lightningVictory": 4,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgHpM003",
+                                "num": 1,
+                                "denom": 6
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "ultraBossCalgarLHE",
+                                "progressionIndex": 1
+                            },
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 35
+                            },
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 35
+                            },
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 35
+                            },
+                            {
+                                "name": "ultraNpc1Inceptor",
+                                "progressionIndex": 35
+                            },
+                            {
+                                "name": "ultraNpc4HeavyIntercessor",
+                                "progressionIndex": 33
+                            },
+                            {
+                                "name": "ultraNpc4HeavyIntercessor",
+                                "progressionIndex": 33
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 37
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 37
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 37
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 37
+                            },
+                            {
+                                "name": "astraNpc1Guardsman",
+                                "progressionIndex": 37
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotTrait",
+                                "ObjectiveTarget": "TerminatorArmour",
+                                "Score": 100
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "unitId": "votanMemnyr",
+        "allowedFactions": ["LeaguesOfVotann", "Ultramarines", "AdeptusMechanicus"],
+        "enemyFactions": ["Orks"],
+        "tiers": [
+            {
+                "index": 0,
+                "battles": [
+                    {
+                        "battleNr": "1",
+                        "lightningVictory": 2,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgDmgC015",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 6
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NoDamageTakenByAnyHero",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "2",
+                        "lightningVictory": 2,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgDmgC007",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "orksNpc3GrotTank",
+                                "progressionIndex": 4
+                            },
+                            {
+                                "name": "orksNpc3GrotTank",
+                                "progressionIndex": 4
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 6
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NoDamageTakenByAnyHero",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "3",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgArmC011",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "orksBossNobLHE",
+                                "progressionIndex": 3
+                            },
+                            {
+                                "name": "orksNpc3GrotTank",
+                                "progressionIndex": 4
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 6
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NoDamageTakenByAnyHero",
+                                "Score": 100
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "index": 1,
+                "battles": [
+                    {
+                        "battleNr": "4",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgArmU014",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "orksNpc3GrotTank",
+                                "progressionIndex": 9
+                            },
+                            {
+                                "name": "orksNpc3GrotTank",
+                                "progressionIndex": 9
+                            },
+                            {
+                                "name": "orksNpc3GrotTank",
+                                "progressionIndex": 9
+                            },
+                            {
+                                "name": "orksNpc3GrotTank",
+                                "progressionIndex": 9
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 10
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 10
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 10
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NoDamageTakenByAnyHero",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "5",
+                        "lightningVictory": 2,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgDmgU009",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "orksNpc3GrotTank",
+                                "progressionIndex": 10
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 10
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 10
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 10
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 12
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 12
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 12
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 12
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NoDamageTakenByAnyHero",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "6",
+                        "lightningVictory": 4,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgDmgU004",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "orksBossBigMekLHE",
+                                "progressionIndex": 3
+                            },
+                            {
+                                "name": "orksNpc3GrotTank",
+                                "progressionIndex": 9
+                            },
+                            {
+                                "name": "orksNpc3GrotTank",
+                                "progressionIndex": 9
+                            },
+                            {
+                                "name": "orksNpc3GrotTank",
+                                "progressionIndex": 9
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 10
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 12
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 12
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 12
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 12
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 12
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NoDamageTakenByAnyHero",
+                                "Score": 100
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "index": 2,
+                "battles": [
+                    {
+                        "battleNr": "7",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgHpR040",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "orksNpc3GrotTank",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "orksNpc3GrotTank",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 14
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 14
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 14
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 14
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NoDamageTakenByAnyHero",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "8",
+                        "lightningVictory": 2,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgDmgR040",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 17
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 17
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 17
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 20
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 20
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 20
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NoDamageTakenByAnyHero",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "9",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgArmR040",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 16
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NoDamageTakenByAnyHero",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "10",
+                        "lightningVictory": 5,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgHpR014",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "orksNpc3GrotTank",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "orksNpc3GrotTank",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "orksNpc3GrotTank",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "orksNpc3GrotTank",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "orksNpc3GrotTank",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "orksNpc3GrotTank",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "orksNpc6Stormboy",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "orksNpc6Stormboy",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "orksNpc6Stormboy",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "orksNpc6Stormboy",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "orksNpc6Stormboy",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "orksNpc6Stormboy",
+                                "progressionIndex": 16
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NoDamageTakenByAnyHero",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "11",
+                        "lightningVictory": 2,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgDmgR005",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "orksBossKillaKanLHE",
+                                "progressionIndex": 3
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 17
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 17
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 17
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 23
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 23
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 23
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 23
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 23
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 23
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 23
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 23
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NoDamageTakenByAnyHero",
+                                "Score": 100
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "index": 3,
+                "battles": [
+                    {
+                        "battleNr": "12",
+                        "lightningVictory": 2,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgArmE010",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "orksNpc3GrotTank",
+                                "progressionIndex": 30
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 28
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 28
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 28
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 28
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NoDamageTakenByAnyHero",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "13",
+                        "lightningVictory": 4,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgHpE012",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "orksNpc6Stormboy",
+                                "progressionIndex": 30
+                            },
+                            {
+                                "name": "orksNpc6Stormboy",
+                                "progressionIndex": 30
+                            },
+                            {
+                                "name": "orksNpc6Stormboy",
+                                "progressionIndex": 30
+                            },
+                            {
+                                "name": "orksNpc6Stormboy",
+                                "progressionIndex": 30
+                            },
+                            {
+                                "name": "orksNpc6Stormboy",
+                                "progressionIndex": 30
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 28
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 28
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 28
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 28
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NoDamageTakenByAnyHero",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "14",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgDmgE004",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "orksBossRuntherdLHE",
+                                "progressionIndex": 2
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 34
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 34
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 34
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 34
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 34
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 34
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 34
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 34
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 31
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 31
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 31
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NoDamageTakenByAnyHero",
+                                "Score": 100
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "index": 4,
+                "battles": [
+                    {
+                        "battleNr": "15",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgHpL099",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "orksNpc3GrotTank",
+                                "progressionIndex": 35
+                            },
+                            {
+                                "name": "orksNpc3GrotTank",
+                                "progressionIndex": 35
+                            },
+                            {
+                                "name": "orksNpc3GrotTank",
+                                "progressionIndex": 35
+                            },
+                            {
+                                "name": "orksNpc6Stormboy",
+                                "progressionIndex": 35
+                            },
+                            {
+                                "name": "orksNpc6Stormboy",
+                                "progressionIndex": 35
+                            },
+                            {
+                                "name": "orksNpc6Stormboy",
+                                "progressionIndex": 35
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 35
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 35
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 35
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 40
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 40
+                            },
+                            {
+                                "name": "orksNpc1Grot",
+                                "progressionIndex": 40
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NoDamageTakenByAnyHero",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "16",
+                        "lightningVictory": 4,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgDmgL204",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "orksBossWarbossLHE",
+                                "progressionIndex": 3
+                            },
+                            {
+                                "name": "orksNpc3GrotTank",
+                                "progressionIndex": 43
+                            },
+                            {
+                                "name": "orksNpc3GrotTank",
+                                "progressionIndex": 43
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 43
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 43
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 43
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 43
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 43
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NoDamageTakenByAnyHero",
+                                "Score": 100
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "index": 5,
+                "battles": [
+                    {
+                        "battleNr": "17",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgHpM004",
+                                "num": 1,
+                                "denom": 6
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "orksBossWarbossLHE",
+                                "progressionIndex": 4
+                            },
+                            {
+                                "name": "orksNpc3GrotTank",
+                                "progressionIndex": 45
+                            },
+                            {
+                                "name": "orksNpc3GrotTank",
+                                "progressionIndex": 45
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 45
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 45
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 45
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 45
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 45
+                            },
+                            {
+                                "name": "orksNpc2OrkBoy",
+                                "progressionIndex": 45
+                            },
+                            {
+                                "name": "orksNpc6Stormboy",
+                                "progressionIndex": 45
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NoDamageTakenByAnyHero",
+                                "Score": 100
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "unitId": "spaceWolfPriest",
+        "allowedFactions": ["SpaceWolves", "Ultramarines", "BlackTemplars", "BloodAngels", "DarkAngels"],
+        "enemyFactions": ["ThousandSons"],
+        "tiers": [
+            {
+                "index": 0,
+                "battles": [
+                    {
+                        "battleNr": "1",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgArmC002",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 5
+                            },
+                            {
+                                "name": "thousNpc3RubricMarine",
+                                "progressionIndex": 6
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotDamageType",
+                                "ObjectiveTarget": "Psychic",
+                                "Score": 100
+                            },
+                            {
+                                "ObjectiveType": "NotDamageType",
+                                "ObjectiveTarget": "Piercing",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "2",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgHpC013",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "thousNpc1PinkHorror",
+                                "progressionIndex": 5
+                            },
+                            {
+                                "name": "thousNpc1PinkHorror",
+                                "progressionIndex": 5
+                            },
+                            {
+                                "name": "thousNpc1PinkHorror",
+                                "progressionIndex": 5
+                            },
+                            {
+                                "name": "thousNpc1PinkHorror",
+                                "progressionIndex": 5
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotTrait",
+                                "ObjectiveTarget": "Overwatch",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "3",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgArmC013",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "thousBossSorcererLHE",
+                                "progressionIndex": 1
+                            },
+                            {
+                                "name": "thousNpc3RubricMarine",
+                                "progressionIndex": 5
+                            },
+                            {
+                                "name": "thousNpc3RubricMarine",
+                                "progressionIndex": 5
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 6
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 6
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "HasNoRangedAttack",
+                                "Score": 100
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "index": 1,
+                "battles": [
+                    {
+                        "battleNr": "4",
+                        "lightningVictory": 2,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgArmU009",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "thousNpc1PinkHorror",
+                                "progressionIndex": 10
+                            },
+                            {
+                                "name": "thousNpc1PinkHorror",
+                                "progressionIndex": 10
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 13
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 13
+                            },
+                            {
+                                "name": "powupDamage",
+                                "progressionIndex": null
+                            },
+                            {
+                                "name": "powupDamage",
+                                "progressionIndex": null
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotDamageType",
+                                "ObjectiveTarget": "Plasma",
+                                "Score": 100
+                            },
+                            {
+                                "ObjectiveType": "NotTrait",
+                                "ObjectiveTarget": "Flying",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "5",
+                        "lightningVictory": 4,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgArmU005",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "thousNpc3RubricMarine",
+                                "progressionIndex": 14
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 11
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 11
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 11
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 11
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 11
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 11
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 11
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 11
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 11
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 11
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 11
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotDamageType",
+                                "ObjectiveTarget": "Piercing",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "6",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgArmU001",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "thousBossTerminatorLHE",
+                                "progressionIndex": 1
+                            },
+                            {
+                                "name": "thousNpc3RubricMarine",
+                                "progressionIndex": 11
+                            },
+                            {
+                                "name": "thousNpc1PinkHorror",
+                                "progressionIndex": 11
+                            },
+                            {
+                                "name": "thousNpc1PinkHorror",
+                                "progressionIndex": 11
+                            },
+                            {
+                                "name": "thousNpc1PinkHorror",
+                                "progressionIndex": 11
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 12
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 12
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotDamageType",
+                                "ObjectiveTarget": "HeavyRound",
+                                "Score": 100
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "index": 2,
+                "battles": [
+                    {
+                        "battleNr": "7",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgHpR031",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 15
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 15
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 15
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 15
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 15
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "DamageType",
+                                "ObjectiveTarget": "Power",
+                                "Score": 100
+                            },
+                            {
+                                "ObjectiveType": "MaxHits",
+                                "ObjectiveTarget": 3,
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "8",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgDmgR031",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "thousNpc1PinkHorror",
+                                "progressionIndex": 14
+                            },
+                            {
+                                "name": "thousNpc1PinkHorror",
+                                "progressionIndex": 14
+                            },
+                            {
+                                "name": "thousNpc1PinkHorror",
+                                "progressionIndex": 14
+                            },
+                            {
+                                "name": "thousNpc1PinkHorror",
+                                "progressionIndex": 14
+                            },
+                            {
+                                "name": "thousNpc1PinkHorror",
+                                "progressionIndex": 14
+                            },
+                            {
+                                "name": "thousNpc3RubricMarine",
+                                "progressionIndex": 14
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "MinHits",
+                                "ObjectiveTarget": 3,
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "9",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgArmR031",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "thousNpc3RubricMarine",
+                                "progressionIndex": 15
+                            },
+                            {
+                                "name": "thousNpc3RubricMarine",
+                                "progressionIndex": 15
+                            },
+                            {
+                                "name": "thousNpc3RubricMarine",
+                                "progressionIndex": 15
+                            },
+                            {
+                                "name": "thousNpc3RubricMarine",
+                                "progressionIndex": 15
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotDamageType",
+                                "ObjectiveTarget": "Plasma",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "10",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgArmR005",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "thousNpc3RubricMarine",
+                                "progressionIndex": 15
+                            },
+                            {
+                                "name": "thousNpc3RubricMarine",
+                                "progressionIndex": 15
+                            },
+                            {
+                                "name": "thousNpc3RubricMarine",
+                                "progressionIndex": 15
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 16
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 16
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotDamageType",
+                                "ObjectiveTarget": "Psychic",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "11",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgArmR015",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "thousBossTzaangorLHE",
+                                "progressionIndex": 1
+                            },
+                            {
+                                "name": "thousNpc4Terminator",
+                                "progressionIndex": 15
+                            },
+                            {
+                                "name": "thousNpc1PinkHorror",
+                                "progressionIndex": 14
+                            },
+                            {
+                                "name": "thousNpc1PinkHorror",
+                                "progressionIndex": 14
+                            },
+                            {
+                                "name": "thousNpc1PinkHorror",
+                                "progressionIndex": 14
+                            },
+                            {
+                                "name": "thousNpc1PinkHorror",
+                                "progressionIndex": 14
+                            },
+                            {
+                                "name": "thousNpc1PinkHorror",
+                                "progressionIndex": 14
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 15
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "UseNoSummons",
+                                "Score": 100
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "index": 3,
+                "battles": [
+                    {
+                        "battleNr": "12",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgHpE003",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "thousNpc1PinkHorror",
+                                "progressionIndex": 20
+                            },
+                            {
+                                "name": "thousNpc1PinkHorror",
+                                "progressionIndex": 20
+                            },
+                            {
+                                "name": "thousNpc1PinkHorror",
+                                "progressionIndex": 20
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 20
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 20
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 20
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotDamageType",
+                                "ObjectiveTarget": "Blast",
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "13",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgDmgE011",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "thousNpc1PinkHorror",
+                                "progressionIndex": 20
+                            },
+                            {
+                                "name": "thousNpc1PinkHorror",
+                                "progressionIndex": 20
+                            },
+                            {
+                                "name": "thousNpc1PinkHorror",
+                                "progressionIndex": 20
+                            },
+                            {
+                                "name": "thousNpc1PinkHorror",
+                                "progressionIndex": 20
+                            },
+                            {
+                                "name": "thousNpc1PinkHorror",
+                                "progressionIndex": 20
+                            },
+                            {
+                                "name": "thousNpc1PinkHorror",
+                                "progressionIndex": 20
+                            },
+                            {
+                                "name": "thousNpc1PinkHorror",
+                                "progressionIndex": 20
+                            },
+                            {
+                                "name": "thousNpc1PinkHorror",
+                                "progressionIndex": 20
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "MaxHits",
+                                "ObjectiveTarget": 4,
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "14",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgArmE013",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "thousBossInfernalMasterLHE",
+                                "progressionIndex": 1
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 23
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 23
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 23
+                            },
+                            {
+                                "name": "thousNpc4Terminator",
+                                "progressionIndex": 19
+                            },
+                            {
+                                "name": "thousNpc4Terminator",
+                                "progressionIndex": 19
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotTrait",
+                                "ObjectiveTarget": "Flying",
+                                "Score": 100
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "index": 4,
+                "battles": [
+                    {
+                        "battleNr": "15",
+                        "lightningVictory": 3,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgHpL111",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "thousNpc4Terminator",
+                                "progressionIndex": 27
+                            },
+                            {
+                                "name": "thousNpc4Terminator",
+                                "progressionIndex": 27
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 29
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 29
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 29
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 29
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 29
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 29
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "MaxHits",
+                                "ObjectiveTarget": 3,
+                                "Score": 100
+                            }
+                        ]
+                    },
+                    {
+                        "battleNr": "16",
+                        "lightningVictory": 2,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgDmgL001",
+                                "num": 3,
+                                "denom": 4
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "thousBossAhrimanLHE",
+                                "progressionIndex": 1
+                            },
+                            {
+                                "name": "thousNpc3RubricMarine",
+                                "progressionIndex": 30
+                            },
+                            {
+                                "name": "thousNpc3RubricMarine",
+                                "progressionIndex": 30
+                            },
+                            {
+                                "name": "thousNpc3RubricMarine",
+                                "progressionIndex": 30
+                            },
+                            {
+                                "name": "thousNpc3RubricMarine",
+                                "progressionIndex": 30
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 30
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 30
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "NotDamageType",
+                                "ObjectiveTarget": "Chain",
+                                "Score": 100
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "index": 5,
+                "battles": [
+                    {
+                        "battleNr": "17",
+                        "lightningVictory": 4,
+                        "loot": {
+                            "reward": {
+                                "upgradeId": "upgHpM001",
+                                "num": 1,
+                                "denom": 6
+                            }
+                        },
+                        "enemies": [
+                            {
+                                "name": "thousBossAhrimanLHE",
+                                "progressionIndex": 2
+                            },
+                            {
+                                "name": "thousNpc1PinkHorror",
+                                "progressionIndex": 34
+                            },
+                            {
+                                "name": "thousNpc1PinkHorror",
+                                "progressionIndex": 34
+                            },
+                            {
+                                "name": "thousNpc1PinkHorror",
+                                "progressionIndex": 34
+                            },
+                            {
+                                "name": "thousNpc4Terminator",
+                                "progressionIndex": 34
+                            },
+                            {
+                                "name": "thousNpc4Terminator",
+                                "progressionIndex": 34
+                            },
+                            {
+                                "name": "thousNpc4Terminator",
+                                "progressionIndex": 34
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 34
+                            },
+                            {
+                                "name": "thousNpc2Screamer",
+                                "progressionIndex": 34
+                            },
+                            {
+                                "name": "powupHealing",
+                                "progressionIndex": null
+                            },
+                            {
+                                "name": "powupHealing",
+                                "progressionIndex": null
+                            }
+                        ],
+                        "objectives": [
+                            {
+                                "ObjectiveType": "UseNoSummons",
+                                "Score": 100
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+]

--- a/src/fsd/4-entities/quests/quests.tsx
+++ b/src/fsd/4-entities/quests/quests.tsx
@@ -1,0 +1,3 @@
+export const Quests = () => {
+    return <div>Quests</div>;
+};

--- a/src/mobile-routes/events/planRoutes.tsx
+++ b/src/mobile-routes/events/planRoutes.tsx
@@ -24,6 +24,7 @@ export const PlanRoutes = () => {
     const dailyRaidsMenuItem = menuItemById['dailyRaids'];
     const teamsMenuItem = menuItemById['teams'];
     const teams2MenuItem = menuItemById['teams2'];
+    const questsMenuItem = menuItemById['quests'];
     const warOffense2MenuItem = menuItemById['warOffense2'];
 
     const [selectedRoutes, setSelectedRoutes] = useState<SelectedRoutes>(SelectedRoutes.all);
@@ -39,6 +40,7 @@ export const PlanRoutes = () => {
                         teams2MenuItem,
                         warOffense2MenuItem,
                         campaignProgressionMenuItem,
+                        questsMenuItem,
                     ].map(menuItem => (
                         <Card
                             variant="outlined"

--- a/src/models/menu-items.tsx
+++ b/src/models/menu-items.tsx
@@ -28,6 +28,7 @@ import { dirtyDozenMenuItem } from '@/fsd/1-pages/learn-dirty-dozen';
 import { mowLookupMenuItem } from '@/fsd/1-pages/learn-mow';
 import { campaignProgressionMenuItem } from '@/fsd/1-pages/plan-campaign-progression';
 import { activeLreMenuItems, inactiveLreMenuItems } from '@/fsd/1-pages/plan-lre';
+import { questsMenuItem } from '@/fsd/1-pages/plan-quests/quests.menu-item';
 import { teams2MenuItem } from '@/fsd/1-pages/plan-teams2/teams2.menu-item';
 import { warDefense2MenuItem } from '@/fsd/1-pages/plan-war-defense-2/war-defense2.menu-item';
 import { warOffense2MenuItem } from '@/fsd/1-pages/plan-war-offense2/war-offense2.menu-item';
@@ -85,6 +86,7 @@ export const menuItemById = {
     guides: guidesMenuItem,
     xpIncome: xpIncomeMenuItem,
     onslaught: new MenuItemTP('Onslaught', <MilitaryTechIcon />, '/learn/onslaught?track=Imperial'),
+    quests: questsMenuItem,
 };
 
 export const inputSubMenu: MenuItemTP[] = [
@@ -112,6 +114,7 @@ export const planSubMenuWeb: MenuItemTP[] = [
     new MenuItemTP('LRE', <TableChartIcon />, '', '', '', [menuItemById['leMasterTable'], ...activeLreMenuItems]),
     new MenuItemTP('LRE Archive', <TableChartIcon />, '', '', '', inactiveLreMenuItems),
     menuItemById['campaignProgression'],
+    menuItemById['quests'],
 ];
 
 export const planSubMenu: MenuItemTP[] = [
@@ -125,6 +128,7 @@ export const planSubMenu: MenuItemTP[] = [
     menuItemById['warOffense2'],
     menuItemById['zones'],
     menuItemById['leMasterTable'],
+    menuItemById['quests'],
     ...activeLreMenuItems,
 ];
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new Quests section accessible from the plan menu, enabling users to view quest details including battle tiers, upgrade requirements, faction information, and enemy data alongside estimated upgrade progression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->