### PR TITLE
feat: Add raid material dialog and related components

### DIFF
--- a/src/fsd/0-app/index.css
+++ b/src/fsd/0-app/index.css
@@ -153,6 +153,8 @@
     }
 
     .dark {
+        color-scheme: dark;
+
         --bg: rgb(37, 38, 36);
         --fg: rgba(214, 207, 195, 0.87);
 

--- a/src/fsd/3-features/goals/expandable-raid-locations.tsx
+++ b/src/fsd/3-features/goals/expandable-raid-locations.tsx
@@ -40,16 +40,14 @@ const LocationRow: React.FC<{ location: ICampaignBattleComposed }> = ({ location
                     setExpanded(v => !v);
                     setEverExpanded(true);
                 }}
-                className="flex w-full cursor-pointer items-center gap-2 px-2 py-1.5 text-sm text-[var(--card-fg)]"
-                style={{ opacity: location.isUnlocked ? 1 : 0.5 }}>
+                className={`flex w-full cursor-pointer items-center gap-2 px-2 py-1.5 text-sm text-[var(--card-fg)] ${location.isUnlocked ? '' : 'opacity-50'}`}>
                 <CampaignImage campaign={location.campaign} size={20} showTooltip={false} />
                 <div className="flex min-w-0 flex-1 items-center gap-1.5">
                     <span className="min-w-0 truncate font-medium">{location.campaign}</span>
                     {!isOnslaught && <span className="shrink-0">· {nodeLabel}</span>}
                 </div>
                 <ExpandMoreIcon
-                    className={`shrink-0 text-[var(--muted-fg)] transition-transform duration-200 ${expanded ? 'rotate-180' : ''}`}
-                    style={{ fontSize: 18 }}
+                    className={`shrink-0 text-[18px] text-[var(--muted-fg)] transition-transform duration-200 ${expanded ? 'rotate-180' : ''}`}
                 />
             </button>
 

--- a/src/fsd/3-features/goals/expandable-raid-locations.tsx
+++ b/src/fsd/3-features/goals/expandable-raid-locations.tsx
@@ -1,0 +1,91 @@
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import React, { lazy, Suspense, useState } from 'react';
+
+import { CampaignImage, Campaign, ICampaignBattleComposed } from '@/fsd/4-entities/campaign';
+
+const LocationDetails = lazy(() => import('./location-details').then(m => ({ default: m.LocationDetails })));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const CHALLENGE_CAMPAIGNS = new Set([
+    Campaign.AMSC,
+    Campaign.AMEC,
+    Campaign.DGSC,
+    Campaign.DGEC,
+    Campaign.TSC,
+    Campaign.TEC,
+    Campaign.TASC,
+    Campaign.TAEC,
+    Campaign.ASSC,
+    Campaign.ASEC,
+]);
+
+const getNodeLabel = (location: ICampaignBattleComposed): string =>
+    CHALLENGE_CAMPAIGNS.has(location.campaign) ? `${location.nodeNumber}B` : String(location.nodeNumber);
+
+// ─── LocationRow ─────────────────────────────────────────────────────────────
+
+const LocationRow: React.FC<{ location: ICampaignBattleComposed }> = ({ location }) => {
+    const [expanded, setExpanded] = useState(false);
+    const [everExpanded, setEverExpanded] = useState(false);
+
+    const nodeLabel = getNodeLabel(location);
+    const isOnslaught = location.campaign === Campaign.Onslaught;
+
+    return (
+        <div className={`rounded-md transition-colors ${expanded ? 'bg-(--secondary)' : 'hover:bg-(--secondary)'}`}>
+            <button
+                type="button"
+                onClick={() => {
+                    setExpanded(v => !v);
+                    setEverExpanded(true);
+                }}
+                className="flex w-full cursor-pointer items-center gap-2 px-2 py-1.5 text-sm text-[var(--card-fg)]"
+                style={{ opacity: location.isUnlocked ? 1 : 0.5 }}>
+                <CampaignImage campaign={location.campaign} size={20} showTooltip={false} />
+                <div className="flex min-w-0 flex-1 items-center gap-1.5">
+                    <span className="min-w-0 truncate font-medium">{location.campaign}</span>
+                    {!isOnslaught && <span className="shrink-0">· {nodeLabel}</span>}
+                </div>
+                <ExpandMoreIcon
+                    className={`shrink-0 text-[var(--muted-fg)] transition-transform duration-200 ${expanded ? 'rotate-180' : ''}`}
+                    style={{ fontSize: 18 }}
+                />
+            </button>
+
+            {everExpanded && (
+                <div
+                    className={`grid transition-[grid-template-rows] duration-200 ${expanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}>
+                    <div className="overflow-hidden">
+                        <div className="ml-3 border-l-2 border-(--primary) pr-2 pb-2 pl-3">
+                            <Suspense fallback={undefined}>
+                                <LocationDetails location={location} />
+                            </Suspense>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+};
+
+// ─── ExpandableRaidLocations ──────────────────────────────────────────────────
+
+interface Props {
+    locations: ICampaignBattleComposed[];
+}
+
+export const ExpandableRaidLocations: React.FC<Props> = ({ locations }) => {
+    if (locations.length === 0) return;
+
+    const suggested = locations.filter(l => l.isSuggested && l.isUnlocked);
+    const displayLocations = suggested.length > 0 ? suggested : locations;
+
+    return (
+        <div className="flex max-h-96 flex-col gap-1 overflow-y-auto">
+            {displayLocations.map(loc => (
+                <LocationRow key={loc.id} location={loc} />
+            ))}
+        </div>
+    );
+};

--- a/src/fsd/3-features/goals/expandable-raid-locations.tsx
+++ b/src/fsd/3-features/goals/expandable-raid-locations.tsx
@@ -40,7 +40,7 @@ const LocationRow: React.FC<{ location: ICampaignBattleComposed }> = ({ location
                     setExpanded(v => !v);
                     setEverExpanded(true);
                 }}
-                className={`flex w-full cursor-pointer items-center gap-2 px-2 py-1.5 text-sm text-[var(--card-fg)] ${location.isUnlocked ? '' : 'opacity-50'}`}>
+                className={`flex w-full cursor-pointer items-center gap-2 px-2 py-1.5 text-sm text-[var(--card-fg)] ${location.isUnlocked ? 'opacity-100' : 'opacity-50'}`}>
                 <CampaignImage campaign={location.campaign} size={20} showTooltip={false} />
                 <div className="flex min-w-0 flex-1 items-center gap-1.5">
                     <span className="min-w-0 truncate font-medium">{location.campaign}</span>

--- a/src/fsd/3-features/goals/location-details.tsx
+++ b/src/fsd/3-features/goals/location-details.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+
+import { MiscIcon } from '@/fsd/5-shared/ui/icons';
+
+import { CampaignBattleEnemies, ICampaignBattleComposed } from '@/fsd/4-entities/campaign';
+import { recipeDataByName, UpgradeImage } from '@/fsd/4-entities/upgrade';
+
+interface Props {
+    location: ICampaignBattleComposed;
+}
+
+const getRewardId = (location: ICampaignBattleComposed): string => {
+    for (const r of location.rewards.guaranteed) {
+        if (r.id !== 'gold') return r.id;
+    }
+    for (const r of location.rewards.potential) {
+        if (r.id !== 'gold') return r.id;
+    }
+    return '';
+};
+
+export const LocationDetails: React.FC<Props> = ({ location }) => {
+    const rewardId = getRewardId(location);
+    const rewardMaterial = recipeDataByName[rewardId];
+    const rewardName = rewardMaterial?.label ?? rewardMaterial?.material ?? rewardId;
+
+    return (
+        <div className="pt-1 pb-1 text-[var(--card-fg)]">
+            <div className="mb-3 flex flex-wrap items-center gap-3 text-sm text-inherit">
+                <span className="inline-flex items-center gap-1">
+                    <MiscIcon icon="energy" width={16} height={16} />
+                    {location.energyCost}
+                </span>
+                {location.slots != undefined && (
+                    <span className="inline-flex items-center gap-1">
+                        <MiscIcon icon="deployment" width={16} height={16} />
+                        {location.slots}
+                    </span>
+                )}
+                {rewardId && (
+                    <span className="inline-flex items-center gap-1">
+                        Reward:
+                        {rewardMaterial ? (
+                            <UpgradeImage
+                                material={rewardMaterial.label ?? rewardName}
+                                iconPath={rewardMaterial.icon ?? ''}
+                                rarity={rewardMaterial.rarity ?? ''}
+                                size={24}
+                                tooltip={rewardName || '-'}
+                            />
+                        ) : (
+                            <span className="text-inherit">{rewardName || '-'}</span>
+                        )}
+                    </span>
+                )}
+            </div>
+
+            {(location.rawEnemyTypes ?? []).length > 0 && (
+                <div>
+                    <div className="mb-1 text-xs font-semibold text-[var(--muted-fg)] uppercase">Enemies</div>
+                    <div className="flex justify-center">
+                        <CampaignBattleEnemies
+                            keyPrefix="expandable"
+                            battleId={location.id}
+                            enemies={location.rawEnemyTypes ?? []}
+                            scale={0.22}
+                        />
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+};

--- a/src/fsd/3-features/goals/location-details.tsx
+++ b/src/fsd/3-features/goals/location-details.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { RarityMapper } from '@/fsd/5-shared/model';
 import { MiscIcon } from '@/fsd/5-shared/ui/icons';
 
 import { CampaignBattleEnemies, ICampaignBattleComposed } from '@/fsd/4-entities/campaign';
@@ -44,7 +45,7 @@ export const LocationDetails: React.FC<Props> = ({ location }) => {
                             <UpgradeImage
                                 material={rewardMaterial.label ?? rewardName}
                                 iconPath={rewardMaterial.icon ?? ''}
-                                rarity={rewardMaterial.rarity ?? ''}
+                                rarity={RarityMapper.stringToRarityString(rewardMaterial.rarity ?? '')}
                                 size={24}
                                 tooltip={rewardName || '-'}
                             />

--- a/src/fsd/3-features/goals/raid-day-helpers.ts
+++ b/src/fsd/3-features/goals/raid-day-helpers.ts
@@ -1,0 +1,15 @@
+import { CharactersService } from '@/fsd/4-entities/character';
+import { mows2Data } from '@/fsd/4-entities/mow';
+
+export const getDisplayName = (idOrName: string): string => {
+    const char = CharactersService.getUnit(idOrName);
+    if (char) return char.shortName || char.name;
+    const mow = mows2Data.mows.find(m => m.snowprintId === idOrName || m.name === idOrName);
+    if (mow) return mow.name;
+    return idOrName;
+};
+
+export const getCharacterIcon = (id: string): string =>
+    CharactersService.getUnit(id)?.roundIcon ??
+    mows2Data.mows.find(m => m.name === id || m.snowprintId === id)?.roundIcon ??
+    id;

--- a/src/fsd/3-features/goals/raid-locations.tsx
+++ b/src/fsd/3-features/goals/raid-locations.tsx
@@ -2,16 +2,16 @@ import React, { useMemo, useState, useCallback, memo } from 'react';
 
 import { ButtonPill } from '@/fsd/5-shared/ui';
 
-import { ICampaignBattleComposed } from '@/fsd/4-entities/campaign/@x/upgrade';
-import { ChipCampaignLocation } from '@/fsd/4-entities/campaign/chip-campaign-location';
+import { ChipCampaignLocation, ICampaignBattleComposed } from '@/fsd/4-entities/campaign';
 
 interface Props {
     locations: ICampaignBattleComposed[];
     maxLocations?: number;
     compactRaidLocations?: boolean;
+    clickable?: boolean;
 }
 
-const Component: React.FC<Props> = ({ locations, maxLocations, compactRaidLocations = true }) => {
+const Component: React.FC<Props> = ({ locations, maxLocations, compactRaidLocations = true, clickable = true }) => {
     const [expanded, setExpanded] = useState(false);
 
     const effectiveMaxLocations = useMemo(() => {
@@ -51,6 +51,7 @@ const Component: React.FC<Props> = ({ locations, maxLocations, compactRaidLocati
                     location={loc}
                     unlocked={loc.isUnlocked ?? false}
                     compact={compactRaidLocations}
+                    clickable={clickable}
                 />
             ))}
 
@@ -73,6 +74,7 @@ export const RaidLocations = memo(Component, (previous, next) => {
     return (
         previous.maxLocations === next.maxLocations &&
         previous.locations === next.locations &&
-        previous.compactRaidLocations === next.compactRaidLocations
+        previous.compactRaidLocations === next.compactRaidLocations &&
+        previous.clickable === next.clickable
     );
 });

--- a/src/fsd/3-features/goals/raid-material-dialog.tsx
+++ b/src/fsd/3-features/goals/raid-material-dialog.tsx
@@ -1,0 +1,106 @@
+import CloseIcon from '@mui/icons-material/Close';
+import { Dialog, DialogContent, DialogTitle, IconButton } from '@mui/material';
+import React from 'react';
+
+import { UnitShardIcon } from '@/fsd/5-shared/ui/icons';
+
+import { IUpgradeRaid } from './goals.models';
+import { getCharacterIcon, getDisplayName } from './raid-day-helpers';
+import { RaidLocations } from './raid-locations';
+import { RaidMaterialIcon } from './raid-material-icon';
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+interface RaidMaterialDialogProps {
+    raid: IUpgradeRaid;
+    onClose: () => void;
+}
+
+export const RaidMaterialDialog: React.FC<RaidMaterialDialogProps> = ({ raid, onClose }) => {
+    const afterRaids = raid.acquiredCount + raid.raidLocations.reduce((s, loc) => s + loc.farmedItems, 0);
+    const isSufficient = afterRaids >= raid.requiredCount;
+    const inventoryPct = raid.requiredCount > 0 ? Math.min((raid.acquiredCount / raid.requiredCount) * 100, 100) : 0;
+    const gainPct =
+        raid.requiredCount > 0
+            ? Math.min(((afterRaids - raid.acquiredCount) / raid.requiredCount) * 100, 100 - inventoryPct)
+            : 0;
+    const uniqueCharIds = [...new Set(raid.relatedCharacters)];
+
+    return (
+        <Dialog
+            open
+            onClose={onClose}
+            maxWidth="xs"
+            fullWidth
+            PaperProps={{ className: 'bg-(--card-bg)! text-(--card-fg)!' }}
+            aria-labelledby="raid-material-dialog-title">
+            <DialogTitle id="raid-material-dialog-title" className="flex items-center gap-3 pr-2 text-(--card-fg)">
+                <div className="shrink-0">
+                    <RaidMaterialIcon raid={raid} size={44} />
+                </div>
+                <span className="flex-1 text-inherit">{raid.label}</span>
+                <IconButton aria-label="close" onClick={onClose} size="small" className="self-start">
+                    <CloseIcon fontSize="small" />
+                </IconButton>
+            </DialogTitle>
+
+            <DialogContent className="flex flex-col gap-5 pb-5! text-(--card-fg)">
+                {/* Characters */}
+                {uniqueCharIds.length > 0 && (
+                    <div>
+                        <div className="mb-2 text-xs font-semibold tracking-wide text-(--muted-fg) uppercase">
+                            Characters
+                        </div>
+                        <div className="flex flex-wrap gap-3">
+                            {uniqueCharIds.map(id => (
+                                <div key={id} className="flex items-center gap-1.5">
+                                    <UnitShardIcon icon={getCharacterIcon(id)} height={28} width={28} />
+                                    <span className="text-sm text-inherit">{getDisplayName(id)}</span>
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                )}
+
+                {/* Progress */}
+                <div>
+                    <div className="mb-2 text-xs font-semibold tracking-wide text-(--muted-fg) uppercase">Progress</div>
+                    <div className="relative mb-3 h-3 w-full overflow-hidden rounded-full bg-(--secondary)">
+                        <div
+                            className="absolute top-0 left-0 h-full bg-slate-400"
+                            style={{ width: `${inventoryPct}%` }}
+                        />
+                        <div
+                            className={`absolute top-0 h-full transition-all ${isSufficient ? 'bg-green-500' : 'bg-orange-400'}`}
+                            style={{ left: `${inventoryPct}%`, width: `${gainPct}%` }}
+                        />
+                    </div>
+                    <div className="grid grid-cols-3 gap-2 text-center">
+                        <div className="rounded-lg bg-(--secondary) p-2">
+                            <div className="text-xs text-(--muted-fg)">In inventory</div>
+                            <div className="text-xl font-bold text-inherit">{Math.floor(raid.acquiredCount)}</div>
+                        </div>
+                        <div className="rounded-lg bg-(--secondary) p-2">
+                            <div className="text-xs text-(--muted-fg)">After raids</div>
+                            <div className={`text-xl font-bold ${isSufficient ? 'text-green-500' : 'text-orange-400'}`}>
+                                {Math.floor(afterRaids)}
+                            </div>
+                        </div>
+                        <div className="rounded-lg bg-(--secondary) p-2">
+                            <div className="text-xs text-(--muted-fg)">Required</div>
+                            <div className="text-xl font-bold text-inherit">{raid.requiredCount}</div>
+                        </div>
+                    </div>
+                </div>
+
+                {/* Locations */}
+                <div>
+                    <div className="mb-2 text-xs font-semibold tracking-wide text-(--muted-fg) uppercase">
+                        Locations
+                    </div>
+                    <RaidLocations locations={raid.raidLocations} compactRaidLocations={false} clickable={false} />
+                </div>
+            </DialogContent>
+        </Dialog>
+    );
+};

--- a/src/fsd/3-features/goals/raid-material-dialog.tsx
+++ b/src/fsd/3-features/goals/raid-material-dialog.tsx
@@ -1,12 +1,12 @@
 import CloseIcon from '@mui/icons-material/Close';
-import { Dialog, DialogContent, DialogTitle, IconButton } from '@mui/material';
+import { Dialog, DialogContent, DialogTitle, IconButton, useMediaQuery } from '@mui/material';
 import React from 'react';
 
 import { UnitShardIcon } from '@/fsd/5-shared/ui/icons';
 
+import { ExpandableRaidLocations } from './expandable-raid-locations';
 import { IUpgradeRaid } from './goals.models';
 import { getCharacterIcon, getDisplayName } from './raid-day-helpers';
-import { RaidLocations } from './raid-locations';
 import { RaidMaterialIcon } from './raid-material-icon';
 
 // ─── Component ───────────────────────────────────────────────────────────────
@@ -17,6 +17,7 @@ interface RaidMaterialDialogProps {
 }
 
 export const RaidMaterialDialog: React.FC<RaidMaterialDialogProps> = ({ raid, onClose }) => {
+    const fullScreen = useMediaQuery('(max-width:600px)');
     const afterRaids = raid.acquiredCount + raid.raidLocations.reduce((s, loc) => s + loc.farmedItems, 0);
     const isSufficient = afterRaids >= raid.requiredCount;
     const inventoryPct = raid.requiredCount > 0 ? Math.min((raid.acquiredCount / raid.requiredCount) * 100, 100) : 0;
@@ -30,6 +31,7 @@ export const RaidMaterialDialog: React.FC<RaidMaterialDialogProps> = ({ raid, on
         <Dialog
             open
             onClose={onClose}
+            fullScreen={fullScreen}
             maxWidth="xs"
             fullWidth
             PaperProps={{ className: 'bg-(--card-bg)! text-(--card-fg)!' }}
@@ -98,7 +100,7 @@ export const RaidMaterialDialog: React.FC<RaidMaterialDialogProps> = ({ raid, on
                     <div className="mb-2 text-xs font-semibold tracking-wide text-(--muted-fg) uppercase">
                         Locations
                     </div>
-                    <RaidLocations locations={raid.raidLocations} compactRaidLocations={false} clickable={false} />
+                    <ExpandableRaidLocations locations={raid.raidLocations} />
                 </div>
             </DialogContent>
         </Dialog>

--- a/src/fsd/3-features/goals/raid-material-icon.tsx
+++ b/src/fsd/3-features/goals/raid-material-icon.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+
+import { Rarity, RarityMapper } from '@/fsd/5-shared/model';
+import { AccessibleTooltip } from '@/fsd/5-shared/ui';
+import { UnitShardIcon } from '@/fsd/5-shared/ui/icons';
+
+import { CharactersService } from '@/fsd/4-entities/character';
+import { mows2Data } from '@/fsd/4-entities/mow';
+import { UpgradeImage } from '@/fsd/4-entities/upgrade';
+
+import { IUpgradeRaid } from './goals.models';
+
+// ─── Private helpers ─────────────────────────────────────────────────────────
+
+const mowMap = new Map(mows2Data.mows.map(m => [m.snowprintId, m]));
+
+const mapUpgradeRarity = (rarity: Rarity | 'Shard' | 'Mythic Shard'): Rarity =>
+    typeof rarity === 'number' ? rarity : Rarity.Common;
+
+const resolveUnit = (id: string): { icon: string } | undefined => {
+    const char = CharactersService.getUnit(id);
+    if (char) return { icon: char.roundIcon };
+    const mow = mowMap.get(id);
+    if (mow) return { icon: mow.roundIcon };
+    return undefined;
+};
+
+const resolveShardMaterialId = (raid: IUpgradeRaid): string => {
+    if (raid.rarity === 'Shard') return raid.snowprintId.slice(7);
+    if (raid.rarity === 'Mythic Shard') return raid.snowprintId.slice(13);
+    return raid.snowprintId;
+};
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export interface RaidMaterialIconProps {
+    raid: IUpgradeRaid;
+    size?: number;
+    tooltip?: React.ReactNode;
+}
+
+export const RaidMaterialIcon: React.FC<RaidMaterialIconProps> = ({ raid, size = 40, tooltip }) => {
+    const isShard = raid.rarity === 'Shard';
+    const isMythicShard = raid.rarity === 'Mythic Shard';
+
+    if (isShard || isMythicShard) {
+        const materialId = resolveShardMaterialId(raid);
+        const icon = (
+            <UnitShardIcon
+                name={raid.snowprintId}
+                icon={resolveUnit(materialId)?.icon ?? materialId}
+                mythic={isMythicShard}
+                height={size}
+                width={size}
+            />
+        );
+        return tooltip ? (
+            <AccessibleTooltip title={tooltip}>
+                <span>{icon}</span>
+            </AccessibleTooltip>
+        ) : (
+            icon
+        );
+    }
+
+    return (
+        <UpgradeImage
+            material={raid.label}
+            iconPath={raid.iconPath}
+            rarity={RarityMapper.rarityToRarityString(mapUpgradeRarity(raid.rarity))}
+            size={size}
+            tooltip={tooltip}
+        />
+    );
+};

--- a/src/fsd/3-features/goals/raids-day-view.tsx
+++ b/src/fsd/3-features/goals/raids-day-view.tsx
@@ -1,45 +1,134 @@
-﻿import { Card, CardContent, CardHeader } from '@mui/material';
-import React from 'react';
+import React, { lazy, Suspense, useMemo, useState } from 'react';
 
-// eslint-disable-next-line import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure
-import { IUpgradesRaidsDay } from '@/fsd/3-features/goals/goals.models';
-// eslint-disable-next-line import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure
-import { MaterialItemView } from '@/fsd/3-features/goals/material-item-view';
+import { getEstimatedDate } from '@/fsd/5-shared/lib';
+import { AccessibleTooltip } from '@/fsd/5-shared/ui';
+import { MiscIcon, UnitShardIcon } from '@/fsd/5-shared/ui/icons';
+
+import { IUpgradeRaid, IUpgradesRaidsDay } from './goals.models';
+import { getCharacterIcon, getDisplayName } from './raid-day-helpers';
+
+const RaidMaterialDialog = lazy(() => import('./raid-material-dialog').then(m => ({ default: m.RaidMaterialDialog })));
+const RaidMaterialIcon = lazy(() => import('./raid-material-icon').then(m => ({ default: m.RaidMaterialIcon })));
 
 interface Props {
     day: IUpgradesRaidsDay;
     title: string;
+    dayIndex: number;
+    expanded: boolean;
+    energyPerDay: number;
 }
 
-export const RaidsDayView: React.FC<Props> = ({ day, title }) => {
-    return (
-        <Card
-            variant="outlined"
-            sx={{
-                minWidth: 300,
-            }}>
-            <CardHeader
-                title={title}
-                subheader={
-                    <div className="flex-box column start">
-                        <span>Energy used {day.energyTotal}</span>
-                        <span>Raids count {day.raidsTotal}</span>
-                    </div>
+const buildTooltip = (label: string, relatedCharacters: string[]) => (
+    <div>
+        {label}
+        {relatedCharacters.length > 0 && (
+            <ul className="ps-[15px]">
+                {[...new Set(relatedCharacters.map(name => getDisplayName(name)))].map(name => (
+                    <li key={name}>{name}</li>
+                ))}
+            </ul>
+        )}
+    </div>
+);
+
+export const RaidsDayView: React.FC<Props> = ({ day, title, dayIndex, expanded, energyPerDay }) => {
+    const [selectedRaid, setSelectedRaid] = useState<IUpgradeRaid | undefined>();
+
+    const calendarDate = useMemo(() => getEstimatedDate(dayIndex + 1), [dayIndex]);
+
+    const characterIds = useMemo(() => {
+        const seen = new Set<string>();
+        const ids: string[] = [];
+        for (const raid of day.raids) {
+            if (raid.isFinished) continue;
+            for (const charId of raid.relatedCharacters) {
+                if (!seen.has(charId)) {
+                    seen.add(charId);
+                    ids.push(charId);
                 }
-            />
-            <CardContent>
-                <ul className="list-none p-0">
-                    {day.raids
-                        .filter(raid => raid.raidLocations.length > 0)
-                        .map((raid, index) => {
-                            return (
-                                <li key={raid.id + index}>
-                                    <MaterialItemView upgradeRaid={raid} />
-                                </li>
-                            );
-                        })}
-                </ul>
-            </CardContent>
-        </Card>
+            }
+        }
+        return ids;
+    }, [day.raids]);
+
+    const farmableRaids = useMemo(() => day.raids.filter(raid => raid.raidLocations.length > 0), [day.raids]);
+
+    const energyFillPct = energyPerDay > 0 ? Math.min((day.energyTotal / energyPerDay) * 100, 100) : 0;
+    const energyFull = energyFillPct >= 95;
+
+    return (
+        <div className="flex min-w-[220px] flex-col rounded-xl border border-(--card-border) bg-(--card-bg) p-3 text-(--card-fg) shadow-sm">
+            {/* Header - always visible */}
+            <div className="flex flex-col gap-2">
+                {/* Title row */}
+                <div className="flex items-center justify-between gap-2">
+                    <span className="font-semibold">{dayIndex === 0 ? 'Today' : title}</span>
+                    <span className="text-xs opacity-60">{calendarDate}</span>
+                </div>
+
+                {/* Stats chips */}
+                <div className="flex items-center gap-1.5">
+                    <span className="flex items-center gap-1 rounded-full bg-(--secondary) px-2 py-0.5 text-xs">
+                        <MiscIcon icon="energy" height={12} width={12} />
+                        <span>{day.energyTotal}</span>
+                        {energyPerDay > 0 && <span className="opacity-50">/{energyPerDay}</span>}
+                    </span>
+                    <span className="flex items-center gap-1 rounded-full bg-(--secondary) px-2 py-0.5 text-xs">
+                        <MiscIcon icon="raidTicket" height={12} width={12} />
+                        {day.raidsTotal}
+                    </span>
+                </div>
+
+                {/* Energy fill bar */}
+                {energyPerDay > 0 && (
+                    <div className="h-1.5 w-full overflow-hidden rounded-full bg-(--secondary)">
+                        <div
+                            className={`h-full rounded-full transition-all ${energyFull ? 'bg-green-500' : 'bg-amber-400'}`}
+                            style={{ width: `${energyFillPct}%` }}
+                        />
+                    </div>
+                )}
+
+                {/* Character icons */}
+                {characterIds.length > 0 && (
+                    <div className="flex flex-wrap gap-1">
+                        {characterIds.map(id => (
+                            <AccessibleTooltip key={id} title={getDisplayName(id)}>
+                                <span>
+                                    <UnitShardIcon icon={getCharacterIcon(id)} height={24} width={24} />
+                                </span>
+                            </AccessibleTooltip>
+                        ))}
+                    </div>
+                )}
+            </div>
+
+            {/* Expanded: 3-col material icon grid */}
+            {expanded && farmableRaids.length > 0 && (
+                <Suspense fallback={undefined}>
+                    <div className="mt-3 grid grid-cols-3 gap-1 border-t border-(--card-border) pt-3">
+                        {farmableRaids.map((raid, index) => (
+                            <button
+                                key={index}
+                                type="button"
+                                onClick={() => setSelectedRaid(raid)}
+                                className="flex items-center justify-center rounded-md p-1 transition-colors hover:bg-(--secondary)">
+                                <RaidMaterialIcon
+                                    raid={raid}
+                                    size={40}
+                                    tooltip={buildTooltip(raid.label, raid.relatedCharacters)}
+                                />
+                            </button>
+                        ))}
+                    </div>
+                </Suspense>
+            )}
+
+            {selectedRaid && (
+                <Suspense fallback={undefined}>
+                    <RaidMaterialDialog raid={selectedRaid} onClose={() => setSelectedRaid(undefined)} />
+                </Suspense>
+            )}
+        </div>
     );
 };

--- a/src/fsd/4-entities/campaign/chip-campaign-location.tsx
+++ b/src/fsd/4-entities/campaign/chip-campaign-location.tsx
@@ -17,6 +17,7 @@ interface Props {
     unlocked: boolean;
     compact?: boolean;
     widthClass?: string;
+    clickable?: boolean;
 }
 
 interface CampaignBattleCardPreviewProps {
@@ -106,7 +107,13 @@ const CampaignBattleCardPreview: React.FC<CampaignBattleCardPreviewProps> = ({ b
     );
 };
 
-export const ChipCampaignLocation: React.FC<Props> = ({ location, unlocked, compact = true, widthClass }) => {
+export const ChipCampaignLocation: React.FC<Props> = ({
+    location,
+    unlocked,
+    compact = true,
+    widthClass,
+    clickable = true,
+}) => {
     const [openDetails, setOpenDetails] = useState(false);
 
     const locationNumber = useMemo(() => {
@@ -143,8 +150,8 @@ export const ChipCampaignLocation: React.FC<Props> = ({ location, unlocked, comp
             <Tooltip title={location.campaign} placement="top">
                 <button
                     type="button"
-                    onClick={() => setOpenDetails(true)}
-                    className={`border-muted-fg/40 inline-flex cursor-pointer items-center gap-1 overflow-hidden rounded-full border bg-transparent px-2 py-0.5 ${setWidthClass} text-[var(--card-fg)]`.trim()}
+                    onClick={clickable ? () => setOpenDetails(true) : undefined}
+                    className={`border-muted-fg/40 inline-flex items-center gap-1 overflow-hidden rounded-full border bg-transparent px-2 py-0.5 ${setWidthClass} text-[var(--card-fg)] ${clickable ? 'cursor-pointer' : 'cursor-default'}`.trim()}
                     style={{
                         opacity: unlocked ? 1 : 0.5,
                     }}>
@@ -158,7 +165,7 @@ export const ChipCampaignLocation: React.FC<Props> = ({ location, unlocked, comp
             </Tooltip>
 
             <Dialog
-                open={openDetails}
+                open={clickable && openDetails}
                 onClose={() => setOpenDetails(false)}
                 maxWidth="sm"
                 aria-labelledby="campaign-location-dialog-title">

--- a/src/fsd/4-entities/campaign/chip-campaign-location.tsx
+++ b/src/fsd/4-entities/campaign/chip-campaign-location.tsx
@@ -159,7 +159,7 @@ export const ChipCampaignLocation: React.FC<Props> = ({
                     }}>
                     <CampaignImage campaign={location.campaign} size={20} showTooltip={false} />
                     <div
-                        className={`flex flex-1 items-center justify-between text-[12px] leading-none text-inherit ${compact ? '' : 'overflow-hidden'}`.trim()}>
+                        className={`flex flex-1 items-center text-[12px] leading-none text-inherit ${compact ? 'justify-between' : 'justify-start gap-2 overflow-hidden'}`.trim()}>
                         <span className={compact ? undefined : 'min-w-0 truncate'}>{locationText}</span>
                         {!isOnslaught && <span className="shrink-0 pl-1">{locationNumber}</span>}
                     </div>

--- a/src/fsd/4-entities/campaign/chip-campaign-location.tsx
+++ b/src/fsd/4-entities/campaign/chip-campaign-location.tsx
@@ -151,6 +151,8 @@ export const ChipCampaignLocation: React.FC<Props> = ({
                 <button
                     type="button"
                     onClick={clickable ? () => setOpenDetails(true) : undefined}
+                    tabIndex={clickable ? undefined : -1}
+                    aria-disabled={clickable ? undefined : true}
                     className={`border-muted-fg/40 inline-flex items-center gap-1 overflow-hidden rounded-full border bg-transparent px-2 py-0.5 ${setWidthClass} text-[var(--card-fg)] ${clickable ? 'cursor-pointer' : 'cursor-default'}`.trim()}
                     style={{
                         opacity: unlocked ? 1 : 0.5,

--- a/src/fsd/4-entities/campaign/index.ts
+++ b/src/fsd/4-entities/campaign/index.ts
@@ -4,3 +4,4 @@ export { Campaign, CampaignType, CampaignGroupType, CampaignDifficulty } from '.
 export { campaignsByGroup, campaignEventsLocations } from './campaigns.constants';
 export { CampaignLocation } from './campaign-location';
 export { CampaignImage } from './campaign.icon';
+export { ChipCampaignLocation } from './chip-campaign-location';

--- a/src/fsd/4-entities/campaign/index.ts
+++ b/src/fsd/4-entities/campaign/index.ts
@@ -5,3 +5,4 @@ export { campaignsByGroup, campaignEventsLocations } from './campaigns.constants
 export { CampaignLocation } from './campaign-location';
 export { CampaignImage } from './campaign.icon';
 export { ChipCampaignLocation } from './chip-campaign-location';
+export { CampaignBattleEnemies } from './campaign-battle-enemies';

--- a/src/fsd/4-entities/upgrade/index.ts
+++ b/src/fsd/4-entities/upgrade/index.ts
@@ -9,5 +9,6 @@ export type {
     IRecipeExpandedUpgrade,
 } from './model';
 export { UpgradeImage } from './upgrade-image';
+export { recipeDataByName } from './data';
 export { UpgradeControl } from './upgrade-control';
 export { UpgradesService } from './upgrades.service';

--- a/src/fsd/5-shared/lib/use-drag-scroll.ts
+++ b/src/fsd/5-shared/lib/use-drag-scroll.ts
@@ -1,0 +1,68 @@
+import React, { useRef } from 'react';
+
+export const useDragScroll = () => {
+    const scrollReference = useRef<HTMLDivElement>(null);
+    const dragState = useRef({ isDragging: false, startX: 0, scrollLeft: 0 });
+
+    const onMouseDown = (event: React.MouseEvent) => {
+        const element = scrollReference.current;
+        if (!element) return;
+        dragState.current = {
+            isDragging: true,
+            startX: event.pageX - element.offsetLeft,
+            scrollLeft: element.scrollLeft,
+        };
+        element.style.cursor = 'grabbing';
+        element.style.userSelect = 'none';
+    };
+
+    const onMouseMove = (event: React.MouseEvent) => {
+        if (!dragState.current.isDragging || !scrollReference.current) return;
+        event.preventDefault();
+        scrollReference.current.scrollLeft =
+            dragState.current.scrollLeft -
+            (event.pageX - scrollReference.current.offsetLeft - dragState.current.startX) * 1.5;
+    };
+
+    const onMouseEnd = () => {
+        const element = scrollReference.current;
+        if (!element) return;
+        dragState.current.isDragging = false;
+        element.style.cursor = 'grab';
+        element.style.userSelect = '';
+    };
+
+    const onTouchStart = (event: React.TouchEvent) => {
+        const element = scrollReference.current;
+        if (!element) return;
+        const touch = event.touches[0];
+        dragState.current = {
+            isDragging: true,
+            startX: touch.pageX - element.offsetLeft,
+            scrollLeft: element.scrollLeft,
+        };
+    };
+
+    const onTouchMove = (event: React.TouchEvent) => {
+        if (!dragState.current.isDragging || !scrollReference.current) return;
+        const touch = event.touches[0];
+        scrollReference.current.scrollLeft =
+            dragState.current.scrollLeft -
+            (touch.pageX - scrollReference.current.offsetLeft - dragState.current.startX) * 1.5;
+    };
+
+    const onTouchEnd = () => {
+        dragState.current.isDragging = false;
+    };
+
+    return {
+        scrollRef: scrollReference,
+        onMouseDown,
+        onMouseMove,
+        onMouseUp: onMouseEnd,
+        onMouseLeave: onMouseEnd,
+        onTouchStart,
+        onTouchMove,
+        onTouchEnd,
+    };
+};

--- a/src/fsd/5-shared/lib/use-drag-scroll.ts
+++ b/src/fsd/5-shared/lib/use-drag-scroll.ts
@@ -64,5 +64,6 @@ export const useDragScroll = () => {
         onTouchStart,
         onTouchMove,
         onTouchEnd,
+        onTouchCancel: onTouchEnd,
     };
 };

--- a/src/routes/tables/raid-upgrade-material-card.tsx
+++ b/src/routes/tables/raid-upgrade-material-card.tsx
@@ -9,10 +9,9 @@ import { mows2Data } from '@/fsd/4-entities/mow';
 import { UpgradeImage } from '@/fsd/4-entities/upgrade';
 
 import { ICharacterUpgradeEstimate, IItemRaidLocation } from '@/fsd/3-features/goals/goals.models';
+import { RaidLocations } from '@/fsd/3-features/goals/raid-locations';
 
 const MaterialEstimatesRow = lazy(() => import('./material-estimates-row'));
-
-import { RaidLocations } from './raid-locations';
 
 interface Props {
     index: number;

--- a/src/routes/tables/raids-plan.tsx
+++ b/src/routes/tables/raids-plan.tsx
@@ -9,24 +9,31 @@ import TableRowsIcon from '@mui/icons-material/TableRows';
 import { Accordion, AccordionDetails, AccordionSummary, FormControlLabel, Switch } from '@mui/material';
 import Button from '@mui/material/Button';
 import { sum } from 'lodash';
-import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
-import { isMobile } from 'react-device-detect';
+import React, { lazy, Suspense, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 
 import { DispatchContext, StoreContext } from '@/reducers/store.provider';
 import { formatDateWithOrdinal } from 'src/shared-logic/functions';
 
+import { useDragScroll } from '@/fsd/5-shared/lib/use-drag-scroll';
 import { AccessibleTooltip, FlexBox } from '@/fsd/5-shared/ui';
 import { MiscIcon } from '@/fsd/5-shared/ui/icons';
 
 import { CharactersService } from '@/fsd/4-entities/character';
 
 import { IEstimatedUpgrades } from '@/fsd/3-features/goals/goals.models';
-import { MaterialsTable } from '@/fsd/3-features/goals/materials-table';
-import { RaidsDayView } from '@/fsd/3-features/goals/raids-day-view';
 
-import { Inventory } from '@/fsd/1-pages/input-inventory';
+import { SectionAccordion } from './section-accordion';
 
-import { RaidUpgradeMaterialCard } from './raid-upgrade-material-card';
+const MaterialsTable = lazy(() =>
+    import('@/fsd/3-features/goals/materials-table').then(m => ({ default: m.MaterialsTable }))
+);
+const RaidsDayView = lazy(() =>
+    import('@/fsd/3-features/goals/raids-day-view').then(m => ({ default: m.RaidsDayView }))
+);
+const Inventory = lazy(() => import('@/fsd/1-pages/input-inventory').then(m => ({ default: m.Inventory })));
+const RaidUpgradeMaterialCard = lazy(() =>
+    import('./raid-upgrade-material-card').then(m => ({ default: m.RaidUpgradeMaterialCard }))
+);
 
 interface Props {
     estimatedRanks: IEstimatedUpgrades;
@@ -39,6 +46,8 @@ interface Props {
 type ReferenceElement = HTMLDivElement | null;
 type ReferenceMap = { [key: string]: ReferenceElement };
 
+// ─── RaidsPlan ───────────────────────────────────────────────────────────────
+
 export const RaidsPlan: React.FC<Props> = ({
     estimatedRanks,
     scrollToCharSnowprintId,
@@ -46,7 +55,7 @@ export const RaidsPlan: React.FC<Props> = ({
     upgrades,
     updateInventory,
 }) => {
-    const { viewPreferences } = useContext(StoreContext);
+    const { viewPreferences, dailyRaidsPreferences } = useContext(StoreContext);
     const dispatch = useContext(DispatchContext);
     const [upgradesPaging, setUpgradesPaging] = useState<{
         start: number;
@@ -58,19 +67,32 @@ export const RaidsPlan: React.FC<Props> = ({
     const [grid2Loaded, setGrid2Loaded] = useState<boolean>(false);
     const [grid3Loaded, setGrid3Loaded] = useState<boolean>(false);
 
+    const [allDaysExpanded, setAllDaysExpanded] = useState(false);
+
     const [expandedPanels, setExpandedPanels] = useState(() => ({
         related: false,
         inProgress: scrollToCharSnowprintId !== undefined,
         finished: false,
         blocked: false,
-        raids: true,
+        raids: false,
     }));
 
-    const togglePanel = (key: keyof typeof expandedPanels) => (_: any, isExpanded: boolean) =>
+    const togglePanel = (key: keyof typeof expandedPanels) => (_: React.SyntheticEvent, isExpanded: boolean) =>
         setExpandedPanels(previous => ({ ...previous, [key]: isExpanded }));
 
     const itemReferences = useRef<ReferenceMap>({});
     const inProgressReference = useRef<HTMLDivElement>(null);
+
+    const {
+        scrollRef: raidsDayScrollReference,
+        onMouseDown: onDragStart,
+        onMouseMove: onDragMove,
+        onMouseUp: onDragEnd,
+        onMouseLeave: onDragLeave,
+        onTouchStart: onDragTouchStart,
+        onTouchMove: onDragTouchMove,
+        onTouchEnd: onDragTouchEnd,
+    } = useDragScroll();
     const setCardReference = useCallback(
         (id: number) => (element: ReferenceElement) => {
             itemReferences.current[id] = element;
@@ -181,10 +203,14 @@ export const RaidsPlan: React.FC<Props> = ({
     }, [daysTotal]);
 
     return (
-        <Accordion defaultExpanded={scrollToCharSnowprintId !== undefined}>
-            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+        <Accordion
+            defaultExpanded={scrollToCharSnowprintId !== undefined}
+            className="overflow-hidden rounded-xl! border border-(--border) bg-transparent shadow-none">
+            <AccordionSummary
+                expandIcon={<ExpandMoreIcon className="text-(--muted-fg)" />}
+                className="px-4 py-0 [&_.MuiAccordionSummary-content]:my-1.5">
                 <FlexBox className="flex-col items-start">
-                    <div className="flex flex-wrap items-center gap-2" style={{ fontSize: isMobile ? 16 : 20 }}>
+                    <div className="flex flex-wrap items-center gap-2 text-base font-semibold sm:text-lg">
                         <span>
                             Raids plan (<b>{daysTotal}</b> Days |
                         </span>
@@ -205,13 +231,13 @@ export const RaidsPlan: React.FC<Props> = ({
                                 />
                             }
                             label={
-                                <div className="flex-box gap5">
+                                <div className="flex items-center gap-1">
                                     {viewPreferences.raidsTableView ? (
-                                        <div className="flex-box gap5">
+                                        <div className="flex items-center gap-1">
                                             <TableRowsIcon color="primary" /> <span>Table View</span>
                                         </div>
                                     ) : (
-                                        <div className="flex-box gap5">
+                                        <div className="flex items-center gap-1">
                                             <GridViewIcon color="primary" /> <span>Cards View</span>
                                         </div>
                                     )}
@@ -219,95 +245,143 @@ export const RaidsPlan: React.FC<Props> = ({
                             }
                         />
                     </div>
-                    <span className="italic">{calendarDateTotal}</span>
+                    <span className="text-sm text-(--muted-fg) italic">{calendarDateTotal}</span>
                 </FlexBox>
             </AccordionSummary>
-            <AccordionDetails>
+            <AccordionDetails className="p-0!">
                 {estimatedRanks.relatedUpgrades.length > 0 && (
-                    <Accordion
-                        TransitionProps={{ unmountOnExit: !grid1Loaded }}
+                    <SectionAccordion
                         expanded={expandedPanels.related}
-                        onChange={togglePanel('related')}>
-                        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                            <div className="flex flex-wrap items-center gap-2" style={{ fontSize: isMobile ? 16 : 20 }}>
+                        onChange={togglePanel('related')}
+                        transitionProps={{ unmountOnExit: true }}
+                        summary={
+                            <div className="flex flex-wrap items-center gap-2 text-sm font-semibold sm:text-base">
                                 <InventoryIcon />
                                 <b>{estimatedRanks.relatedUpgrades.length}</b> related upgrades (Inventory)
                             </div>
-                        </AccordionSummary>
-                        <AccordionDetails>
+                        }>
+                        <Suspense fallback={undefined}>
                             <Inventory itemsFilter={estimatedRanks.relatedUpgrades} onUpdate={updateInventoryAny} />
-                        </AccordionDetails>
-                    </Accordion>
+                        </Suspense>
+                    </SectionAccordion>
                 )}
                 {estimatedRanks.inProgressMaterials.length > 0 && (
-                    <Accordion
+                    <SectionAccordion
                         ref={inProgressReference}
                         expanded={expandedPanels.inProgress}
                         onChange={togglePanel('inProgress')}
-                        TransitionProps={{ unmountOnExit: !grid1Loaded }}>
-                        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                            <div className="flex flex-wrap items-center gap-2" style={{ fontSize: isMobile ? 16 : 20 }}>
+                        transitionProps={{ unmountOnExit: !grid1Loaded }}
+                        summary={
+                            <div className="flex flex-wrap items-center gap-2 text-sm font-semibold sm:text-base">
                                 <PendingIcon color={'primary'} />
                                 <b>{estimatedRanks.inProgressMaterials.length}</b> in progress upgrades
                             </div>
-                        </AccordionSummary>
-                        <AccordionDetails>
-                            <div className="h-[600px] overflow-y-auto">
-                                {viewPreferences.raidsTableView === true ? (
-                                    <div className="ag-theme-material flex h-[600px] min-h-[150px] w-full flex-col">
-                                        <MaterialsTable
-                                            rows={estimatedRanks.inProgressMaterials}
-                                            updateMaterialQuantity={updateInventory}
-                                            onGridReady={() => setGrid1Loaded(true)}
-                                            inventory={upgrades}
-                                            scrollToCharSnowprintId={scrollToCharSnowprintId}
-                                            alreadyUsedMaterials={estimatedRanks.finishedMaterials}
-                                        />
-                                    </div>
-                                ) : (
-                                    <div className="flex max-h-[600px] w-full flex-wrap gap-x-4 gap-y-4 overflow-y-auto p-2">
-                                        {estimatedRanks.inProgressMaterials.length > 0 &&
-                                            estimatedRanks.inProgressMaterials.map((material, index) => (
-                                                <div key={index} ref={setCardReference(index)}>
-                                                    <RaidUpgradeMaterialCard
-                                                        key={index}
-                                                        index={index}
-                                                        upgradeEstimate={material}
-                                                    />
-                                                </div>
-                                            ))}
-                                    </div>
-                                )}
+                        }>
+                        {viewPreferences.raidsTableView === true ? (
+                            <div className="ag-theme-material flex h-[600px] min-h-[150px] w-full flex-col">
+                                <Suspense fallback={undefined}>
+                                    <MaterialsTable
+                                        rows={estimatedRanks.inProgressMaterials}
+                                        updateMaterialQuantity={updateInventory}
+                                        onGridReady={() => setGrid1Loaded(true)}
+                                        inventory={upgrades}
+                                        scrollToCharSnowprintId={scrollToCharSnowprintId}
+                                        alreadyUsedMaterials={estimatedRanks.finishedMaterials}
+                                    />
+                                </Suspense>
                             </div>
-                        </AccordionDetails>
-                    </Accordion>
+                        ) : (
+                            <Suspense fallback={undefined}>
+                                <div className="flex max-h-[600px] w-full flex-wrap gap-x-4 gap-y-4 overflow-y-auto py-2 min-[354px]:px-2">
+                                    {estimatedRanks.inProgressMaterials.length > 0 &&
+                                        estimatedRanks.inProgressMaterials.map((material, index) => (
+                                            <div key={index} ref={setCardReference(index)}>
+                                                <RaidUpgradeMaterialCard
+                                                    key={index}
+                                                    index={index}
+                                                    upgradeEstimate={material}
+                                                />
+                                            </div>
+                                        ))}
+                                </div>
+                            </Suspense>
+                        )}
+                    </SectionAccordion>
                 )}
                 {estimatedRanks.finishedMaterials.length > 0 && (
-                    <Accordion
-                        TransitionProps={{ unmountOnExit: !grid3Loaded }}
+                    <SectionAccordion
                         expanded={expandedPanels.finished}
-                        onChange={togglePanel('finished')}>
-                        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                            <div className="flex flex-wrap items-center gap-2" style={{ fontSize: isMobile ? 16 : 20 }}>
+                        onChange={togglePanel('finished')}
+                        transitionProps={{ unmountOnExit: !grid3Loaded }}
+                        summary={
+                            <div className="flex flex-wrap items-center gap-2 text-sm font-semibold sm:text-base">
                                 <CheckCircleIcon color={'success'} /> <b>{estimatedRanks.finishedMaterials.length}</b>{' '}
                                 finished upgrades
                             </div>
-                        </AccordionSummary>
-                        <AccordionDetails>
-                            <div className="max-h-[600px] overflow-y-auto">
+                        }>
+                        {viewPreferences.raidsTableView === true ? (
+                            <div className="ag-theme-material flex h-[600px] w-full flex-col">
+                                <Suspense fallback={undefined}>
+                                    <MaterialsTable
+                                        rows={estimatedRanks.finishedMaterials}
+                                        updateMaterialQuantity={updateInventory}
+                                        onGridReady={() => setGrid3Loaded(true)}
+                                        inventory={upgrades}
+                                    />
+                                </Suspense>
+                            </div>
+                        ) : (
+                            <Suspense fallback={undefined}>
+                                <div className="flex max-h-[600px] w-full flex-wrap gap-x-4 gap-y-4 overflow-y-auto py-2 min-[354px]:px-2">
+                                    {estimatedRanks.finishedMaterials.map((material, index) => (
+                                        <RaidUpgradeMaterialCard
+                                            key={index}
+                                            index={index}
+                                            upgradeEstimate={material}
+                                            showAdditionalInfo={false}
+                                        />
+                                    ))}
+                                </div>
+                            </Suspense>
+                        )}
+                    </SectionAccordion>
+                )}
+                {estimatedRanks.blockedMaterials.length > 0 && (
+                    <SectionAccordion
+                        expanded={expandedPanels.blocked}
+                        onChange={togglePanel('blocked')}
+                        transitionProps={{ unmountOnExit: !grid2Loaded }}
+                        summary={
+                            <AccessibleTooltip
+                                title={`You don't any have location for ${estimatedRanks.blockedMaterials.length} upgrades`}>
+                                <div className="flex flex-wrap items-center gap-2 text-sm font-semibold sm:text-base">
+                                    <Warning color={'warning'} />
+                                    <b>{estimatedRanks.blockedMaterials.length}</b> blocked upgrades
+                                </div>
+                            </AccessibleTooltip>
+                        }>
+                        <div className="flex flex-col">
+                            <div className="flex items-center gap-2 p-2">
+                                <InfoIcon color="primary" /> You don&apos;t have available campaigns nodes for the items
+                                listed in the table below
+                            </div>
+
+                            <div className="grow">
                                 {viewPreferences.raidsTableView === true ? (
                                     <div className="ag-theme-material flex h-[600px] w-full flex-col">
-                                        <MaterialsTable
-                                            rows={estimatedRanks.finishedMaterials}
-                                            updateMaterialQuantity={updateInventory}
-                                            onGridReady={() => setGrid3Loaded(true)}
-                                            inventory={upgrades}
-                                        />
+                                        <Suspense fallback={undefined}>
+                                            <MaterialsTable
+                                                rows={estimatedRanks.blockedMaterials}
+                                                updateMaterialQuantity={updateInventory}
+                                                onGridReady={() => setGrid2Loaded(true)}
+                                                inventory={upgrades}
+                                            />
+                                        </Suspense>
                                     </div>
                                 ) : (
-                                    <div className="flex max-h-[600px] w-full flex-wrap gap-1 p-2">
-                                        <div className="flex flex-wrap gap-x-4 gap-y-4">
-                                            {estimatedRanks.finishedMaterials.map((material, index) => (
+                                    <Suspense fallback={undefined}>
+                                        <div className="flex max-h-[600px] w-full flex-wrap gap-x-4 gap-y-4 overflow-y-auto py-2 min-[354px]:px-2">
+                                            {estimatedRanks.blockedMaterials.map((material, index) => (
                                                 <RaidUpgradeMaterialCard
                                                     key={index}
                                                     index={index}
@@ -316,97 +390,78 @@ export const RaidsPlan: React.FC<Props> = ({
                                                 />
                                             ))}
                                         </div>
-                                    </div>
+                                    </Suspense>
                                 )}
                             </div>
-                        </AccordionDetails>
-                    </Accordion>
-                )}
-                {estimatedRanks.blockedMaterials.length > 0 && (
-                    <Accordion
-                        TransitionProps={{ unmountOnExit: !grid2Loaded }}
-                        expanded={expandedPanels.blocked}
-                        onChange={togglePanel('blocked')}>
-                        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                            <AccessibleTooltip
-                                title={`You don't any have location for ${estimatedRanks.blockedMaterials.length} upgrades`}>
-                                <div
-                                    className="flex flex-wrap items-center gap-2"
-                                    style={{ fontSize: isMobile ? 16 : 20 }}>
-                                    <Warning color={'warning'} />
-                                    <b>{estimatedRanks.blockedMaterials.length}</b> blocked upgrades
-                                </div>
-                            </AccessibleTooltip>
-                        </AccordionSummary>
-                        <AccordionDetails>
-                            <div className="flex flex-col">
-                                <div className="flex-box p-2">
-                                    <InfoIcon color="primary" /> You don&apos;t have available campaigns nodes for the
-                                    items listed in the table below
-                                </div>
-
-                                <div className="grow">
-                                    {viewPreferences.raidsTableView === true ? (
-                                        <div className="ag-theme-material flex h-[600px] w-full flex-col">
-                                            <MaterialsTable
-                                                rows={estimatedRanks.blockedMaterials}
-                                                updateMaterialQuantity={updateInventory}
-                                                onGridReady={() => setGrid2Loaded(true)}
-                                                inventory={upgrades}
-                                            />
-                                        </div>
-                                    ) : (
-                                        <div className="flex max-h-[600px] w-full flex-wrap gap-1 overflow-y-scroll p-2">
-                                            <div className="flex flex-wrap gap-x-4 gap-y-4">
-                                                {estimatedRanks.blockedMaterials.map((material, index) => (
-                                                    <RaidUpgradeMaterialCard
-                                                        key={index}
-                                                        index={index}
-                                                        upgradeEstimate={material}
-                                                        showAdditionalInfo={false}
-                                                    />
-                                                ))}
-                                            </div>
-                                        </div>
-                                    )}
-                                </div>
-                            </div>
-                        </AccordionDetails>
-                    </Accordion>
+                        </div>
+                    </SectionAccordion>
                 )}
 
                 {estimatedRanks.upgradesRaids.length > 0 && (
-                    <Accordion
-                        TransitionProps={{ unmountOnExit: !upgradesPaging.completed }}
+                    <SectionAccordion
                         expanded={expandedPanels.raids}
-                        onChange={togglePanel('raids')}>
-                        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                            <FlexBox className="flex-col items-start">
-                                <div className="flex-box gap5 wrap" style={{ fontSize: isMobile ? 16 : 20 }}>
+                        onChange={togglePanel('raids')}
+                        transitionProps={{ unmountOnExit: !upgradesPaging.completed }}
+                        summary={
+                            <div className="flex w-full flex-col gap-1">
+                                <span className="text-sm font-semibold sm:text-base">Daily Raids</span>
+                                <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-(--muted-fg)">
                                     <span>
-                                        Raids Plan (<b>{estimatedRanks.upgradesRaids.length}</b> Days |
+                                        <b className="text-(--card-fg)">{estimatedRanks.upgradesRaids.length}</b> days
                                     </span>
-                                    <span>
-                                        <b>{estimatedRanks.freeEnergyDays}</b> Unused{' '}
-                                        <MiscIcon icon={'energy'} height={15} width={15} /> Days |
+                                    <span className="flex items-center gap-1">
+                                        <b className="text-(--card-fg)">{energyTotal}</b>
+                                        <MiscIcon icon={'energy'} height={13} width={13} />
                                     </span>
-                                    <span>
-                                        <b>{energyTotal}</b> <MiscIcon icon={'energy'} height={15} width={15} /> |
+                                    <span className="flex items-center gap-1">
+                                        <b className="text-(--card-fg)">{estimatedRanks.raidsTotal}</b>
+                                        <MiscIcon icon={'raidTicket'} height={13} width={13} />
                                     </span>
-                                    <span>
-                                        <b>{estimatedRanks.raidsTotal}</b> Raids)
+                                    <span className="flex items-center gap-1">
+                                        <b className="text-(--card-fg)">{estimatedRanks.freeEnergyDays}</b> days unused
+                                        <MiscIcon icon={'energy'} height={13} width={13} />
                                     </span>
+                                    <span className="italic">{upgradesCalendarDate}</span>
+                                    {expandedPanels.raids && (
+                                        <Button
+                                            size="small"
+                                            variant="outlined"
+                                            onClick={event => {
+                                                event.stopPropagation();
+                                                setAllDaysExpanded(v => !v);
+                                            }}>
+                                            {allDaysExpanded ? 'Collapse cards' : 'Expand cards'}
+                                        </Button>
+                                    )}
                                 </div>
-                                <span className="italic">{upgradesCalendarDate}</span>
-                            </FlexBox>
-                        </AccordionSummary>
-                        <AccordionDetails>
-                            <div className="overflow-x-auto overflow-y-hidden" style={{ transform: 'rotateX(180deg)' }}>
-                                <div className="flex gap-2.5" style={{ transform: 'rotateX(180deg)' }}>
+                            </div>
+                        }>
+                        <div
+                            ref={raidsDayScrollReference}
+                            className="overflow-x-auto overflow-y-hidden"
+                            style={{ cursor: 'grab' }}
+                            onMouseDown={onDragStart}
+                            onMouseMove={onDragMove}
+                            onMouseUp={onDragEnd}
+                            onMouseLeave={onDragLeave}
+                            onTouchStart={onDragTouchStart}
+                            onTouchMove={onDragTouchMove}
+                            onTouchEnd={onDragTouchEnd}>
+                            <Suspense fallback={undefined}>
+                                <div className="flex gap-2.5">
                                     {estimatedRanks.upgradesRaids
                                         .slice(upgradesPaging.start, upgradesPaging.end)
                                         .map((day, index) => {
-                                            return <RaidsDayView key={index} day={day} title={'Day ' + (index + 1)} />;
+                                            return (
+                                                <RaidsDayView
+                                                    key={index}
+                                                    day={day}
+                                                    title={'Day ' + (index + 1)}
+                                                    dayIndex={index}
+                                                    expanded={allDaysExpanded}
+                                                    energyPerDay={dailyRaidsPreferences.dailyEnergy}
+                                                />
+                                            );
                                         })}
                                     {!upgradesPaging.completed && (
                                         <Button
@@ -423,9 +478,9 @@ export const RaidsPlan: React.FC<Props> = ({
                                         </Button>
                                     )}
                                 </div>
-                            </div>
-                        </AccordionDetails>
-                    </Accordion>
+                            </Suspense>
+                        </div>
+                    </SectionAccordion>
                 )}
             </AccordionDetails>
         </Accordion>

--- a/src/routes/tables/raids-plan.tsx
+++ b/src/routes/tables/raids-plan.tsx
@@ -68,6 +68,7 @@ export const RaidsPlan: React.FC<Props> = ({
     const [grid3Loaded, setGrid3Loaded] = useState<boolean>(false);
 
     const [allDaysExpanded, setAllDaysExpanded] = useState(false);
+    const [outerExpanded, setOuterExpanded] = useState(scrollToCharSnowprintId !== undefined);
 
     const [expandedPanels, setExpandedPanels] = useState(() => ({
         related: false,
@@ -92,6 +93,7 @@ export const RaidsPlan: React.FC<Props> = ({
         onTouchStart: onDragTouchStart,
         onTouchMove: onDragTouchMove,
         onTouchEnd: onDragTouchEnd,
+        onTouchCancel: onDragTouchCancel,
     } = useDragScroll();
     const setCardReference = useCallback(
         (id: number) => (element: ReferenceElement) => {
@@ -143,6 +145,7 @@ export const RaidsPlan: React.FC<Props> = ({
 
     useEffect(() => {
         if (scrollToCharSnowprintId !== undefined) {
+            setOuterExpanded(true);
             setExpandedPanels(previous => ({ ...previous, inProgress: true }));
         }
     }, [scrollToCharSnowprintId]);
@@ -204,7 +207,8 @@ export const RaidsPlan: React.FC<Props> = ({
 
     return (
         <Accordion
-            defaultExpanded={scrollToCharSnowprintId !== undefined}
+            expanded={outerExpanded}
+            onChange={(_, isExpanded) => setOuterExpanded(isExpanded)}
             className="overflow-hidden rounded-xl! border border-(--border) bg-transparent shadow-none">
             <AccordionSummary
                 expandIcon={<ExpandMoreIcon className="text-(--muted-fg)" />}
@@ -446,7 +450,8 @@ export const RaidsPlan: React.FC<Props> = ({
                             onMouseLeave={onDragLeave}
                             onTouchStart={onDragTouchStart}
                             onTouchMove={onDragTouchMove}
-                            onTouchEnd={onDragTouchEnd}>
+                            onTouchEnd={onDragTouchEnd}
+                            onTouchCancel={onDragTouchCancel}>
                             <Suspense fallback={undefined}>
                                 <div className="flex gap-2.5">
                                     {estimatedRanks.upgradesRaids

--- a/src/routes/tables/section-accordion.tsx
+++ b/src/routes/tables/section-accordion.tsx
@@ -1,0 +1,33 @@
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import { Accordion, AccordionDetails, AccordionSummary } from '@mui/material';
+import React, { forwardRef } from 'react';
+
+interface SectionAccordionProps {
+    expanded: boolean;
+    onChange: (event: React.SyntheticEvent, isExpanded: boolean) => void;
+    summary: React.ReactNode;
+    children: React.ReactNode;
+    transitionProps?: React.ComponentProps<typeof Accordion>['TransitionProps'];
+}
+
+export const SectionAccordion = forwardRef<HTMLDivElement, SectionAccordionProps>(
+    ({ expanded, onChange, summary, children, transitionProps }, reference) => (
+        <Accordion
+            ref={reference}
+            expanded={expanded}
+            onChange={onChange}
+            TransitionProps={transitionProps}
+            disableGutters
+            square
+            className="overflow-hidden border-0 border-t border-(--border) bg-transparent shadow-none [&::before]:hidden">
+            <AccordionSummary
+                expandIcon={<ExpandMoreIcon className="text-(--muted-fg)" />}
+                className="px-4 py-0 [&_.MuiAccordionSummary-content]:my-1.5">
+                {summary}
+            </AccordionSummary>
+            <AccordionDetails className="px-0! pt-0 pb-4 min-[354px]:px-2!">{children}</AccordionDetails>
+        </Accordion>
+    )
+);
+
+SectionAccordion.displayName = 'SectionAccordion';


### PR DESCRIPTION
- Implemented RaidMaterialDialog component for displaying raid material details.
- Created RaidMaterialIcon component to represent raid materials with icons.
- Added raid-day-helpers for character name and icon retrieval.
- Enhanced RaidsDayView to support expanded view and drag-scroll functionality.
- Introduced SectionAccordion for better accordion management in RaidsPlan.
- Updated ChipCampaignLocation to support clickable behavior.
- Added useDragScroll hook for improved drag scrolling experience.
- Modified CSS to support dark mode color scheme.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dark-mode color-scheme support for native form controls
  * Raid material dialog with character list, progress bars, and locations
  * New raid material icon and expandable location/details views
  * Drag-to-scroll gesture for horizontal raid cards; lazy-loading for large panels
  * Section accordion and clickability control for location chips

* **UI Improvements**
  * Redesigned daily raids card with energy tracking, compact stats, and improved tooltips

* **Chores**
  * Added new re-exports to simplify imports
<!-- end of auto-generated comment: release notes by coderabbit.ai -->