### PR TITLE
Fix MoWs missing from bulk goal creator

### DIFF
--- a/src/fsd/1-pages/plan-bulk-goals/bulk-goal-creator.tsx
+++ b/src/fsd/1-pages/plan-bulk-goals/bulk-goal-creator.tsx
@@ -257,6 +257,25 @@ export const BulkGoalCreator = () => {
         [bulkUnits, resolvedCharacters]
     );
 
+    const bulkTeamMows = useMemo(
+        () =>
+            filterMap(bulkUnits, entry => {
+                if (!entry.unit || !('snowprintId' in entry.unit)) return;
+                const unit = entry.unit;
+                const mow = resolvedMows.find(m => m.snowprintId === unit.snowprintId);
+                if (!mow) return;
+                return {
+                    ...mow,
+                    unlocked: entry.unlockMow,
+                    rarity: entry.rarity,
+                    stars: entry.stars,
+                    primaryAbilityLevel: entry.activeAbilityLevel,
+                    secondaryAbilityLevel: entry.passiveAbilityLevel,
+                };
+            }),
+        [bulkUnits, resolvedMows]
+    );
+
     const goalSummaryRows = useMemo(() => {
         const rows: Array<{
             category: GoalCategory;
@@ -660,7 +679,7 @@ export const BulkGoalCreator = () => {
                         <div className="mb-2 text-sm font-semibold">Preview:</div>
                         <TeamFlow
                             chars={bulkTeamCharacters}
-                            mows={[]}
+                            mows={bulkTeamMows}
                             showEquipment={RosterSnapshotShowVariableSettings.Never}
                             onCharClicked={() => {}}
                             onMowClicked={() => {}}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the TeamFlow preview to correctly display configured units with their abilities and stats instead of showing an empty state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->