### PR TITLE
Fix of a tooltip that was empty

### DIFF
--- a/src/routes/tables/raid-upgrade-material-card.tsx
+++ b/src/routes/tables/raid-upgrade-material-card.tsx
@@ -23,7 +23,6 @@ interface Props {
     widthClass?: string;
     compactRaidLocations?: boolean;
     showPlannedRaidLocationsOnly?: boolean;
-    tooltipRelatedCharactersOnly?: boolean;
 }
 
 const mowMap = new Map(mows2Data.mows.map(m => [m.snowprintId, m]));
@@ -71,7 +70,6 @@ const Component: React.FC<Props> = ({
     widthClass = 'w-67',
     compactRaidLocations = true,
     showPlannedRaidLocationsOnly = false,
-    tooltipRelatedCharactersOnly = false,
 }) => {
     const isShard = upgradeEstimate.rarity === 'Shard';
     const isMythicShard = upgradeEstimate.rarity === 'Mythic Shard';
@@ -120,7 +118,7 @@ const Component: React.FC<Props> = ({
 
     const iconTooltipContent = (
         <div>
-            {!tooltipRelatedCharactersOnly && upgradeEstimate.label}
+            {upgradeEstimate.label}
             <ul className="ps-[15px]">
                 {relatedUnitTooltipNames.map(nameItem => (
                     <li
@@ -242,7 +240,6 @@ export const RaidUpgradeMaterialCard = memo(Component, (previous, next) => {
         previous.maxLocations === next.maxLocations &&
         previous.showAdditionalInfo === next.showAdditionalInfo &&
         previous.showRelatedCharacters === next.showRelatedCharacters &&
-        previous.showPlannedRaidLocationsOnly === next.showPlannedRaidLocationsOnly &&
-        previous.tooltipRelatedCharactersOnly === next.tooltipRelatedCharactersOnly
+        previous.showPlannedRaidLocationsOnly === next.showPlannedRaidLocationsOnly
     );
 });

--- a/src/routes/tables/today-raids.tsx
+++ b/src/routes/tables/today-raids.tsx
@@ -49,7 +49,6 @@ export const TodayRaids: React.FC<Props> = ({ raids, bonusRaids }: Props) => {
                                 showRelatedCharacters={false}
                                 showAdditionalInfo={false}
                                 showPlannedRaidLocationsOnly={true}
-                                tooltipRelatedCharactersOnly={true}
                             />
                         ))}
                         {completedMaterialRaids.map((raid, index) => (
@@ -60,7 +59,6 @@ export const TodayRaids: React.FC<Props> = ({ raids, bonusRaids }: Props) => {
                                 showRelatedCharacters={false}
                                 showAdditionalInfo={false}
                                 showPlannedRaidLocationsOnly={true}
-                                tooltipRelatedCharactersOnly={true}
                             />
                         ))}
                         {completedShardRaids.map((raid, index) => (
@@ -71,7 +69,6 @@ export const TodayRaids: React.FC<Props> = ({ raids, bonusRaids }: Props) => {
                                 showRelatedCharacters={false}
                                 showAdditionalInfo={false}
                                 showPlannedRaidLocationsOnly={true}
-                                tooltipRelatedCharactersOnly={true}
                             />
                         ))}
                     </div>


### PR DESCRIPTION
When the material was raided it was showing empty tooltip now it shows the name of material 
<img width="444" height="214" alt="image" src="https://github.com/user-attachments/assets/8e78582c-298a-48bd-bbb4-435843dac580" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed raid upgrade material card tooltips to consistently display labels in all contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->