### PR TITLE
Add theme CSS variables for card styling and enable SyncButton color config

### DIFF
--- a/src/fsd/0-app/index.css
+++ b/src/fsd/0-app/index.css
@@ -15,6 +15,10 @@
     --color-bg: var(--bg);
     --color-fg: var(--fg);
 
+    --color-card-bg: var(--card-bg);
+    --color-card-border: var(--card-border);
+    --color-card-fg: var(--card-fg);
+
     --color-primary: var(--primary);
     --color-primary-fg: var(--primary-fg);
 
@@ -276,7 +280,7 @@ body {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
 
-    @apply bg-[var(--bg)] text-[var(--fg)];
+    @apply bg-(--bg) text-(--fg);
 }
 
 code {

--- a/src/fsd/1-pages/input-resources/resources.tsx
+++ b/src/fsd/1-pages/input-resources/resources.tsx
@@ -81,7 +81,7 @@ export const Resources = () => {
                 onClick={onClick}
                 title={onClick ? `Click to ${isEnabled ? 'disable' : 'enable'}` : undefined}>
                 <div className="flex h-[45px] w-[45px] items-center justify-center">{icon}</div>
-                <span className="mt-1 text-sm font-semibold text-white">{quantity}</span>
+                <span className="mt-1 text-sm font-semibold">{quantity}</span>
             </div>
         );
     };
@@ -89,13 +89,13 @@ export const Resources = () => {
     return (
         <div className="flex flex-col gap-y-4 p-2">
             {hasSync && (
-                <div className="flex justify-end border-b border-gray-600 p-2">
+                <div className="flex justify-end border-b border-(--card-border) p-2">
                     <SyncButton showText={!isMobile} />
                 </div>
             )}
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-                <div className="flex flex-col rounded-lg border border-gray-700 bg-gray-800 p-3 shadow-lg">
-                    <h4 className="text-md mb-2 border-b border-gray-600 pb-2 font-bold tracking-wide text-gray-300 uppercase">
+                <div className="flex flex-col rounded-lg border border-(--card-border) bg-(--card-bg) p-3 text-(--card-fg) shadow-lg">
+                    <h4 className="text-md mb-2 border-b border-(--card-border) pb-2 font-bold tracking-wide text-(--card-fg) uppercase">
                         XP Books
                     </h4>
                     <div className="flex flex-wrap justify-start gap-x-1">
@@ -116,8 +116,8 @@ export const Resources = () => {
                     </div>
                 </div>
 
-                <div className="flex flex-col rounded-lg border border-gray-700 bg-gray-800 p-3 shadow-lg">
-                    <h4 className="text-md mb-2 border-b border-gray-600 pb-2 font-bold tracking-wide text-gray-300 uppercase">
+                <div className="flex flex-col rounded-lg border border-(--card-border) bg-(--card-bg) p-3 text-(--card-fg) shadow-lg">
+                    <h4 className="text-md mb-2 border-b border-(--card-border) pb-2 font-bold tracking-wide text-(--card-fg) uppercase">
                         Forge Badges
                     </h4>
                     <div className="flex flex-wrap justify-start gap-x-1">
@@ -133,8 +133,8 @@ export const Resources = () => {
                     </div>
                 </div>
 
-                <div className="flex flex-col rounded-lg border border-gray-700 bg-gray-800 p-3 shadow-lg">
-                    <h4 className="text-md mb-2 border-b border-gray-600 pb-2 font-bold tracking-wide text-gray-300 uppercase">
+                <div className="flex flex-col rounded-lg border border-(--card-border) bg-(--card-bg) p-3 text-(--card-fg) shadow-lg">
+                    <h4 className="text-md mb-2 border-b border-(--card-border) pb-2 font-bold tracking-wide text-(--card-fg) uppercase">
                         Machine of War Components
                     </h4>
                     <div className="flex flex-wrap justify-start gap-x-1">
@@ -148,15 +148,15 @@ export const Resources = () => {
                     </div>
                 </div>
             </div>{' '}
-            <div className="mt-4 flex flex-col rounded-lg border border-gray-700 bg-gray-800 p-3 shadow-lg">
-                <h3 className="mb-3 border-b border-gray-600 pb-2 text-lg font-bold tracking-wider text-gray-300 uppercase">
+            <div className="mt-4 flex flex-col rounded-lg border border-(--card-border) bg-(--card-bg) p-3 text-(--card-fg) shadow-lg">
+                <h3 className="mb-3 border-b border-(--card-border) pb-2 text-lg font-bold tracking-wider text-(--card-fg) uppercase">
                     Alliance Resources
                 </h3>
 
                 <div className="flex flex-col divide-y divide-gray-700">
                     {[Alliance.Imperial, Alliance.Xenos, Alliance.Chaos].map(alliance => (
                         <div key={alliance} className="py-3">
-                            <h4 className="mb-2 text-sm font-semibold text-gray-400 uppercase">{alliance}</h4>
+                            <h4 className="mb-2 text-sm font-semibold text-(--card-fg) uppercase">{alliance}</h4>
 
                             <div className="grid grid-cols-2 gap-x-4">
                                 <div className="flex flex-wrap justify-start">

--- a/src/fsd/1-pages/plan-hse/hse.tsx
+++ b/src/fsd/1-pages/plan-hse/hse.tsx
@@ -339,7 +339,7 @@ export const HomeScreenEvent = () => {
                         <button
                             type="button"
                             aria-label="Dismiss warning permanently"
-                            className="rounded px-2 py-0.5 text-red-200 hover:bg-red-500/20 hover:text-red-100"
+                            className="text-warning-fg hover:bg-warning-fg/10 rounded px-2 py-0.5"
                             onClick={() =>
                                 dispatch.viewPreferences({
                                     type: 'Update',

--- a/src/fsd/1-pages/plan-hse/hse.tsx
+++ b/src/fsd/1-pages/plan-hse/hse.tsx
@@ -329,7 +329,7 @@ export const HomeScreenEvent = () => {
     return (
         <div>
             {showHseWarning && (
-                <div className="mb-2 rounded-md border border-red-500/60 bg-red-500/10 px-3 py-2 text-red-100">
+                <div className="text-warning-fg bg-warning border-warning mb-2 rounded-md border px-3 py-2">
                     <div className="flex items-start justify-between gap-3">
                         <h1 className="m-0 text-base leading-relaxed font-semibold">
                             This page is informational only. You most likely want the Daily Raids page instead, where
@@ -362,7 +362,7 @@ export const HomeScreenEvent = () => {
                             value={selectedEvent}
                             onChange={event => setSelectedEvent(event.target.value as IDailyRaidsHomeScreenEvent)}
                             size="small"
-                            className="rounded-md bg-slate-700">
+                            className="rounded-md">
                             <MenuItem value={IDailyRaidsHomeScreenEvent.purgeOrder}>Purge Order</MenuItem>
                             <MenuItem value={IDailyRaidsHomeScreenEvent.trainingRush}>Training Rush</MenuItem>
                             <MenuItem value={IDailyRaidsHomeScreenEvent.warpSurge}>Warp Surge</MenuItem>
@@ -386,7 +386,7 @@ export const HomeScreenEvent = () => {
                                 );
                             }}
                             size="small"
-                            className="rounded-md bg-slate-700"
+                            className="rounded-md"
                             style={{ minWidth: 200, maxWidth: 500 }}>
                             {CampaignsService.allCampaigns.map(campaign => (
                                 <MenuItem key={campaign.id} value={campaign.id} className="flex items-center gap-2">

--- a/src/fsd/1-pages/plan-lre/le-token-card.tsx
+++ b/src/fsd/1-pages/plan-lre/le-token-card.tsx
@@ -91,23 +91,7 @@ export const LeTokenCard: React.FC<CardProps> = ({
                         <SyncButton
                             showText={false}
                             variant="text"
-                            sx={{
-                                minWidth: 'auto',
-                                padding: 0,
-                                minHeight: 'auto',
-                                height: 'auto',
-                                fontSize: '0.75rem',
-                                lineHeight: '1.25rem',
-                                alignSelf: 'center',
-                                marginTop: '-4px',
-                                '& .MuiButton-startIcon': {
-                                    margin: 0,
-                                },
-                                '& .MuiSvgIcon-root': {
-                                    fontSize: '1.25rem',
-                                    verticalAlign: 'middle',
-                                },
-                            }}
+                            className="-mt-1 h-auto !min-h-[auto] !min-w-[auto] self-center !p-0 text-xs leading-5 [&_.MuiButton-startIcon]:!m-0 [&_.MuiSvgIcon-root]:align-middle [&_.MuiSvgIcon-root]:[font-size:1.25rem]"
                         />
                         <button
                             onClick={() => {

--- a/src/fsd/1-pages/plan-lre/le-token-table.tsx
+++ b/src/fsd/1-pages/plan-lre/le-token-table.tsx
@@ -226,23 +226,7 @@ export const LeTokenTable: React.FC<Props> = ({
                                                 <SyncButton
                                                     showText={false}
                                                     variant="text"
-                                                    sx={{
-                                                        minWidth: 'auto',
-                                                        padding: 0,
-                                                        minHeight: 'auto',
-                                                        height: 'auto',
-                                                        fontSize: '1.25rem',
-                                                        lineHeight: '1.25rem',
-                                                        alignSelf: 'center',
-                                                        marginTop: '-2px',
-                                                        '& .MuiButton-startIcon': {
-                                                            margin: 0,
-                                                        },
-                                                        '& .MuiSvgIcon-root': {
-                                                            fontSize: '1.25rem',
-                                                            verticalAlign: 'middle',
-                                                        },
-                                                    }}
+                                                    className="-mt-0.5 h-auto !min-h-[auto] !min-w-[auto] self-center !p-0 text-[1.25rem] leading-5 [&_.MuiButton-startIcon]:!m-0 [&_.MuiSvgIcon-root]:align-middle [&_.MuiSvgIcon-root]:[font-size:1.25rem]"
                                                 />
                                                 <button
                                                     onClick={() => {

--- a/src/fsd/2-widgets/app-bar/app-bar.tsx
+++ b/src/fsd/2-widgets/app-bar/app-bar.tsx
@@ -183,12 +183,7 @@ export const TopAppBar: React.FC<Props> = ({ headerTitle, seenAppVersion, onClos
                             </IconButton>
                         </Tooltip>
                         <Tooltip title="Sync with the Tacticus API">
-                            <SyncButton
-                                showText={false}
-                                variant={'text'}
-                                sx={{ minWidth: 0, px: 1 }}
-                                color={'inherit'}
-                            />
+                            <SyncButton showText={false} variant={'text'} className="!min-w-0 !px-2 !text-inherit" />
                         </Tooltip>
                         <ThemeSwitch />
                         <Button

--- a/src/fsd/2-widgets/app-bar/app-bar.tsx
+++ b/src/fsd/2-widgets/app-bar/app-bar.tsx
@@ -183,7 +183,12 @@ export const TopAppBar: React.FC<Props> = ({ headerTitle, seenAppVersion, onClos
                             </IconButton>
                         </Tooltip>
                         <Tooltip title="Sync with the Tacticus API">
-                            <SyncButton showText={false} variant={'text'} sx={{ minWidth: 0, px: 1 }} />
+                            <SyncButton
+                                showText={false}
+                                variant={'text'}
+                                sx={{ minWidth: 0, px: 1 }}
+                                color={'inherit'}
+                            />
                         </Tooltip>
                         <ThemeSwitch />
                         <Button

--- a/src/fsd/3-features/characters/components/faction-tile.tsx
+++ b/src/fsd/3-features/characters/components/faction-tile.tsx
@@ -48,7 +48,7 @@ export const FactionsTile = ({
     }, [faction.units.length]);
     const { showBsValue, showPower } = useContext(CharactersViewContext);
     return (
-        <div className="flex max-w-[525px] min-w-[375px] flex-col overflow-hidden rounded-xl border border-gray-800 bg-[#1a1a1a] shadow-lg max-[500px]:max-w-[375px] lg:max-w-[800px]">
+        <div className="flex max-w-[525px] min-w-[375px] flex-col overflow-hidden rounded-xl bg-(--muted) max-[500px]:max-w-[375px] lg:max-w-[800px]">
             {/* Modern Card Header */}
             <div
                 className="flex items-center justify-between px-3 py-2 font-medium text-white shadow-md"
@@ -85,14 +85,14 @@ export const FactionsTile = ({
             </div>
 
             {/* Units Container */}
-            <div className={`flex flex-wrap items-center gap-1 bg-[#121212]/50 p-2 ${factionClass}`}>
+            <div className={`flex flex-wrap items-center gap-1 p-2 ${factionClass}`}>
                 {faction.units.map(unit => {
                     const isCharacter = unit.unitType === UnitType.character;
                     return (
                         <div
                             key={unit.snowprintId}
                             onClick={() => onCharacterClick?.(unit)}
-                            className="flex-shrink-0 cursor-pointer transition-all duration-200 hover:scale-[1.03] hover:brightness-110 active:scale-95"
+                            className="shrink-0 cursor-pointer transition-all duration-200 hover:scale-[1.03] hover:brightness-110 active:scale-95"
                             title={`Select ${unit.name || 'Unit'}`}>
                             <RosterSnapshotCharacter
                                 char={isCharacter ? RosterSnapshotsService.snapshotCharacter(unit) : undefined}

--- a/src/fsd/5-shared/ui/sync-button/sync-button.tsx
+++ b/src/fsd/5-shared/ui/sync-button/sync-button.tsx
@@ -9,9 +9,10 @@ interface SyncButtonProps {
     showText: boolean;
     variant?: 'text' | 'outlined' | 'contained' | undefined;
     sx?: SxProps<Theme>;
+    color?: 'inherit' | 'primary' | 'secondary' | 'success' | 'error' | 'info' | 'warning' | undefined;
 }
 
-const SyncButton: React.FC<SyncButtonProps> = ({ showText, variant, sx }) => {
+const SyncButton: React.FC<SyncButtonProps> = ({ showText, variant, sx, color }) => {
     const { syncWithTacticus } = useSyncWithTacticus();
 
     const sync = async () => {
@@ -25,7 +26,7 @@ const SyncButton: React.FC<SyncButtonProps> = ({ showText, variant, sx }) => {
             aria-label="Sync with Tacticus"
             title="Sync with Tacticus"
             variant={variant === undefined ? 'contained' : variant}
-            color={'primary'}
+            color={color === undefined ? 'primary' : color}
             sx={sx}
             onClick={event => {
                 event.stopPropagation();

--- a/src/fsd/5-shared/ui/sync-button/sync-button.tsx
+++ b/src/fsd/5-shared/ui/sync-button/sync-button.tsx
@@ -1,5 +1,5 @@
 import SyncIcon from '@mui/icons-material/Sync';
-import { Button, SxProps, Theme } from '@mui/material';
+import { Button } from '@mui/material';
 import React from 'react';
 
 // eslint-disable-next-line import-x/no-internal-modules, boundaries/element-types
@@ -8,11 +8,10 @@ import { useSyncWithTacticus } from '@/fsd/3-features/tacticus-integration/use-s
 interface SyncButtonProps {
     showText: boolean;
     variant?: 'text' | 'outlined' | 'contained' | undefined;
-    sx?: SxProps<Theme>;
-    color?: 'inherit' | 'primary' | 'secondary' | 'success' | 'error' | 'info' | 'warning' | undefined;
+    className?: string;
 }
 
-const SyncButton: React.FC<SyncButtonProps> = ({ showText, variant, sx, color }) => {
+const SyncButton: React.FC<SyncButtonProps> = ({ showText, variant, className }) => {
     const { syncWithTacticus } = useSyncWithTacticus();
 
     const sync = async () => {
@@ -26,8 +25,8 @@ const SyncButton: React.FC<SyncButtonProps> = ({ showText, variant, sx, color })
             aria-label="Sync with Tacticus"
             title="Sync with Tacticus"
             variant={variant === undefined ? 'contained' : variant}
-            color={color === undefined ? 'primary' : color}
-            sx={sx}
+            color={'primary'}
+            className={className}
             onClick={event => {
                 event.stopPropagation();
                 sync();


### PR DESCRIPTION
I went through a lot based on this 

https://discord.com/channels/1146809197023997972/1492643336052408401

Now it looks like this 
<img width="98" height="53" alt="image" src="https://github.com/user-attachments/assets/aa890eaa-60ab-4839-9ad3-750702bdb0b4" />
<img width="1177" height="677" alt="image" src="https://github.com/user-attachments/assets/997787f3-3da3-43bc-b27a-d658bd4af2a0" />
<img width="1170" height="682" alt="image" src="https://github.com/user-attachments/assets/d6018db2-65a1-4118-bf19-2cc592d99f25" />
<img width="1176" height="480" alt="image" src="https://github.com/user-attachments/assets/f982a726-9407-4636-870b-c4be1aa54e1c" />


In dark mode

<img width="1160" height="864" alt="image" src="https://github.com/user-attachments/assets/3762d082-8005-420b-a067-fe89a1bbc5fc" />


<img width="1181" height="631" alt="image" src="https://github.com/user-attachments/assets/2d9ca76d-f8f0-4061-bd42-ae964d28ecc8" />

<img width="1179" height="716" alt="image" src="https://github.com/user-attachments/assets/395836f4-b9fb-443f-b124-206021ecba5b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sync button spacing and layout adjusted for a tighter header.

* **Style**
  * Added theme-level card color variables for consistent theming.
  * Resource and card UIs now use theme colors instead of hard-coded grays.
  * Warning panels updated to use the unified warning theme.
  * Card and unit tile backgrounds and sizing refined for improved visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->