### PR TITLE
Optimize upgrade images and tooltips

### DIFF
--- a/src/fsd/4-entities/upgrade/upgrade-image.tsx
+++ b/src/fsd/4-entities/upgrade/upgrade-image.tsx
@@ -1,5 +1,5 @@
 ﻿/* eslint-disable import-x/no-internal-modules */
-import React, { useState, CSSProperties } from 'react';
+import React, { useState } from 'react';
 
 import frameCommonUrl from '@/assets/images/snowprint_assets/frames/ui_frame_upgrades_common.png';
 import frameEpicUrl from '@/assets/images/snowprint_assets/frames/ui_frame_upgrades_epic.png';
@@ -26,22 +26,6 @@ const FRAME_URL_BY_RARITY: Partial<Record<RarityString, string>> = {
     [RarityString.Common]: frameCommonUrl,
 };
 
-const UPGRADE_HEIGHT_RATIO = 0.78;
-
-const CENTERED_STACK_STYLES: CSSProperties = {
-    position: 'absolute',
-    top: '50%',
-    left: '50%',
-    transform: 'translate(-50%, -50%)',
-    maxWidth: '100%',
-    maxHeight: '100%',
-};
-
-const CENTERED_STACK_STYLES_MAIN_IMG: CSSProperties = {
-    ...CENTERED_STACK_STYLES,
-    height: `${UPGRADE_HEIGHT_RATIO * 100}%`,
-};
-
 interface UpgradeImageBaseProps {
     material: string;
     iconPath: string;
@@ -57,30 +41,27 @@ const UpgradeImageBase = ({ material, iconPath, size, rarity }: UpgradeImageBase
     const image = getImageUrl(imagePath);
     const frameImgUrl = rarity ? FRAME_URL_BY_RARITY[rarity] : undefined;
 
-    const imageMissingStyles: CSSProperties = {
-        height,
-        width,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        fontSize: `clamp(8px, ${width / 4.5}px, 14px)`,
-        textAlign: 'center',
-        overflow: 'hidden',
-        whiteSpace: 'pre-wrap',
-        wordBreak: 'break-word',
-        lineHeight: '0.9',
-    };
+    // Tailwind handles most styles; fontSize remains dynamic
+    const imageMissingFontSize = `clamp(8px, ${width / 4.5}px, 14px)`;
 
     return (
-        <div style={{ width, height }} className={'upgrade'}>
+        <div style={{ width, height }} className="upgrade">
             {imgError ? (
-                <div style={imageMissingStyles}>{material}</div>
+                <div
+                    className="flex h-full w-full items-center justify-center overflow-hidden text-center leading-[0.9] break-words whitespace-pre-wrap"
+                    style={{ fontSize: imageMissingFontSize }}>
+                    {material}
+                </div>
             ) : (
                 <div className="relative mx-auto my-0 block" style={{ width, height }}>
-                    <img style={CENTERED_STACK_STYLES} src={bgUnderlayUrl} alt={`${rarity} upgrade`} />
                     <img
-                        loading={'lazy'}
-                        style={CENTERED_STACK_STYLES_MAIN_IMG}
+                        className="absolute top-1/2 left-1/2 max-h-full max-w-full -translate-x-1/2 -translate-y-1/2"
+                        src={bgUnderlayUrl}
+                        alt={`${rarity} upgrade`}
+                    />
+                    <img
+                        loading="lazy"
+                        className="absolute top-1/2 left-1/2 h-[78%] max-h-full max-w-full -translate-x-1/2 -translate-y-1/2"
                         src={image}
                         alt={material}
                         onError={() => {
@@ -88,7 +69,11 @@ const UpgradeImageBase = ({ material, iconPath, size, rarity }: UpgradeImageBase
                             setImgError(true);
                         }}
                     />
-                    <img loading={'lazy'} style={CENTERED_STACK_STYLES} src={frameImgUrl} />
+                    <img
+                        loading="lazy"
+                        className="absolute top-1/2 left-1/2 max-h-full max-w-full -translate-x-1/2 -translate-y-1/2"
+                        src={frameImgUrl}
+                    />
                 </div>
             )}
         </div>

--- a/src/fsd/4-entities/upgrade/upgrade-image.tsx
+++ b/src/fsd/4-entities/upgrade/upgrade-image.tsx
@@ -1,64 +1,61 @@
-﻿import React, { useState, CSSProperties, useMemo } from 'react';
+﻿/* eslint-disable import-x/no-internal-modules */
+import React, { useState, CSSProperties } from 'react';
+
+import frameCommonUrl from '@/assets/images/snowprint_assets/frames/ui_frame_upgrades_common.png';
+import frameEpicUrl from '@/assets/images/snowprint_assets/frames/ui_frame_upgrades_epic.png';
+import frameLegendaryUrl from '@/assets/images/snowprint_assets/frames/ui_frame_upgrades_legendary.png';
+import frameMythicUrl from '@/assets/images/snowprint_assets/frames/ui_frame_upgrades_mythic.png';
+import frameRareUrl from '@/assets/images/snowprint_assets/frames/ui_frame_upgrades_rare.png';
+import frameUncommonUrl from '@/assets/images/snowprint_assets/frames/ui_frame_upgrades_uncommon.png';
+import bgUnderlayUrl from '@/assets/images/snowprint_assets/frames/ui_underlay_upgrades.png';
 
 import { RarityString } from '@/fsd/5-shared/model';
 import { AccessibleTooltip, getImageUrl } from '@/fsd/5-shared/ui';
 
 import { recipeDataByName } from './data';
 
-export const UpgradeImage = ({
-    material,
-    iconPath,
-    size,
-    tooltip,
-    rarity,
-}: {
+// Static assets — resolved to hashed URLs by Vite at build time. Zero
+// per-render cost (just string references), unlike getImageUrl which
+// runs new URL(...) at runtime.
+const FRAME_URL_BY_RARITY: Partial<Record<RarityString, string>> = {
+    [RarityString.Mythic]: frameMythicUrl,
+    [RarityString.Legendary]: frameLegendaryUrl,
+    [RarityString.Epic]: frameEpicUrl,
+    [RarityString.Rare]: frameRareUrl,
+    [RarityString.Uncommon]: frameUncommonUrl,
+    [RarityString.Common]: frameCommonUrl,
+};
+
+const UPGRADE_HEIGHT_RATIO = 0.78;
+
+const CENTERED_STACK_STYLES: CSSProperties = {
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    transform: 'translate(-50%, -50%)',
+    maxWidth: '100%',
+    maxHeight: '100%',
+};
+
+const CENTERED_STACK_STYLES_MAIN_IMG: CSSProperties = {
+    ...CENTERED_STACK_STYLES,
+    height: `${UPGRADE_HEIGHT_RATIO * 100}%`,
+};
+
+interface UpgradeImageBaseProps {
     material: string;
     iconPath: string;
     size?: number;
-    tooltip?: React.ReactNode;
     rarity?: RarityString;
-}) => {
+}
+
+const UpgradeImageBase = ({ material, iconPath, size, rarity }: UpgradeImageBaseProps) => {
     const [imgError, setImgError] = useState(false);
     const width = size ?? 50;
     const height = size ?? 50;
     const imagePath = iconPath || material.toLowerCase() + '.png';
     const image = getImageUrl(imagePath);
-    const frameImageDirectory = 'snowprint_assets/frames';
-    const bgImgUrl = getImageUrl(`${frameImageDirectory}/ui_underlay_upgrades.png`);
-    const upgradeHeightRatio = 0.78;
-
-    function getFrameUrl(rarity?: RarityString) {
-        switch (rarity) {
-            case RarityString.Mythic: {
-                return getImageUrl(`${frameImageDirectory}/ui_frame_upgrades_mythic.png`);
-            }
-            case RarityString.Legendary: {
-                return getImageUrl(`${frameImageDirectory}/ui_frame_upgrades_legendary.png`);
-            }
-            case RarityString.Epic: {
-                return getImageUrl(`${frameImageDirectory}/ui_frame_upgrades_epic.png`);
-            }
-            case RarityString.Rare: {
-                return getImageUrl(`${frameImageDirectory}/ui_frame_upgrades_rare.png`);
-            }
-            case RarityString.Uncommon: {
-                return getImageUrl(`${frameImageDirectory}/ui_frame_upgrades_uncommon.png`);
-            }
-            case RarityString.Common: {
-                return getImageUrl(`${frameImageDirectory}/ui_frame_upgrades_common.png`);
-            }
-        }
-    }
-    const frameImgUrl = getFrameUrl(rarity);
-
-    const centeredImageStackStyles: CSSProperties = {
-        position: 'absolute',
-        top: '50%',
-        left: '50%',
-        transform: 'translate(-50%, -50%)',
-        maxWidth: '100%',
-        maxHeight: '100%',
-    };
+    const frameImgUrl = rarity ? FRAME_URL_BY_RARITY[rarity] : undefined;
 
     const imageMissingStyles: CSSProperties = {
         height,
@@ -74,38 +71,48 @@ export const UpgradeImage = ({
         lineHeight: '0.9',
     };
 
-    const tooltipText = useMemo(() => {
-        if (tooltip) {
-            return tooltip;
-        }
-        return recipeDataByName[material]?.material ?? material;
-    }, [material, tooltip]);
+    return (
+        <div style={{ width, height }} className={'upgrade'}>
+            {imgError ? (
+                <div style={imageMissingStyles}>{material}</div>
+            ) : (
+                <div className="relative mx-auto my-0 block" style={{ width, height }}>
+                    <img style={CENTERED_STACK_STYLES} src={bgUnderlayUrl} alt={`${rarity} upgrade`} />
+                    <img
+                        loading={'lazy'}
+                        style={CENTERED_STACK_STYLES_MAIN_IMG}
+                        src={image}
+                        alt={material}
+                        onError={() => {
+                            console.error(`Image not found: ${imagePath}`);
+                            setImgError(true);
+                        }}
+                    />
+                    <img loading={'lazy'} style={CENTERED_STACK_STYLES} src={frameImgUrl} />
+                </div>
+            )}
+        </div>
+    );
+};
+
+export const UpgradeImage = ({
+    material,
+    iconPath,
+    size,
+    tooltip,
+    rarity,
+    showTooltip = true,
+}: UpgradeImageBaseProps & {
+    tooltip?: React.ReactNode;
+    showTooltip?: boolean;
+}) => {
+    if (!showTooltip) return <UpgradeImageBase material={material} iconPath={iconPath} size={size} rarity={rarity} />;
+
+    const tooltipText = tooltip ?? recipeDataByName[material]?.material ?? material;
 
     return (
         <AccessibleTooltip title={tooltipText}>
-            <div style={{ width, height }} className={'upgrade'}>
-                {imgError ? (
-                    <div style={imageMissingStyles}>{material}</div>
-                ) : (
-                    <div className="relative mx-auto my-0 block" style={{ width, height }}>
-                        <img style={centeredImageStackStyles} src={bgImgUrl} alt={`${rarity} upgrade`} />
-                        <img
-                            loading={'lazy'}
-                            style={{
-                                ...centeredImageStackStyles,
-                                height: `${upgradeHeightRatio * 100}%`,
-                            }}
-                            src={image}
-                            alt={material}
-                            onError={() => {
-                                console.error(`Image not found: ${imagePath}`);
-                                setImgError(true);
-                            }}
-                        />
-                        <img loading={'lazy'} style={centeredImageStackStyles} src={frameImgUrl} />
-                    </div>
-                )}
-            </div>
+            <UpgradeImageBase material={material} iconPath={iconPath} size={size} rarity={rarity} />
         </AccessibleTooltip>
     );
 };

--- a/src/routes/tables/raid-upgrade-material-card.tsx
+++ b/src/routes/tables/raid-upgrade-material-card.tsx
@@ -38,20 +38,6 @@ const resolveUnit = (id: string) => {
     return;
 };
 
-const getRelatedUnitDisplayName = (idOrName: string) => {
-    const char = CharactersService.getUnit(idOrName);
-    if (char) {
-        return char.shortName || char.name;
-    }
-
-    const mow = mows2Data.mows.find(x => x.snowprintId === idOrName || x.name === idOrName);
-    if (mow) {
-        return mow.name;
-    }
-
-    return idOrName;
-};
-
 const hasRaidLocations = (
     estimate: ICharacterUpgradeEstimate
 ): estimate is ICharacterUpgradeEstimate & { raidLocations: IItemRaidLocation[] } => {
@@ -101,10 +87,6 @@ const Component: React.FC<Props> = ({
         return upgradeEstimate.locations;
     }, [showPlannedRaidLocationsOnly, upgradeEstimate]);
 
-    const relatedUnitTooltipNames = useMemo(() => {
-        return [...new Set(upgradeEstimate.relatedCharacters.map(idOrName => getRelatedUnitDisplayName(idOrName)))];
-    }, [upgradeEstimate.relatedCharacters]);
-
     const hasSuggestedRaidsRemaining = useMemo(() => {
         if (hasRaidLocations(upgradeEstimate)) {
             return upgradeEstimate.raidLocations.some(loc => loc.raidsToPerform > 0);
@@ -114,30 +96,6 @@ const Component: React.FC<Props> = ({
     }, [upgradeEstimate, displayedLocations]);
 
     const noSuggestedRaidsRemaining = !hasSuggestedRaidsRemaining;
-
-    const iconTooltipContent = useMemo(
-        () => (
-            <div>
-                {upgradeEstimate.label}
-                <ul className="ps-[15px]">
-                    {relatedUnitTooltipNames.map(nameItem => (
-                        <li
-                            key={
-                                'material-item-input-' +
-                                upgradeEstimate.id +
-                                '-' +
-                                displayedLocations.map(loc => loc.id).join(',') +
-                                '-' +
-                                nameItem
-                            }>
-                            {nameItem}
-                        </li>
-                    ))}
-                </ul>
-            </div>
-        ),
-        [upgradeEstimate.label, upgradeEstimate.id, relatedUnitTooltipNames, displayedLocations]
-    );
 
     const icon = useMemo(() => {
         if (isShard || isMythicShard) {
@@ -153,10 +111,19 @@ const Component: React.FC<Props> = ({
                 material={upgradeEstimate.label}
                 iconPath={upgradeEstimate.iconPath}
                 rarity={RarityMapper.rarityToRarityString(mapUpgradeRarity(upgradeEstimate.rarity))}
-                tooltip={iconTooltipContent}
+                showTooltip={false}
             />
         );
-    }, [isShard, isMythicShard, resolvedUnit, materialId, upgradeEstimate.snowprintId, iconTooltipContent]);
+    }, [
+        isShard,
+        isMythicShard,
+        resolvedUnit,
+        materialId,
+        upgradeEstimate.snowprintId,
+        upgradeEstimate.label,
+        upgradeEstimate.iconPath,
+        upgradeEstimate.rarity,
+    ]);
 
     const isSufficient = upgradeEstimate.acquiredCount >= upgradeEstimate.requiredCount;
     const flooredAcquiredCount = Math.min(Math.floor(upgradeEstimate.acquiredCount), upgradeEstimate.requiredCount);


### PR DESCRIPTION
I did some profiling and the biggest offender for render time on the `dailyRaids` page was the `UpgradeTooltip`. That came down to it doing a lot of unnecessary work on every render and on it wrapping everything in an expensive tooltip component.

Solution:			
- Import static frame/bg assets to avoid per‑render URL creation
- Use a constant lookup for rarity->frame to avoid redefining function on every renderd
- Tooltip was redundant on `raid-upgrade-material-card` since the label was right next to the image. Add option to exclude tooltip and apply it.
- Replaced static styling objects with Tailwind to avoid recreating the JS object on every render.