### PR TITLE
Fix mobile layout issues on home screen and sync button shape

### DIFF
--- a/src/fsd/1-pages/home/daily-raids-section.tsx
+++ b/src/fsd/1-pages/home/daily-raids-section.tsx
@@ -98,11 +98,11 @@ export function DailyRaidsSection() {
                         </div>
                     </div>
                 </div>
-                <div className="px-4 py-3 text-sm">
+                <div className="px-2 py-3 text-sm sm:px-4">
                     {locationCount === 0 ? (
                         <p className="text-xs text-(--muted-fg)">No raids recorded today.</p>
                     ) : (
-                        <div className="flex flex-wrap gap-x-3 gap-y-1.5">
+                        <div className="grid grid-cols-1 gap-x-3 gap-y-1.5 min-[356px]:grid-cols-2">
                             {dailyRaids.raidedLocations.map(x => {
                                 const reward = getRewardDisplay(x);
                                 return (

--- a/src/fsd/1-pages/home/lre-section.tsx
+++ b/src/fsd/1-pages/home/lre-section.tsx
@@ -133,7 +133,7 @@ export function LreSection({ nextEvent, leProgress, characters }: LreSectionProp
                         </div>
                     </div>
                 </div>
-                <div className="flex flex-col gap-3 px-4 py-3.5 text-sm">
+                <div className="flex flex-col gap-3 px-2 py-3.5 text-sm sm:px-4">
                     {lreShardProgress !== undefined &&
                         (lreShardProgress.addlShardsForNextMilestone === Infinity ? (
                             <div className="flex items-center gap-1.5 text-xs text-(--muted-fg)">

--- a/src/fsd/1-pages/home/mobile-home.tsx
+++ b/src/fsd/1-pages/home/mobile-home.tsx
@@ -48,7 +48,7 @@ export const MobileHome = () => {
                         <Tooltip title="Frequently Asked Questions">{menuItemById.faq.icon}</Tooltip>
                     </IconButton>
                     <Tooltip title="Sync">
-                        <SyncButton showText={false} variant={'text'} />
+                        <SyncButton showText={false} iconButton={true} />
                     </Tooltip>
 
                     <Tooltip title="Join Tacticus Planner community on Discord">

--- a/src/fsd/2-widgets/app-bar/app-bar.tsx
+++ b/src/fsd/2-widgets/app-bar/app-bar.tsx
@@ -183,7 +183,7 @@ export const TopAppBar: React.FC<Props> = ({ headerTitle, seenAppVersion, onClos
                             </IconButton>
                         </Tooltip>
                         <Tooltip title="Sync with the Tacticus API">
-                            <SyncButton showText={false} variant={'text'} className="!min-w-0 !px-2 !text-inherit" />
+                            <SyncButton showText={false} iconButton={true} />
                         </Tooltip>
                         <ThemeSwitch />
                         <Button

--- a/src/fsd/5-shared/ui/sync-button/sync-button.tsx
+++ b/src/fsd/5-shared/ui/sync-button/sync-button.tsx
@@ -1,5 +1,5 @@
 import SyncIcon from '@mui/icons-material/Sync';
-import { Button } from '@mui/material';
+import { Button, IconButton } from '@mui/material';
 import React from 'react';
 
 // eslint-disable-next-line import-x/no-internal-modules, boundaries/element-types
@@ -9,15 +9,33 @@ interface SyncButtonProps {
     showText: boolean;
     variant?: 'text' | 'outlined' | 'contained' | undefined;
     className?: string;
+    iconButton?: boolean;
 }
 
-const SyncButton: React.FC<SyncButtonProps> = ({ showText, variant, className }) => {
+const SyncButton: React.FC<SyncButtonProps> = ({ showText, variant, className, iconButton }) => {
     const { syncWithTacticus } = useSyncWithTacticus();
 
     const sync = async () => {
         console.log('Syncing with Tacticus...');
         await syncWithTacticus();
     };
+
+    const handleClick = (event: React.MouseEvent) => {
+        event.stopPropagation();
+        sync();
+    };
+
+    if (iconButton) {
+        return (
+            <IconButton
+                color="inherit"
+                aria-label="Sync with Tacticus"
+                title="Sync with Tacticus"
+                onClick={handleClick}>
+                <SyncIcon />
+            </IconButton>
+        );
+    }
 
     return (
         <Button
@@ -27,10 +45,7 @@ const SyncButton: React.FC<SyncButtonProps> = ({ showText, variant, className })
             variant={variant === undefined ? 'contained' : variant}
             color={'primary'}
             className={className}
-            onClick={event => {
-                event.stopPropagation();
-                sync();
-            }}>
+            onClick={handleClick}>
             <SyncIcon /> {showText && 'Sync'}
         </Button>
     );


### PR DESCRIPTION

  - Home screen cards: Reduced card body padding from px-4 to px-2 on mobile (sm:px-4 restores it on wider screens). On a 360px budget Android phone the card content area was only 296px — too narrow to fit two raid items side by side (needed 308px). The padding reduction brings it to 312px.
  - DailyRaidsSection: Switched from flex flex-wrap to grid grid-cols-1 min-[356px]:grid-cols-2 — two columns on phones ≥ 356px, one column on narrower devices (e.g. original iPhone SE).
  - LreSection: Same responsive padding fix so track progress stats have adequate spacing on small screens.
  - Sync button shape: SyncButton was rendering as a rectangular Button while all surrounding buttons in the app bar and mobile header used circular IconButton. Added an iconButton prop to SyncButton and updated both app-bar.tsx and mobile-home.tsx to use it.
  
  
  From:
  
<img width="454" height="767" alt="image" src="https://github.com/user-attachments/assets/2ad58a14-2f07-4fcd-b9a6-86c1f9cb0dba" />


To:
<img width="585" height="834" alt="image" src="https://github.com/user-attachments/assets/61086e08-2d0c-430c-8260-c051f21c7372" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced mobile responsiveness with optimized grid layout and improved spacing in the raids section.
  * Adjusted padding for better small-screen display across multiple sections.
  * Redesigned Sync button to display as icon-only mode in the mobile header and app bar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->