### PR TITLE
Add mobile drawer and improve raids plan layout and tooltips

### DIFF
--- a/src/fsd/3-features/goals/raid-material-dialog.tsx
+++ b/src/fsd/3-features/goals/raid-material-dialog.tsx
@@ -1,5 +1,5 @@
 import CloseIcon from '@mui/icons-material/Close';
-import { Dialog, DialogContent, DialogTitle, IconButton, useMediaQuery } from '@mui/material';
+import { Dialog, DialogContent, DialogTitle, IconButton, SwipeableDrawer, useMediaQuery } from '@mui/material';
 import React from 'react';
 
 import { UnitShardIcon } from '@/fsd/5-shared/ui/icons';
@@ -17,7 +17,7 @@ interface RaidMaterialDialogProps {
 }
 
 export const RaidMaterialDialog: React.FC<RaidMaterialDialogProps> = ({ raid, onClose }) => {
-    const fullScreen = useMediaQuery('(max-width:600px)');
+    const isMobile = useMediaQuery('(max-width:600px)');
     const afterRaids = raid.acquiredCount + raid.raidLocations.reduce((s, loc) => s + loc.farmedItems, 0);
     const isSufficient = afterRaids >= raid.requiredCount;
     const inventoryPct = raid.requiredCount > 0 ? Math.min((raid.acquiredCount / raid.requiredCount) * 100, 100) : 0;
@@ -27,82 +27,106 @@ export const RaidMaterialDialog: React.FC<RaidMaterialDialogProps> = ({ raid, on
             : 0;
     const uniqueCharIds = [...new Set(raid.relatedCharacters)];
 
+    const titleRow = (
+        <DialogTitle id="raid-material-dialog-title" className="flex items-center gap-3 pr-2 text-(--card-fg)">
+            <div className="shrink-0">
+                <RaidMaterialIcon raid={raid} size={44} />
+            </div>
+            <span className="flex-1 text-inherit">{raid.label}</span>
+            <IconButton
+                aria-label="close"
+                onClick={onClose}
+                size={isMobile ? 'medium' : 'small'}
+                className={isMobile ? 'min-h-[44px] min-w-[44px] self-start' : 'self-start'}>
+                <CloseIcon fontSize={isMobile ? 'medium' : 'small'} />
+            </IconButton>
+        </DialogTitle>
+    );
+
+    const bodyContent = (
+        <DialogContent className="flex flex-col gap-5 pb-5! text-(--card-fg)">
+            {uniqueCharIds.length > 0 && (
+                <div>
+                    <div className="mb-2 text-xs font-semibold tracking-wide text-(--muted-fg) uppercase">
+                        Characters
+                    </div>
+                    <div className="flex flex-wrap gap-3">
+                        {uniqueCharIds.map(id => (
+                            <div key={id} className="flex items-center gap-1.5">
+                                <UnitShardIcon icon={getCharacterIcon(id)} height={28} width={28} />
+                                <span className="text-sm text-inherit">{getDisplayName(id)}</span>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            )}
+
+            <div>
+                <div className="mb-2 text-xs font-semibold tracking-wide text-(--muted-fg) uppercase">Progress</div>
+                <div className="relative mb-3 h-3 w-full overflow-hidden rounded-full bg-(--secondary)">
+                    <div className="absolute top-0 left-0 h-full bg-slate-400" style={{ width: `${inventoryPct}%` }} />
+                    <div
+                        className={`absolute top-0 h-full transition-all ${isSufficient ? 'bg-green-500' : 'bg-orange-400'}`}
+                        style={{ left: `${inventoryPct}%`, width: `${gainPct}%` }}
+                    />
+                </div>
+                <div className="grid grid-cols-3 gap-2 text-center">
+                    <div className="rounded-lg bg-(--secondary) p-2">
+                        <div className="text-xs text-(--muted-fg)">In inventory</div>
+                        <div className="text-xl font-bold text-inherit">{Math.floor(raid.acquiredCount)}</div>
+                    </div>
+                    <div className="rounded-lg bg-(--secondary) p-2">
+                        <div className="text-xs text-(--muted-fg)">After raids</div>
+                        <div className={`text-xl font-bold ${isSufficient ? 'text-green-500' : 'text-orange-400'}`}>
+                            {Math.floor(afterRaids)}
+                        </div>
+                    </div>
+                    <div className="rounded-lg bg-(--secondary) p-2">
+                        <div className="text-xs text-(--muted-fg)">Required</div>
+                        <div className="text-xl font-bold text-inherit">{raid.requiredCount}</div>
+                    </div>
+                </div>
+            </div>
+
+            <div>
+                <div className="mb-2 text-xs font-semibold tracking-wide text-(--muted-fg) uppercase">Locations</div>
+                <ExpandableRaidLocations locations={raid.raidLocations} />
+            </div>
+        </DialogContent>
+    );
+
+    if (isMobile) {
+        return (
+            <SwipeableDrawer
+                anchor="bottom"
+                open
+                onClose={onClose}
+                onOpen={() => {}}
+                disableSwipeToOpen
+                PaperProps={{
+                    className: 'bg-(--card-bg)! text-(--card-fg)!',
+                    sx: { borderTopLeftRadius: 16, borderTopRightRadius: 16, maxHeight: '85vh' },
+                }}
+                aria-labelledby="raid-material-dialog-title">
+                <div className="flex justify-center pt-2 pb-1" aria-hidden="true">
+                    <div className="h-1.5 w-10 rounded-full bg-(--card-border)" />
+                </div>
+                {titleRow}
+                {bodyContent}
+            </SwipeableDrawer>
+        );
+    }
+
     return (
         <Dialog
             open
             onClose={onClose}
-            fullScreen={fullScreen}
             maxWidth="xs"
             fullWidth
             PaperProps={{ className: 'bg-(--card-bg)! text-(--card-fg)!' }}
             aria-labelledby="raid-material-dialog-title">
-            <DialogTitle id="raid-material-dialog-title" className="flex items-center gap-3 pr-2 text-(--card-fg)">
-                <div className="shrink-0">
-                    <RaidMaterialIcon raid={raid} size={44} />
-                </div>
-                <span className="flex-1 text-inherit">{raid.label}</span>
-                <IconButton aria-label="close" onClick={onClose} size="small" className="self-start">
-                    <CloseIcon fontSize="small" />
-                </IconButton>
-            </DialogTitle>
-
-            <DialogContent className="flex flex-col gap-5 pb-5! text-(--card-fg)">
-                {/* Characters */}
-                {uniqueCharIds.length > 0 && (
-                    <div>
-                        <div className="mb-2 text-xs font-semibold tracking-wide text-(--muted-fg) uppercase">
-                            Characters
-                        </div>
-                        <div className="flex flex-wrap gap-3">
-                            {uniqueCharIds.map(id => (
-                                <div key={id} className="flex items-center gap-1.5">
-                                    <UnitShardIcon icon={getCharacterIcon(id)} height={28} width={28} />
-                                    <span className="text-sm text-inherit">{getDisplayName(id)}</span>
-                                </div>
-                            ))}
-                        </div>
-                    </div>
-                )}
-
-                {/* Progress */}
-                <div>
-                    <div className="mb-2 text-xs font-semibold tracking-wide text-(--muted-fg) uppercase">Progress</div>
-                    <div className="relative mb-3 h-3 w-full overflow-hidden rounded-full bg-(--secondary)">
-                        <div
-                            className="absolute top-0 left-0 h-full bg-slate-400"
-                            style={{ width: `${inventoryPct}%` }}
-                        />
-                        <div
-                            className={`absolute top-0 h-full transition-all ${isSufficient ? 'bg-green-500' : 'bg-orange-400'}`}
-                            style={{ left: `${inventoryPct}%`, width: `${gainPct}%` }}
-                        />
-                    </div>
-                    <div className="grid grid-cols-3 gap-2 text-center">
-                        <div className="rounded-lg bg-(--secondary) p-2">
-                            <div className="text-xs text-(--muted-fg)">In inventory</div>
-                            <div className="text-xl font-bold text-inherit">{Math.floor(raid.acquiredCount)}</div>
-                        </div>
-                        <div className="rounded-lg bg-(--secondary) p-2">
-                            <div className="text-xs text-(--muted-fg)">After raids</div>
-                            <div className={`text-xl font-bold ${isSufficient ? 'text-green-500' : 'text-orange-400'}`}>
-                                {Math.floor(afterRaids)}
-                            </div>
-                        </div>
-                        <div className="rounded-lg bg-(--secondary) p-2">
-                            <div className="text-xs text-(--muted-fg)">Required</div>
-                            <div className="text-xl font-bold text-inherit">{raid.requiredCount}</div>
-                        </div>
-                    </div>
-                </div>
-
-                {/* Locations */}
-                <div>
-                    <div className="mb-2 text-xs font-semibold tracking-wide text-(--muted-fg) uppercase">
-                        Locations
-                    </div>
-                    <ExpandableRaidLocations locations={raid.raidLocations} />
-                </div>
-            </DialogContent>
+            {titleRow}
+            {bodyContent}
         </Dialog>
     );
 };

--- a/src/fsd/3-features/goals/raid-material-dialog.tsx
+++ b/src/fsd/3-features/goals/raid-material-dialog.tsx
@@ -1,5 +1,13 @@
 import CloseIcon from '@mui/icons-material/Close';
-import { Dialog, DialogContent, DialogTitle, IconButton, SwipeableDrawer, useMediaQuery } from '@mui/material';
+import {
+    Dialog,
+    DialogContent,
+    DialogTitle,
+    IconButton,
+    SwipeableDrawer,
+    useMediaQuery,
+    useTheme,
+} from '@mui/material';
 import React from 'react';
 
 import { UnitShardIcon } from '@/fsd/5-shared/ui/icons';
@@ -17,7 +25,8 @@ interface RaidMaterialDialogProps {
 }
 
 export const RaidMaterialDialog: React.FC<RaidMaterialDialogProps> = ({ raid, onClose }) => {
-    const isMobile = useMediaQuery('(max-width:600px)');
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
     const afterRaids = raid.acquiredCount + raid.raidLocations.reduce((s, loc) => s + loc.farmedItems, 0);
     const isSufficient = afterRaids >= raid.requiredCount;
     const inventoryPct = raid.requiredCount > 0 ? Math.min((raid.acquiredCount / raid.requiredCount) * 100, 100) : 0;

--- a/src/fsd/3-features/goals/raid-material-icon.tsx
+++ b/src/fsd/3-features/goals/raid-material-icon.tsx
@@ -37,9 +37,10 @@ export interface RaidMaterialIconProps {
     raid: IUpgradeRaid;
     size?: number;
     tooltip?: React.ReactNode;
+    showTooltip?: boolean;
 }
 
-export const RaidMaterialIcon: React.FC<RaidMaterialIconProps> = ({ raid, size = 40, tooltip }) => {
+export const RaidMaterialIcon: React.FC<RaidMaterialIconProps> = ({ raid, size = 40, tooltip, showTooltip = true }) => {
     const isShard = raid.rarity === 'Shard';
     const isMythicShard = raid.rarity === 'Mythic Shard';
 
@@ -54,7 +55,7 @@ export const RaidMaterialIcon: React.FC<RaidMaterialIconProps> = ({ raid, size =
                 width={size}
             />
         );
-        return tooltip ? (
+        return tooltip && showTooltip ? (
             <AccessibleTooltip title={tooltip}>
                 <span>{icon}</span>
             </AccessibleTooltip>
@@ -70,6 +71,7 @@ export const RaidMaterialIcon: React.FC<RaidMaterialIconProps> = ({ raid, size =
             rarity={RarityMapper.rarityToRarityString(mapUpgradeRarity(raid.rarity))}
             size={size}
             tooltip={tooltip}
+            showTooltip={showTooltip}
         />
     );
 };

--- a/src/fsd/3-features/goals/raids-day-view.tsx
+++ b/src/fsd/3-features/goals/raids-day-view.tsx
@@ -128,6 +128,7 @@ export const RaidsDayView: FC<Props> = ({ day, title, dayIndex, expanded, energy
                                     disableTouchListener>
                                     <button
                                         type="button"
+                                        aria-label={raid.label}
                                         onClick={() => setSelectedRaid(raid)}
                                         className="flex flex-col items-center gap-2 rounded-lg border border-transparent p-2 transition-all hover:border-(--card-border) hover:bg-(--secondary)">
                                         {/* Icon with count badge overlaid */}

--- a/src/fsd/3-features/goals/raids-day-view.tsx
+++ b/src/fsd/3-features/goals/raids-day-view.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@mui/material';
 import { FC, lazy, Suspense, useState } from 'react';
 
 import { getEstimatedDate } from '@/fsd/5-shared/lib';
@@ -6,6 +7,28 @@ import { MiscIcon, UnitShardIcon } from '@/fsd/5-shared/ui/icons';
 
 import { IUpgradeRaid, IUpgradesRaidsDay } from './goals.models';
 import { getCharacterIcon, getDisplayName } from './raid-day-helpers';
+
+const buildCellTooltip = (raid: IUpgradeRaid) => {
+    const uniqueCharNames = [...new Set(raid.relatedCharacters.map(id => getDisplayName(id)))];
+    const visibleLocations = raid.raidLocations.slice(0, 4);
+    const overflow = raid.raidLocations.length - visibleLocations.length;
+    return (
+        <div className="flex flex-col gap-1 text-xs">
+            <div className="font-semibold">{raid.label}</div>
+            {uniqueCharNames.length > 0 && <div className="opacity-80">{uniqueCharNames.join(', ')}</div>}
+            {visibleLocations.length > 0 && (
+                <div className="mt-0.5 flex flex-col gap-0.5 border-t border-white/20 pt-0.5 opacity-80">
+                    {visibleLocations.map(loc => (
+                        <div key={loc.id}>
+                            {loc.campaign} {loc.nodeNumber} &times; {loc.raidsToPerform}
+                        </div>
+                    ))}
+                    {overflow > 0 && <div>+{overflow} more</div>}
+                </div>
+            )}
+        </div>
+    );
+};
 
 const RaidMaterialDialog = lazy(() => import('./raid-material-dialog').then(m => ({ default: m.RaidMaterialDialog })));
 const RaidMaterialIcon = lazy(() => import('./raid-material-icon').then(m => ({ default: m.RaidMaterialIcon })));
@@ -18,24 +41,10 @@ interface Props {
     energyPerDay: number;
 }
 
-const buildTooltip = (label: string, relatedCharacters: string[]) => (
-    <div>
-        {label}
-        {relatedCharacters.length > 0 && (
-            <ul className="ps-[15px]">
-                {[...new Set(relatedCharacters.map(name => getDisplayName(name)))].map(name => (
-                    <li key={name}>{name}</li>
-                ))}
-            </ul>
-        )}
-    </div>
-);
-
 export const RaidsDayView: FC<Props> = ({ day, title, dayIndex, expanded, energyPerDay }) => {
     const [selectedRaid, setSelectedRaid] = useState<IUpgradeRaid | undefined>();
 
     const calendarDate = getEstimatedDate(dayIndex + 1);
-
     const seen = new Set<string>();
     const characterIds: string[] = [];
     for (const raid of day.raids) {
@@ -54,7 +63,7 @@ export const RaidsDayView: FC<Props> = ({ day, title, dayIndex, expanded, energy
     const energyFull = energyFillPct >= 95;
 
     return (
-        <div className="flex min-w-[220px] flex-col rounded-xl border border-(--card-border) bg-(--card-bg) p-3 text-(--card-fg) shadow-sm">
+        <div className="flex min-w-[260px] flex-col rounded-xl border border-(--card-border) bg-(--card-bg) p-3 text-(--card-fg) shadow-sm">
             {/* Header - always visible */}
             <div className="flex flex-col gap-2">
                 {/* Title row */}
@@ -100,23 +109,62 @@ export const RaidsDayView: FC<Props> = ({ day, title, dayIndex, expanded, energy
                 )}
             </div>
 
-            {/* Expanded: 3-col material icon grid */}
+            {/* Expanded: material icon grid with count badge overlay and character avatar stack */}
             {expanded && farmableRaids.length > 0 && (
                 <Suspense fallback={undefined}>
-                    <div className="mt-3 grid grid-cols-3 gap-1 border-t border-(--card-border) pt-3">
-                        {farmableRaids.map((raid, index) => (
-                            <button
-                                key={index}
-                                type="button"
-                                onClick={() => setSelectedRaid(raid)}
-                                className="flex items-center justify-center rounded-md p-1 transition-colors hover:bg-(--secondary)">
-                                <RaidMaterialIcon
-                                    raid={raid}
-                                    size={40}
-                                    tooltip={buildTooltip(raid.label, raid.relatedCharacters)}
-                                />
-                            </button>
-                        ))}
+                    <div className="mt-3 grid grid-cols-3 gap-2 border-t border-(--card-border) pt-3">
+                        {farmableRaids.map((raid, index) => {
+                            const uniqueIds = [...new Set(raid.relatedCharacters)];
+                            const shown = uniqueIds.slice(0, 2);
+                            const overflow = uniqueIds.length - shown.length;
+                            const sufficient = Math.floor(raid.acquiredCount) >= raid.requiredCount;
+                            return (
+                                <Tooltip
+                                    key={index}
+                                    title={buildCellTooltip(raid)}
+                                    arrow
+                                    placement="top"
+                                    enterDelay={500}
+                                    disableTouchListener>
+                                    <button
+                                        type="button"
+                                        onClick={() => setSelectedRaid(raid)}
+                                        className="flex flex-col items-center gap-2 rounded-lg border border-transparent p-2 transition-all hover:border-(--card-border) hover:bg-(--secondary)">
+                                        {/* Icon with count badge overlaid */}
+                                        <div className="relative pb-2">
+                                            <RaidMaterialIcon raid={raid} size={40} showTooltip={false} />
+                                            <span
+                                                className={`absolute -bottom-0.5 left-1/2 -translate-x-1/2 rounded-full px-1.5 py-0.5 text-[9px] leading-none font-bold whitespace-nowrap tabular-nums shadow-sm ${
+                                                    sufficient
+                                                        ? 'bg-green-500 text-white'
+                                                        : 'bg-(--card-fg)/80 text-(--card-bg)'
+                                                }`}>
+                                                {Math.floor(raid.acquiredCount)}/{raid.requiredCount}
+                                            </span>
+                                        </div>
+                                        {/* Overlapping avatar stack */}
+                                        {uniqueIds.length > 0 && (
+                                            <div className="flex items-center">
+                                                {shown.map((id, index_) => (
+                                                    <div key={id} className={index_ > 0 ? '-ml-2' : ''}>
+                                                        <UnitShardIcon
+                                                            icon={getCharacterIcon(id)}
+                                                            height={24}
+                                                            width={24}
+                                                        />
+                                                    </div>
+                                                ))}
+                                                {overflow > 0 && (
+                                                    <span className="ml-1 text-[10px] leading-none opacity-50">
+                                                        +{overflow}
+                                                    </span>
+                                                )}
+                                            </div>
+                                        )}
+                                    </button>
+                                </Tooltip>
+                            );
+                        })}
                     </div>
                 </Suspense>
             )}

--- a/src/routes/tables/raids-header.tsx
+++ b/src/routes/tables/raids-header.tsx
@@ -54,7 +54,7 @@ export const RaidsHeader: React.FC<Props> = ({
                     </span>
                 </div>
 
-                <div className="flex-box gap10 pb-2.5">
+                <div className="flex-box gap10 flex-wrap pb-2.5">
                     {hasSync && (
                         <Button size="small" variant={'contained'} color={'primary'} onClick={syncHandle}>
                             {isMobile ? (

--- a/src/routes/tables/raids-plan.tsx
+++ b/src/routes/tables/raids-plan.tsx
@@ -436,7 +436,7 @@ export const RaidsPlan: React.FC<Props> = ({
                         }>
                         <div
                             ref={raidsDayScrollReference}
-                            className="overflow-x-auto overflow-y-hidden"
+                            className="w-full overflow-x-auto overflow-y-hidden"
                             style={{ cursor: 'grab' }}
                             onMouseDown={onDragStart}
                             onMouseMove={onDragMove}


### PR DESCRIPTION
Solved the bug where it showed tooltip and popup

Screenshot are in discord
https://discord.com/channels/1146809197023997972/1492068156674543716/1497187830215086101

this is an addition for phones
<img width="459" height="777" alt="image" src="https://github.com/user-attachments/assets/7a306e49-4560-4120-858b-c8b66a23beb6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Mobile raid dialogs now use a bottom drawer interface for improved usability.
  * Character avatars and overflow indicators now display on raid cells.

* **Improvements**
  * Enhanced raid tooltips with location details and character counts.
  * Improved responsive layout for header controls and raid containers on all screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->