### PR TITLE
Fix BookSelect Tooltip

### DIFF
--- a/src/fsd/1-pages/input-xp-income/xp-income.tsx
+++ b/src/fsd/1-pages/input-xp-income/xp-income.tsx
@@ -5,16 +5,13 @@ import { DispatchContext, StoreContext } from '@/reducers/store.provider';
 
 import { cn } from '@/fsd/5-shared/lib';
 import { Rarity, RarityStars } from '@/fsd/5-shared/model';
-import { AccessibleTooltip } from '@/fsd/5-shared/ui';
 import { UnitShardIcon } from '@/fsd/5-shared/ui/icons';
 import { BookSelect } from '@/fsd/5-shared/ui/selects';
 
 import { CharactersService } from '@/fsd/4-entities/character';
 
-import { XpIncomeState } from '@/fsd/1-pages/input-xp-income';
-
 import { DecimalSpinner } from './decimal-spinner';
-import { ArenaLeague } from './models';
+import { ArenaLeague, XpIncomeState } from './models';
 import { useDebouncedState } from './use-debounced-state';
 import { kBlueStarCharacters, kEliteEnergyPerRaid, kNonEliteEnergyPerRaid, XpIncomeService } from './xp-income.service';
 
@@ -134,15 +131,14 @@ export const XpIncome: React.FC = () => {
                 />
             </div>
 
-            <AccessibleTooltip title="This controls which book rarity is used to display and calculate XP requirements. Smaller books (e.g. Common) show higher counts with less waste. Larger books (e.g. Mythic) show lower counts but may round up to cover remaining XP, costing more than needed.">
-                <div className="justify-endrounded-lg mb-5 border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800">
-                    <BookSelect
-                        label="Default XP Book for Calculations"
-                        value={defaultBookToUse ?? Rarity.Legendary}
-                        valueChanges={v => dispatchUpdate('defaultBookToUse', v)}
-                    />
-                </div>
-            </AccessibleTooltip>
+            <div className="mb-5 rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800">
+                <BookSelect
+                    label="Default XP Book for Calculations"
+                    tooltip="This controls which book rarity is used to display and calculate XP requirements. Smaller books (e.g. Common) show higher counts with less waste. Larger books (e.g. Mythic) show lower counts but may round up to cover remaining XP, costing more than needed."
+                    value={defaultBookToUse ?? Rarity.Legendary}
+                    valueChanges={v => dispatchUpdate('defaultBookToUse', v)}
+                />
+            </div>
 
             <hr className="my-5 border-gray-300 dark:border-gray-700" />
 

--- a/src/fsd/5-shared/ui/selects/book-select.tsx
+++ b/src/fsd/5-shared/ui/selects/book-select.tsx
@@ -4,21 +4,26 @@ import { Check, ChevronsUpDown } from 'lucide-react';
 import { Rarity, XP_BOOK_ORDER } from '@/fsd/5-shared/model';
 
 import { MiscIcon } from '../icons';
+import { AccessibleTooltip } from '../tooltip';
 
 const bookIconName = (rarity: Rarity) => Rarity[rarity].toLowerCase() + 'Book';
 
 export const BookSelect = ({
     label,
+    tooltip,
     value,
     valueChanges,
 }: {
     label?: string;
+    tooltip?: string;
     value: Rarity;
     valueChanges: (value: Rarity) => void;
 }) => {
     return (
         <Field className="flex flex-wrap items-center justify-between gap-4">
-            {label && <Label className="font-bold whitespace-nowrap">{label}:</Label>}
+            <AccessibleTooltip title={tooltip}>
+                <span>{label && <Label className="font-bold whitespace-nowrap">{label}:</Label>}</span>
+            </AccessibleTooltip>
             <div className="relative w-48">
                 <Listbox value={value} onChange={valueChanges}>
                     <ListboxButton className="relative w-full cursor-pointer rounded-lg border border-slate-300 bg-white py-2 pr-10 pl-3 text-left shadow-sm transition-all hover:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-slate-600 dark:bg-[#0f172a] dark:text-white">
@@ -33,7 +38,7 @@ export const BookSelect = ({
 
                     <ListboxOptions
                         transition
-                        className="absolute z-50 mt-2 w-full overflow-auto rounded-lg border border-slate-200 bg-white py-1 shadow-xl transition duration-100 ease-in data-[leave]:opacity-0 dark:border-slate-700 dark:bg-[#161b22]">
+                        className="absolute z-50 mt-2 w-full overflow-auto rounded-lg border border-slate-200 bg-white py-1 shadow-xl transition duration-100 ease-in data-leave:opacity-0 dark:border-slate-700 dark:bg-[#161b22]">
                         {XP_BOOK_ORDER.map(rarity => (
                             <ListboxOption
                                 key={rarity}


### PR DESCRIPTION
In https://discord.com/channels/1146809197023997972/1490065691725009116 was raised issue with tooltip being over the whole block and then the select was unusable on touchscreens. Also fixed the rounding of the block

From:
<img width="552" height="164" alt="image" src="https://github.com/user-attachments/assets/0c4e8d08-4d1b-4a80-92b9-f8e62f7b58ed" />
To: 
<img width="531" height="130" alt="image" src="https://github.com/user-attachments/assets/cc322f8f-b468-4f68-a5b2-792c96b1b2fa" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved tooltip display on the book selection component by integrating tooltip functionality directly into the component configuration.
  * Refined dropdown transition animations for smoother interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->