### PR TITLE
Change the dropdown items for single teams to have the unit shard icons underneath the text.

### DIFF
--- a/src/fsd/1-pages/input-roster-snapshots/roster-filter-dropdown.tsx
+++ b/src/fsd/1-pages/input-roster-snapshots/roster-filter-dropdown.tsx
@@ -169,8 +169,10 @@ export const RosterFilterDropdown = ({
                                                     disableRipple
                                                 />
                                             </ListItemIcon>
-                                            <ListItemText primary={team.name} />
-                                            {renderTeamIcons(team.name)}
+                                            <div className="flex w-full flex-col">
+                                                <ListItemText primary={team.name} />
+                                                <div className="mt-1">{renderTeamIcons(team.name)}</div>
+                                            </div>
                                         </MenuItem>
                                     ))}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the layout of the roster filter dropdown menu. Team information is now better organized with enhanced vertical spacing between team names and icons, resulting in a cleaner visual presentation and improved readability for easier team identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->