### PR TITLE
Add EQUIPMENT_TYPE_ORDER for stable equipment sorting in snapshots

### DIFF
--- a/src/fsd/1-pages/input-roster-snapshots/roster-snapshots-service.ts
+++ b/src/fsd/1-pages/input-roster-snapshots/roster-snapshots-service.ts
@@ -7,7 +7,7 @@ import { Rarity, RarityStars } from '@/fsd/5-shared/model';
 import { ISnapshotCharacter, ISnapshotMachineOfWar } from '@/fsd/5-shared/ui/unit-portrait';
 
 import { CharactersService } from '@/fsd/4-entities/character';
-import { EquipmentService } from '@/fsd/4-entities/equipment/equipment.service';
+import { EQUIPMENT_TYPE_ORDER, EquipmentService } from '@/fsd/4-entities/equipment/equipment.service';
 import { IMow2 } from '@/fsd/4-entities/mow';
 
 import { IRosterSnapshot, IRosterSnapshotDiff, ISnapshotUnitDiff, IRosterSnapshotsState } from './models';
@@ -18,6 +18,16 @@ export class RosterSnapshotsService {
 
     /** @returns a new snapshot view of the character. */
     public static snapshotCharacter(c: ICharacter2): ISnapshotCharacter {
+        // Sort equipment by type order so that positional comparison in diffCharacter() is
+        // stable regardless of the order the API returns items in.
+        const sortedEquipment = (c.equipment ?? []).toSorted((a, b) => {
+            const typeA = EquipmentService.equipmentData.find(equip => equip.id === a.id)?.type ?? '';
+            const typeB = EquipmentService.equipmentData.find(equip => equip.id === b.id)?.type ?? '';
+            const diff =
+                (EQUIPMENT_TYPE_ORDER[typeA] ?? Number.MAX_SAFE_INTEGER) -
+                (EQUIPMENT_TYPE_ORDER[typeB] ?? Number.MAX_SAFE_INTEGER);
+            return diff === 0 ? a.id.localeCompare(b.id) : diff;
+        });
         return {
             id: c.snowprintId,
             rank: c.rank,
@@ -28,12 +38,12 @@ export class RosterSnapshotsService {
             shards: c.shards,
             mythicShards: c.mythicShards,
             xpLevel: c.level,
-            equip0: EquipmentService.equipmentData.find(equip => equip.id === c.equipment?.[0]?.id),
-            equip1: EquipmentService.equipmentData.find(equip => equip.id === c.equipment?.[1]?.id),
-            equip2: EquipmentService.equipmentData.find(equip => equip.id === c.equipment?.[2]?.id),
-            equip0Level: c.equipment?.[0]?.level,
-            equip1Level: c.equipment?.[1]?.level,
-            equip2Level: c.equipment?.[2]?.level,
+            equip0: EquipmentService.equipmentData.find(equip => equip.id === sortedEquipment[0]?.id),
+            equip1: EquipmentService.equipmentData.find(equip => equip.id === sortedEquipment[1]?.id),
+            equip2: EquipmentService.equipmentData.find(equip => equip.id === sortedEquipment[2]?.id),
+            equip0Level: sortedEquipment[0]?.level,
+            equip1Level: sortedEquipment[1]?.level,
+            equip2Level: sortedEquipment[2]?.level,
         };
     }
 

--- a/src/fsd/1-pages/input-roster-snapshots/roster-snapshots-service.ts
+++ b/src/fsd/1-pages/input-roster-snapshots/roster-snapshots-service.ts
@@ -166,6 +166,27 @@ export class RosterSnapshotsService {
             char.xpLevel = Math.max(1, char.xpLevel);
             char.rarity = Math.max(char.rarity, CharactersService.getInitialRarity(char.id) ?? Rarity.Common);
             char.stars = Math.max(char.stars, this.getMinimumStarsForRarity(char.rarity));
+
+            // Older snapshots may have equipment slots in API order rather than canonical
+            // type order, causing false positional diffs in diffCharacter(). Re-sort here.
+            const equipSlots = [
+                { equip: char.equip0, level: char.equip0Level },
+                { equip: char.equip1, level: char.equip1Level },
+                { equip: char.equip2, level: char.equip2Level },
+            ]
+                .filter(slot => slot.equip !== undefined)
+                .toSorted((a, b) => {
+                    const diff =
+                        (EQUIPMENT_TYPE_ORDER[a.equip!.type] ?? Number.MAX_SAFE_INTEGER) -
+                        (EQUIPMENT_TYPE_ORDER[b.equip!.type] ?? Number.MAX_SAFE_INTEGER);
+                    return diff === 0 ? a.equip!.id.localeCompare(b.equip!.id) : diff;
+                });
+            char.equip0 = equipSlots[0]?.equip;
+            char.equip0Level = equipSlots[0]?.level;
+            char.equip1 = equipSlots[1]?.equip;
+            char.equip1Level = equipSlots[1]?.level;
+            char.equip2 = equipSlots[2]?.equip;
+            char.equip2Level = equipSlots[2]?.level;
         }
         for (const mow of returnValue.mows) {
             mow.primaryAbilityLevel = Math.max(1, mow.primaryAbilityLevel);

--- a/src/fsd/1-pages/input-roster-snapshots/roster-snapshots-unit-diff-detailed.tsx
+++ b/src/fsd/1-pages/input-roster-snapshots/roster-snapshots-unit-diff-detailed.tsx
@@ -11,7 +11,7 @@ import { tacticusIcons } from '@/fsd/5-shared/ui/icons/icon-list';
 import { ISnapshotCharacter, ISnapshotMachineOfWar } from '@/fsd/5-shared/ui/unit-portrait';
 
 import { CharactersService } from '@/fsd/4-entities/character';
-import { EquipmentService, IEquipment } from '@/fsd/4-entities/equipment';
+import { EQUIPMENT_TYPE_ORDER, EquipmentService, IEquipment } from '@/fsd/4-entities/equipment';
 import { MowsService } from '@/fsd/4-entities/mow';
 
 import { RosterSnapshotShowVariableSettings } from '@/fsd/3-features/view-settings/model';
@@ -153,18 +153,7 @@ export const RosterSnapshotsUnitDiffDetailed: React.FC<Props> = ({
         const pad = 4;
         const base = staticChar;
 
-        const order: Record<string, number> = {
-            I_Crit: 0,
-            R_Crit: 0,
-            I_Block: 1,
-            R_Block: 1,
-            I_Defensive: 1,
-            R_Defensive: 1,
-            I_Booster_Block: 2,
-            R_Booster_Block: 2,
-            I_Booster_Crit: 2,
-            R_Booster_Crit: 2,
-        };
+        const order = EQUIPMENT_TYPE_ORDER;
 
         const renderType = (t?: string) => {
             if (!t) {

--- a/src/fsd/4-entities/equipment/equipment.service.ts
+++ b/src/fsd/4-entities/equipment/equipment.service.ts
@@ -8,6 +8,19 @@ import { CharactersService } from '../character';
 import { newEquipmentData } from './data';
 import { IEquipment, IEquipmentStatic } from './model';
 
+export const EQUIPMENT_TYPE_ORDER: Record<string, number> = {
+    I_Crit: 0,
+    R_Crit: 0,
+    I_Block: 1,
+    R_Block: 1,
+    I_Defensive: 1,
+    R_Defensive: 1,
+    I_Booster_Block: 2,
+    R_Booster_Block: 2,
+    I_Booster_Crit: 2,
+    R_Booster_Crit: 2,
+};
+
 export class EquipmentService {
     static readonly equipmentData: IEquipment[] = this.convertEquipmentData();
 

--- a/src/fsd/4-entities/equipment/index.ts
+++ b/src/fsd/4-entities/equipment/index.ts
@@ -1,3 +1,3 @@
 export * from './ui';
 export type { IEquipment } from './model';
-export { EquipmentService } from './equipment.service';
+export { EquipmentService, EQUIPMENT_TYPE_ORDER } from './equipment.service';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed equipment ordering so items are consistently sorted by type priority, preventing positional equipment diffs caused by API ordering differences and ensuring stable snapshots.

* **Refactor**
  * Centralized equipment type priority into a shared definition, removing duplicate ordering logic across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->