### PR TITLE
Disable editing units from the wyo page.

### DIFF
--- a/src/fsd/1-pages/who-you-own/who-you-own.tsx
+++ b/src/fsd/1-pages/who-you-own/who-you-own.tsx
@@ -154,13 +154,13 @@ export const WhoYouOwn = () => {
                     <CharactersViewControls viewControls={viewControls} viewControlsChanges={updatePreferences} />
                     <div className="min-h-[10px]" />
 
-                    {factionsView && <FactionsGrid factions={factions} onCharacterClick={startEditUnit} />}
+                    {factionsView && <FactionsGrid factions={factions} onCharacterClick={() => {}} />}
 
                     {charactersView && (
                         <CharactersGrid
                             characters={units}
-                            onAvailableCharacterClick={startEditUnit}
-                            onLockedCharacterClick={startEditUnit}
+                            onAvailableCharacterClick={() => {}}
+                            onLockedCharacterClick={() => {}}
                         />
                     )}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved unintended navigation when clicking character and faction tiles on the owned units screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->