### PR TITLE
Use card color variables for consistent theming in new section

### DIFF
--- a/src/fsd/0-app/index.css
+++ b/src/fsd/0-app/index.css
@@ -57,6 +57,10 @@
         --bg: var(--color-white);
         --fg: var(--color-slate-950);
 
+        --card-bg: var(--color-white);
+        --card-border: var(--color-slate-400);
+        --card-fg: var(--color-slate-950);
+
         --primary: var(--color-blue-600);
         --primary-fg: var(--color-white);
 
@@ -147,6 +151,10 @@
     .dark {
         --bg: rgb(37, 38, 36);
         --fg: rgba(214, 207, 195, 0.87);
+
+        --card-bg: var(--color-slate-900);
+        --card-border: var(--color-slate-800);
+        --card-fg: var(--color-white);
 
         --primary: var(--color-blue-600);
         --primary-fg: var(--color-white);
@@ -299,12 +307,15 @@ code {
 .gamma {
     background-color: #fce5cd;
 }
+
 .stone1 {
     background-color: var(--rank-stone1);
 }
+
 .stone2 {
     background-color: var(--rank-stone2);
 }
+
 .stone3 {
     background-color: var(--rank-stone3);
 }
@@ -312,9 +323,11 @@ code {
 .iron1 {
     background-color: var(--rank-iron1);
 }
+
 .iron2 {
     background-color: var(--rank-iron2);
 }
+
 .iron3 {
     background-color: var(--rank-iron3);
 }
@@ -322,9 +335,11 @@ code {
 .bronze1 {
     background-color: var(--rank-bronze1);
 }
+
 .bronze2 {
     background-color: var(--rank-bronze2);
 }
+
 .bronze3 {
     background-color: var(--rank-bronze3);
 }
@@ -332,9 +347,11 @@ code {
 .silver1 {
     background-color: var(--rank-silver1);
 }
+
 .silver2 {
     background-color: var(--rank-silver2);
 }
+
 .silver3 {
     background-color: var(--rank-silver3);
 }
@@ -342,9 +359,11 @@ code {
 .gold1 {
     background-color: var(--rank-gold1);
 }
+
 .gold2 {
     background-color: var(--rank-gold2);
 }
+
 .gold3 {
     background-color: var(--rank-gold3);
 }
@@ -352,9 +371,11 @@ code {
 .diamond1 {
     background-color: var(--rank-diamond1);
 }
+
 .diamond2 {
     background-color: var(--rank-diamond2);
 }
+
 .diamond3 {
     background-color: var(--rank-diamond3);
 }
@@ -362,9 +383,11 @@ code {
 .adamantine1 {
     background-color: var(--rank-adamantine1);
 }
+
 .adamantine2 {
     background-color: var(--rank-adamantine2);
 }
+
 .adamantine3 {
     background-color: var(--rank-adamantine3);
 }
@@ -483,48 +506,63 @@ code {
     .gap5 {
         gap: 5px;
     }
+
     .gap6 {
         gap: 6px;
     }
+
     .gap7 {
         gap: 7px;
     }
+
     .gap8 {
         gap: 8px;
     }
+
     .gap9 {
         gap: 9px;
     }
+
     .gap10 {
         gap: 10px;
     }
+
     .gap11 {
         gap: 11px;
     }
+
     .gap12 {
         gap: 12px;
     }
+
     .gap13 {
         gap: 13px;
     }
+
     .gap14 {
         gap: 14px;
     }
+
     .gap15 {
         gap: 15px;
     }
+
     .gap16 {
         gap: 16px;
     }
+
     .gap17 {
         gap: 17px;
     }
+
     .gap18 {
         gap: 18px;
     }
+
     .gap19 {
         gap: 19px;
     }
+
     .gap20 {
         gap: 20px;
     }
@@ -532,30 +570,39 @@ code {
     .p1 {
         padding: 1px;
     }
+
     .p2 {
         padding: 2px;
     }
+
     .p3 {
         padding: 3px;
     }
+
     .p4 {
         padding: 4px;
     }
+
     .p5 {
         padding: 5px;
     }
+
     .p6 {
         padding: 6px;
     }
+
     .p7 {
         padding: 7px;
     }
+
     .p8 {
         padding: 8px;
     }
+
     .p9 {
         padding: 9px;
     }
+
     .p10 {
         padding: 10px;
     }

--- a/src/fsd/4-entities/campaign/chip-campaign-location.tsx
+++ b/src/fsd/4-entities/campaign/chip-campaign-location.tsx
@@ -58,23 +58,19 @@ const CampaignBattleCardPreview: React.FC<CampaignBattleCardPreviewProps> = ({ b
     const rewardRarity = RarityMapper.stringToRarityString(rewardMaterial?.rarity ?? '');
 
     return (
-        <div className="mx-auto flex w-fit max-w-full flex-col gap-3 rounded-md border border-gray-300 bg-white p-4 shadow-md dark:border-gray-700 dark:bg-gray-900 dark:shadow-lg">
-            <div className="flex flex-wrap items-center gap-3 border-b border-gray-200 pb-3 dark:border-gray-700">
+        <div className="mx-auto flex w-fit max-w-full flex-col gap-3 rounded-md border border-[var(--card-border)] bg-[var(--card-bg)] p-4 text-[var(--card-fg)] shadow-md">
+            <div className="flex flex-wrap items-center gap-3 border-b border-[var(--card-border)] pb-3 text-inherit">
                 <CampaignImage campaign={battle.campaign} size={26} showTooltip={false} />
-                <div className="ml-auto flex flex-wrap items-center gap-3">
-                    <span className="inline-flex items-center gap-1 whitespace-nowrap">
+                <div className="ml-auto flex flex-wrap items-center gap-3 text-inherit">
+                    <span className="inline-flex items-center gap-1 whitespace-nowrap text-inherit">
                         <MiscIcon icon="deployment" width={18} height={18} />
-                        <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                            {battle.slots ?? 0}
-                        </span>
+                        <span className="text-sm font-medium text-inherit">{battle.slots ?? 0}</span>
                     </span>
-                    <span className="inline-flex items-center gap-1 whitespace-nowrap">
+                    <span className="inline-flex items-center gap-1 whitespace-nowrap text-inherit">
                         <MiscIcon icon="energy" width={18} height={18} />
-                        <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                            {battle.energyCost}
-                        </span>
+                        <span className="text-sm font-medium text-inherit">{battle.energyCost}</span>
                     </span>
-                    <span className="inline-flex items-center gap-1 text-sm font-medium text-gray-700 dark:text-gray-300">
+                    <span className="inline-flex items-center gap-1 text-sm font-medium text-inherit">
                         Reward:
                         {rewardMaterial ? (
                             <UpgradeImage
@@ -85,16 +81,16 @@ const CampaignBattleCardPreview: React.FC<CampaignBattleCardPreviewProps> = ({ b
                                 tooltip={rewardName || '-'}
                             />
                         ) : (
-                            <span>{rewardName || '-'}</span>
+                            <span className="text-inherit">{rewardName || '-'}</span>
                         )}
                     </span>
                 </div>
             </div>
 
             <div>
-                <h4 className="mb-2 text-xs font-semibold text-gray-500 uppercase dark:text-gray-400">Enemies</h4>
+                <h4 className="mb-2 text-xs font-semibold text-inherit uppercase">Enemies</h4>
                 {(battle.rawEnemyTypes ?? []).length === 0 ? (
-                    <div className="text-sm text-gray-600 dark:text-gray-400">No enemy info available.</div>
+                    <div className="text-sm text-inherit">No enemy info available.</div>
                 ) : (
                     <div className="flex justify-center">
                         <CampaignBattleEnemies
@@ -141,20 +137,20 @@ export const ChipCampaignLocation: React.FC<Props> = ({ location, unlocked, comp
     const isOnslaught = location.campaign === Campaign.Onslaught;
 
     return location === undefined ? (
-        <span>undefined</span>
+        <span className="text-[var(--card-fg)]">undefined</span>
     ) : (
         <>
             <Tooltip title={location.campaign} placement="top">
                 <button
                     type="button"
                     onClick={() => setOpenDetails(true)}
-                    className={`border-muted-fg/40 inline-flex cursor-pointer items-center gap-1 overflow-hidden rounded-full border bg-transparent px-2 py-0.5 ${setWidthClass}`.trim()}
+                    className={`border-muted-fg/40 inline-flex cursor-pointer items-center gap-1 overflow-hidden rounded-full border bg-transparent px-2 py-0.5 ${setWidthClass} text-[var(--card-fg)]`.trim()}
                     style={{
                         opacity: unlocked ? 1 : 0.5,
                     }}>
                     <CampaignImage campaign={location.campaign} size={20} showTooltip={false} />
                     <div
-                        className={`flex flex-1 items-center justify-between text-[12px] leading-none text-gray-200 ${compact ? '' : 'overflow-hidden'}`.trim()}>
+                        className={`flex flex-1 items-center justify-between text-[12px] leading-none text-inherit ${compact ? '' : 'overflow-hidden'}`.trim()}>
                         <span className={compact ? undefined : 'min-w-0 truncate'}>{locationText}</span>
                         {!isOnslaught && <span className="shrink-0 pl-1">{locationNumber}</span>}
                     </div>
@@ -168,14 +164,14 @@ export const ChipCampaignLocation: React.FC<Props> = ({ location, unlocked, comp
                 aria-labelledby="campaign-location-dialog-title">
                 <DialogTitle
                     id="campaign-location-dialog-title"
-                    className="flex items-center justify-between gap-3 pr-2">
-                    <span>{fullLocationName}</span>
+                    className="flex items-center justify-between gap-3 pr-2 text-[var(--card-fg)]">
+                    <span className="text-inherit">{fullLocationName}</span>
                     <IconButton aria-label="close" onClick={() => setOpenDetails(false)} size="small">
                         <CloseIcon fontSize="small" />
                     </IconButton>
                 </DialogTitle>
-                <DialogContent className="pt-2! pb-3!">
-                    <div className="flex justify-center">
+                <DialogContent className="pt-2! pb-3! text-[var(--card-fg)]">
+                    <div className="flex justify-center text-inherit">
                         <CampaignBattleCardPreview battle={location} />
                     </div>
                 </DialogContent>

--- a/src/routes/tables/material-estimates-row.tsx
+++ b/src/routes/tables/material-estimates-row.tsx
@@ -20,23 +20,23 @@ const MaterialEstimatesRow: React.FC<MaterialEstimatesRowProps> = ({ estimate })
     }, [estimate.daysTotal]);
 
     return (
-        <div className="mt-1 flex w-full flex-row items-center justify-evenly gap-3 rounded bg-gray-800 px-2 py-1 text-[11px] text-gray-300">
+        <div className="mt-1 flex w-full flex-row items-center justify-evenly gap-3 rounded bg-[var(--card-border)] px-2 py-1 text-[11px] text-[var(--card-fg)]">
             <AccessibleTooltip title={`${estimate.daysTotal} days. Estimated date ${calendarDate ?? ''}`}>
-                <span className="inline-flex items-center gap-1 whitespace-nowrap">
+                <span className="inline-flex items-center gap-1 whitespace-nowrap text-inherit">
                     <CalendarMonthIcon style={{ opacity: 0.8 }} fontSize="small" sx={{ fontSize: iconSize }} />
-                    <span className="text-xs font-medium text-gray-700 dark:text-gray-300">{estimate.daysTotal}</span>
+                    <span className="text-xs font-medium text-inherit">{estimate.daysTotal}</span>
                 </span>
             </AccessibleTooltip>
             <AccessibleTooltip title="Total energy required">
-                <span className="inline-flex items-center gap-1 whitespace-nowrap">
+                <span className="inline-flex items-center gap-1 whitespace-nowrap text-inherit">
                     <MiscIcon icon="energy" width={iconSize} height={iconSize} className="opacity-80" />
-                    <span className="text-xs font-medium text-gray-700 dark:text-gray-300">{estimate.energyTotal}</span>
+                    <span className="text-xs font-medium text-inherit">{estimate.energyTotal}</span>
                 </span>
             </AccessibleTooltip>
             <AccessibleTooltip title="Total raids required">
-                <span className="inline-flex items-center gap-1 whitespace-nowrap">
+                <span className="inline-flex items-center gap-1 whitespace-nowrap text-inherit">
                     <MiscIcon icon="raidTicket" width={iconSize} height={iconSize} className="opacity-80" />
-                    <span className="text-xs font-medium text-gray-700 dark:text-gray-300">{estimate.raidsTotal}</span>
+                    <span className="text-xs font-medium text-inherit">{estimate.raidsTotal}</span>
                 </span>
             </AccessibleTooltip>
         </div>

--- a/src/routes/tables/raid-locations.tsx
+++ b/src/routes/tables/raid-locations.tsx
@@ -44,7 +44,7 @@ const Component: React.FC<Props> = ({ locations, maxLocations, compactRaidLocati
 
     return (
         <div
-            className={`text-muted-fg flex gap-y-1 text-xs ${compactRaidLocations ? 'flex-wrap items-center gap-x-2' : 'flex-col'}`}>
+            className={`flex gap-y-1 text-xs text-inherit ${compactRaidLocations ? 'flex-wrap items-center gap-x-2' : 'flex-col'}`}>
             {visibleLocationList.map(loc => (
                 <ChipCampaignLocation
                     key={loc.id}

--- a/src/routes/tables/raid-upgrade-material-card.tsx
+++ b/src/routes/tables/raid-upgrade-material-card.tsx
@@ -165,8 +165,10 @@ const Component: React.FC<Props> = ({
 
     return (
         <div
-            className={`flex flex-col justify-between rounded-lg border border-gray-700 bg-gray-900 p-3 shadow-lg ${widthClass}`.trim()}>
-            <div className="flex w-full flex-row items-start!">
+            className={`flex flex-col justify-between rounded-lg border p-3 shadow-lg ${widthClass} border-[var(--card-border)] bg-[var(--card-bg)] text-[var(--card-fg)] ${
+                noSuggestedRaidsRemaining ? 'opacity-80' : ''
+            }`.trim()}>
+            <div className="flex w-full flex-row items-start! text-inherit">
                 {/* Left: Icon, quantity */}
                 <div
                     className={`flex w-14 shrink-0 flex-col items-center justify-start gap-1 ${
@@ -174,11 +176,11 @@ const Component: React.FC<Props> = ({
                     }`}>
                     <div className="mt-2 flex h-10 w-10 items-center justify-center">{icon}</div>
                     <span
-                        className={`mt-1 flex h-6 items-center text-sm font-bold ${
+                        className={`mt-1 flex h-6 items-center text-sm font-bold text-inherit ${
                             noSuggestedRaidsRemaining
-                                ? 'text-gray-400'
+                                ? 'opacity-70'
                                 : showPlannedRaidLocationsOnly
-                                  ? 'text-gray-200'
+                                  ? ''
                                   : isSufficient
                                     ? 'text-green-400'
                                     : 'text-red-400'
@@ -190,10 +192,7 @@ const Component: React.FC<Props> = ({
                 {/* Right: Content */}
                 <div className="flex min-w-0 flex-1 flex-col justify-start gap-2 pl-2">
                     <div className="flex items-center justify-between gap-1">
-                        <h4
-                            className={`mb-0 truncate text-xs font-normal ${
-                                noSuggestedRaidsRemaining ? 'text-gray-400' : 'text-gray-200'
-                            }`}>
+                        <h4 className={`mb-0 truncate text-xs font-normal text-inherit`}>
                             {name ?? upgradeEstimate.snowprintId}
                         </h4>
                     </div>


### PR DESCRIPTION
Ensured the new section uses card color variables for consistent theming in light and dark modes.


From
<img width="815" height="1603" alt="image" src="https://github.com/user-attachments/assets/2a1b9d75-05eb-4096-992c-296b6b1c796c" />
<img width="809" height="1561" alt="image" src="https://github.com/user-attachments/assets/ddfae1ce-442a-4850-a194-1ae020eebbfd" />


To
<img width="785" height="1583" alt="image" src="https://github.com/user-attachments/assets/4d5454fb-6bec-456c-b895-2ba1b27ba5bd" />
<img width="791" height="1593" alt="image" src="https://github.com/user-attachments/assets/74ead906-268a-44ee-a95d-7ac8ce51d17c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated card component styling throughout the application to use theme-driven CSS variables for backgrounds, borders, and text colors, providing consistent theming across light and dark modes in campaign tracking, material estimates, and raid management sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->