### PR TITLE
Fix tooltips in daily raids by forwarding refs in UpgradeImageBase

### DIFF
--- a/src/fsd/4-entities/upgrade/upgrade-image.tsx
+++ b/src/fsd/4-entities/upgrade/upgrade-image.tsx
@@ -1,5 +1,5 @@
 ﻿/* eslint-disable import-x/no-internal-modules */
-import React, { useState } from 'react';
+import React, { forwardRef, useState } from 'react';
 
 import frameCommonUrl from '@/assets/images/snowprint_assets/frames/ui_frame_upgrades_common.png';
 import frameEpicUrl from '@/assets/images/snowprint_assets/frames/ui_frame_upgrades_epic.png';
@@ -33,52 +33,55 @@ interface UpgradeImageBaseProps {
     rarity?: RarityString;
 }
 
-const UpgradeImageBase = ({ material, iconPath, size, rarity }: UpgradeImageBaseProps) => {
-    const [imgError, setImgError] = useState(false);
-    const width = size ?? 50;
-    const height = size ?? 50;
-    const imagePath = iconPath || material.toLowerCase() + '.png';
-    const image = getImageUrl(imagePath);
-    const frameImgUrl = rarity ? FRAME_URL_BY_RARITY[rarity] : undefined;
+const UpgradeImageBase = forwardRef<HTMLDivElement, UpgradeImageBaseProps & React.HTMLAttributes<HTMLDivElement>>(
+    ({ material, iconPath, size, rarity, ...htmlProps }, reference) => {
+        const [imgError, setImgError] = useState(false);
+        const width = size ?? 50;
+        const height = size ?? 50;
+        const imagePath = iconPath || material.toLowerCase() + '.png';
+        const image = getImageUrl(imagePath);
+        const frameImgUrl = rarity ? FRAME_URL_BY_RARITY[rarity] : undefined;
 
-    // Tailwind handles most styles; fontSize remains dynamic
-    const imageMissingFontSize = `clamp(8px, ${width / 4.5}px, 14px)`;
+        // Tailwind handles most styles; fontSize remains dynamic
+        const imageMissingFontSize = `clamp(8px, ${width / 4.5}px, 14px)`;
 
-    return (
-        <div style={{ width, height }} className="upgrade">
-            {imgError ? (
-                <div
-                    className="flex h-full w-full items-center justify-center overflow-hidden text-center leading-[0.9] break-words whitespace-pre-wrap"
-                    style={{ fontSize: imageMissingFontSize }}>
-                    {material}
-                </div>
-            ) : (
-                <div className="relative mx-auto my-0 block" style={{ width, height }}>
-                    <img
-                        className="absolute top-1/2 left-1/2 max-h-full max-w-full -translate-x-1/2 -translate-y-1/2"
-                        src={bgUnderlayUrl}
-                        alt={`${rarity} upgrade`}
-                    />
-                    <img
-                        loading="lazy"
-                        className="absolute top-1/2 left-1/2 h-[78%] max-h-full max-w-full -translate-x-1/2 -translate-y-1/2"
-                        src={image}
-                        alt={material}
-                        onError={() => {
-                            console.error(`Image not found: ${imagePath}`);
-                            setImgError(true);
-                        }}
-                    />
-                    <img
-                        loading="lazy"
-                        className="absolute top-1/2 left-1/2 max-h-full max-w-full -translate-x-1/2 -translate-y-1/2"
-                        src={frameImgUrl}
-                    />
-                </div>
-            )}
-        </div>
-    );
-};
+        return (
+            <div ref={reference} {...htmlProps} style={{ width, height }} className="upgrade">
+                {imgError ? (
+                    <div
+                        className="flex h-full w-full items-center justify-center overflow-hidden text-center leading-[0.9] break-words whitespace-pre-wrap"
+                        style={{ fontSize: imageMissingFontSize }}>
+                        {material}
+                    </div>
+                ) : (
+                    <div className="relative mx-auto my-0 block" style={{ width, height }}>
+                        <img
+                            className="absolute top-1/2 left-1/2 max-h-full max-w-full -translate-x-1/2 -translate-y-1/2"
+                            src={bgUnderlayUrl}
+                            alt={`${rarity} upgrade`}
+                        />
+                        <img
+                            loading="lazy"
+                            className="absolute top-1/2 left-1/2 h-[78%] max-h-full max-w-full -translate-x-1/2 -translate-y-1/2"
+                            src={image}
+                            alt={material}
+                            onError={() => {
+                                console.error(`Image not found: ${imagePath}`);
+                                setImgError(true);
+                            }}
+                        />
+                        <img
+                            loading="lazy"
+                            className="absolute top-1/2 left-1/2 max-h-full max-w-full -translate-x-1/2 -translate-y-1/2"
+                            src={frameImgUrl}
+                        />
+                    </div>
+                )}
+            </div>
+        );
+    }
+);
+UpgradeImageBase.displayName = 'UpgradeImageBase';
 
 export const UpgradeImage = ({
     material,

--- a/src/fsd/5-shared/ui/icons/unit-shard.icon.tsx
+++ b/src/fsd/5-shared/ui/icons/unit-shard.icon.tsx
@@ -1,4 +1,6 @@
-﻿import { getImageUrl } from '../get-image-url';
+﻿import React from 'react';
+
+import { getImageUrl } from '../get-image-url';
 import { AccessibleTooltip } from '../tooltip';
 
 export const UnitShardIcon = ({
@@ -11,7 +13,7 @@ export const UnitShardIcon = ({
 }: {
     icon: string;
     name?: string;
-    tooltip?: string;
+    tooltip?: React.ReactNode;
     height?: number;
     width?: number;
     mythic?: boolean;

--- a/src/fsd/5-shared/ui/tooltip.tsx
+++ b/src/fsd/5-shared/ui/tooltip.tsx
@@ -21,8 +21,8 @@ export const AccessibleTooltip: React.FC<Props> = ({ children, title }) => {
         return (
             <ClickAwayListener onClickAway={handleTooltipClose} mouseEvent={'onMouseUp'}>
                 <Tooltip
-                    PopperProps={{
-                        disablePortal: false,
+                    slotProps={{
+                        popper: { disablePortal: false },
                     }}
                     placement="top"
                     arrow

--- a/src/routes/tables/raid-upgrade-material-card.tsx
+++ b/src/routes/tables/raid-upgrade-material-card.tsx
@@ -9,6 +9,7 @@ import { mows2Data } from '@/fsd/4-entities/mow';
 import { UpgradeImage } from '@/fsd/4-entities/upgrade';
 
 import { ICharacterUpgradeEstimate, IItemRaidLocation } from '@/fsd/3-features/goals/goals.models';
+import { getDisplayName } from '@/fsd/3-features/goals/raid-day-helpers';
 import { RaidLocations } from '@/fsd/3-features/goals/raid-locations';
 
 const MaterialEstimatesRow = lazy(() => import('./material-estimates-row'));
@@ -84,10 +85,29 @@ export const RaidUpgradeMaterialCard: FC<Props> = ({
 
     const noSuggestedRaidsRemaining = !hasSuggestedRaidsRemaining;
 
+    const tooltipContent =
+        upgradeEstimate.relatedCharacters.length > 0 ? (
+            <div>
+                {name}
+                <ul className="ps-[15px]">
+                    {upgradeEstimate.relatedCharacters.map(id => (
+                        <li key={id}>{getDisplayName(id)}</li>
+                    ))}
+                </ul>
+            </div>
+        ) : (
+            name
+        );
+
     const icon =
         isShard || isMythicShard ? (
             resolvedUnit ? (
-                <UnitShardIcon name={upgradeEstimate.snowprintId} icon={resolvedUnit.icon} mythic={isMythicShard} />
+                <UnitShardIcon
+                    name={upgradeEstimate.snowprintId}
+                    icon={resolvedUnit.icon}
+                    mythic={isMythicShard}
+                    tooltip={tooltipContent}
+                />
             ) : (
                 materialId
             )
@@ -96,7 +116,7 @@ export const RaidUpgradeMaterialCard: FC<Props> = ({
                 material={upgradeEstimate.label}
                 iconPath={upgradeEstimate.iconPath}
                 rarity={RarityMapper.rarityToRarityString(mapUpgradeRarity(upgradeEstimate.rarity))}
-                showTooltip={false}
+                tooltip={tooltipContent}
             />
         );
 


### PR DESCRIPTION
UpgradeImageBase was a plain function component that silently dropped the ref and event handlers (onMouseEnter/Leave) injected by MUI Tooltip via cloneElement, so hover tooltips never fired anywhere UpgradeImage was used with showTooltip=true.

- Convert UpgradeImageBase to forwardRef, spreading extra HTML props onto its root <div> so MUI Tooltip can attach its listeners
- Replace deprecated MUI v5 PopperProps with slotProps.popper in AccessibleTooltip (MUI v6)
- Widen UnitShardIcon.tooltip from string to React.ReactNode
- Re-enable tooltip on UpgradeImage in RaidUpgradeMaterialCard and add tooltip to UnitShardIcon; both now show the material/unit name plus a list of related characters that need the upgrade

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tooltips now display related character information when viewing upgrade materials.

* **Refactor**
  * Enhanced component architecture for improved tooltip rendering and React integration compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->