### PR TITLE
fix(raid-locations): improve chip layout and card sizing

### DIFF
--- a/src/fsd/4-entities/campaign/chip-campaign-location.tsx
+++ b/src/fsd/4-entities/campaign/chip-campaign-location.tsx
@@ -131,13 +131,13 @@ export const ChipCampaignLocation: React.FC<Props> = ({ location, unlocked, comp
             return location.nodeNumber + 'B';
         }
         return location.nodeNumber;
-    }, []);
+    }, [location]);
 
     const campaignShort = campaignDisplayNames[location.campaign] ?? location.campaign;
     const fullLocationName = `Battle ${locationNumber} - ${location.campaign}`;
 
     const locationText = compact ? campaignShort : location.campaign;
-    const setWidthClass = widthClass ?? (compact ? 'w-[84px]' : 'w-[178px]');
+    const setWidthClass = widthClass ?? (compact ? 'w-[96px]' : 'w-full');
     const isOnslaught = location.campaign === Campaign.Onslaught;
 
     return location === undefined ? (
@@ -148,14 +148,15 @@ export const ChipCampaignLocation: React.FC<Props> = ({ location, unlocked, comp
                 <button
                     type="button"
                     onClick={() => setOpenDetails(true)}
-                    className={`border-muted-fg/40 inline-flex cursor-pointer items-center gap-1 rounded-full border bg-transparent px-2 py-0.5 ${setWidthClass}`.trim()}
+                    className={`border-muted-fg/40 inline-flex cursor-pointer items-center gap-1 overflow-hidden rounded-full border bg-transparent px-2 py-0.5 ${setWidthClass}`.trim()}
                     style={{
                         opacity: unlocked ? 1 : 0.5,
                     }}>
-                    <CampaignImage campaign={location.campaign} size={18} showTooltip={false} />
-                    <div className="w-full flex-row justify-between text-[12px] leading-none text-gray-200">
-                        <span className="truncate">{locationText}</span>
-                        {!isOnslaught && <span>{locationNumber}</span>}
+                    <CampaignImage campaign={location.campaign} size={20} showTooltip={false} />
+                    <div
+                        className={`flex flex-1 items-center justify-between text-[12px] leading-none text-gray-200 ${compact ? '' : 'overflow-hidden'}`.trim()}>
+                        <span className={compact ? undefined : 'min-w-0 truncate'}>{locationText}</span>
+                        {!isOnslaught && <span className="shrink-0 pl-1">{locationNumber}</span>}
                     </div>
                 </button>
             </Tooltip>

--- a/src/fsd/5-shared/ui/button-pill.tsx
+++ b/src/fsd/5-shared/ui/button-pill.tsx
@@ -14,7 +14,7 @@ export const ButtonPill: React.FC<ButtonPillProps> = ({
     widthClass,
     ...props
 }) => {
-    const resolvedWidthClass = widthClass ?? (compact ? 'w-[84px]' : 'w-[178px]');
+    const resolvedWidthClass = widthClass ?? (compact ? 'w-[96px]' : 'w-full');
     return (
         <button
             type="button"

--- a/src/routes/tables/raid-locations.tsx
+++ b/src/routes/tables/raid-locations.tsx
@@ -43,7 +43,8 @@ const Component: React.FC<Props> = ({ locations, maxLocations, compactRaidLocati
     const collapse = useCallback(() => setExpanded(false), []);
 
     return (
-        <div className="text-muted-fg flex flex-wrap items-center gap-x-2 gap-y-1 text-xs">
+        <div
+            className={`text-muted-fg flex gap-y-1 text-xs ${compactRaidLocations ? 'flex-wrap items-center gap-x-2' : 'flex-col'}`}>
             {visibleLocationList.map(loc => (
                 <ChipCampaignLocation
                     key={loc.id}

--- a/src/routes/tables/raid-upgrade-material-card.tsx
+++ b/src/routes/tables/raid-upgrade-material-card.tsx
@@ -243,6 +243,8 @@ export const RaidUpgradeMaterialCard = memo(Component, (previous, next) => {
         previous.maxLocations === next.maxLocations &&
         previous.showAdditionalInfo === next.showAdditionalInfo &&
         previous.showRelatedCharacters === next.showRelatedCharacters &&
-        previous.showPlannedRaidLocationsOnly === next.showPlannedRaidLocationsOnly
+        previous.showPlannedRaidLocationsOnly === next.showPlannedRaidLocationsOnly &&
+        previous.compactRaidLocations === next.compactRaidLocations &&
+        previous.widthClass === next.widthClass
     );
 });

--- a/src/routes/tables/raid-upgrade-material-card.tsx
+++ b/src/routes/tables/raid-upgrade-material-card.tsx
@@ -157,7 +157,7 @@ const Component: React.FC<Props> = ({
                 tooltip={iconTooltipContent}
             />
         );
-    }, [isShard, isMythicShard, resolvedUnit, materialId, upgradeEstimate.snowprintId]);
+    }, [isShard, isMythicShard, resolvedUnit, materialId, upgradeEstimate.snowprintId, iconTooltipContent]);
 
     const isSufficient = upgradeEstimate.acquiredCount >= upgradeEstimate.requiredCount;
     const flooredAcquiredCount = Math.min(Math.floor(upgradeEstimate.acquiredCount), upgradeEstimate.requiredCount);

--- a/src/routes/tables/raid-upgrade-material-card.tsx
+++ b/src/routes/tables/raid-upgrade-material-card.tsx
@@ -67,7 +67,7 @@ const Component: React.FC<Props> = ({
     showAdditionalInfo = true,
     maxLocations,
     upgradeEstimate,
-    widthClass = 'w-67',
+    widthClass = 'w-76',
     compactRaidLocations = true,
     showPlannedRaidLocationsOnly = false,
 }) => {
@@ -116,25 +116,28 @@ const Component: React.FC<Props> = ({
 
     const noSuggestedRaidsRemaining = !hasSuggestedRaidsRemaining;
 
-    const iconTooltipContent = (
-        <div>
-            {upgradeEstimate.label}
-            <ul className="ps-[15px]">
-                {relatedUnitTooltipNames.map(nameItem => (
-                    <li
-                        key={
-                            'material-item-input-' +
-                            upgradeEstimate.id +
-                            '-' +
-                            displayedLocations.map(loc => loc.id).join(',') +
-                            '-' +
-                            nameItem
-                        }>
-                        {nameItem}
-                    </li>
-                ))}
-            </ul>
-        </div>
+    const iconTooltipContent = useMemo(
+        () => (
+            <div>
+                {upgradeEstimate.label}
+                <ul className="ps-[15px]">
+                    {relatedUnitTooltipNames.map(nameItem => (
+                        <li
+                            key={
+                                'material-item-input-' +
+                                upgradeEstimate.id +
+                                '-' +
+                                displayedLocations.map(loc => loc.id).join(',') +
+                                '-' +
+                                nameItem
+                            }>
+                            {nameItem}
+                        </li>
+                    ))}
+                </ul>
+            </div>
+        ),
+        [upgradeEstimate.label, upgradeEstimate.id, relatedUnitTooltipNames, displayedLocations]
     );
 
     const icon = useMemo(() => {
@@ -166,12 +169,12 @@ const Component: React.FC<Props> = ({
             <div className="flex w-full flex-row items-start!">
                 {/* Left: Icon, quantity */}
                 <div
-                    className={`flex h-full w-14 shrink-0 flex-col items-center justify-start gap-1 ${
+                    className={`flex w-14 shrink-0 flex-col items-center justify-start gap-1 ${
                         noSuggestedRaidsRemaining ? 'opacity-70' : ''
                     }`}>
                     <div className="mt-2 flex h-10 w-10 items-center justify-center">{icon}</div>
                     <span
-                        className={`mt-1 py-0.5 text-sm font-bold ${
+                        className={`mt-1 flex h-6 items-center text-sm font-bold ${
                             noSuggestedRaidsRemaining
                                 ? 'text-gray-400'
                                 : showPlannedRaidLocationsOnly
@@ -185,7 +188,7 @@ const Component: React.FC<Props> = ({
                 </div>
 
                 {/* Right: Content */}
-                <div className="flex h-full min-w-0 flex-1 flex-col justify-start gap-2 pl-2">
+                <div className="flex min-w-0 flex-1 flex-col justify-start gap-2 pl-2">
                     <div className="flex items-center justify-between gap-1">
                         <h4
                             className={`mb-0 truncate text-xs font-normal ${
@@ -194,9 +197,9 @@ const Component: React.FC<Props> = ({
                             {name ?? upgradeEstimate.snowprintId}
                         </h4>
                     </div>
-                    {showRelatedCharacters && (
+                    {showRelatedCharacters && upgradeEstimate.relatedCharacters.length > 0 && (
                         <div
-                            className={`flex min-h-7 flex-row items-center gap-1 ${
+                            className={`flex flex-row items-center gap-1 ${
                                 noSuggestedRaidsRemaining ? 'opacity-70' : ''
                             }`}>
                             {upgradeEstimate.relatedCharacters.map(id => (


### PR DESCRIPTION
- Wider compact chips (`w-[96px]`) to fit all campaign names and Onslaught; non-compact fills container
- Fixed chip text layout so node number is pinned right; added `overflow-hidden`
- Fixed `locationNumber` stale `useMemo` closure
- Card widened to `w-76`; count badge height aligned to chip; empty character row no longer renders
- Non-compact `RaidLocations` uses `flex-col`

From
<img width="876" height="261" alt="image" src="https://github.com/user-attachments/assets/ee4b53f7-28de-4aeb-9f57-a5b79c05f47a" />
<img width="597" height="241" alt="image" src="https://github.com/user-attachments/assets/e3751918-5466-479c-8eb1-90e95bccdf7b" />
<img width="879" height="649" alt="image" src="https://github.com/user-attachments/assets/615af412-4d54-4b39-8520-a02b42f27de5" />


To

<img width="993" height="283" alt="image" src="https://github.com/user-attachments/assets/2bb0a86a-e27f-49d4-9426-27236bdd7cdd" />
<img width="983" height="398" alt="image" src="https://github.com/user-attachments/assets/09a4ee09-0a1f-4163-84d8-9786ffc8f259" />
<img width="981" height="672" alt="image" src="https://github.com/user-attachments/assets/034b0273-2200-4989-a4a5-89775fed799a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated campaign location chip sizing and image size for a more consistent layout.
  * Increased default widths for pill buttons and certain cards to improve spacing.
  * Made raid locations list adapt between compact horizontal and expanded vertical layouts.
  * Tweaked raid upgrade material card spacing and tooltip handling for cleaner presentation.
* **Bug Fixes**
  * Fixed chip content not updating when a location changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->