### PR TITLE
Add materials goals and some options to other goals

### DIFF
--- a/src/fsd/1-pages/goals/goal-card/goal-card.tsx
+++ b/src/fsd/1-pages/goals/goal-card/goal-card.tsx
@@ -1,16 +1,19 @@
-﻿import { CheckCircle, FilterListOff } from '@mui/icons-material';
+﻿/* eslint-disable import-x/no-internal-modules */
+import { CheckCircle, FilterListOff } from '@mui/icons-material';
 import Button from '@mui/material/Button';
 import React, { useMemo } from 'react';
 
 import { getEstimatedDate } from '@/fsd/5-shared/lib';
-import { Rarity } from '@/fsd/5-shared/model';
+import { Rarity, RarityMapper } from '@/fsd/5-shared/model';
 import { UnitShardIcon } from '@/fsd/5-shared/ui/icons';
 
 import { ICharacter2 } from '@/fsd/4-entities/character';
 import { PersonalGoalType } from '@/fsd/4-entities/goal';
 import { IMow2 } from '@/fsd/4-entities/mow';
+import { UpgradeImage, UpgradesService } from '@/fsd/4-entities/upgrade';
 
-import { CharacterRaidGoalSelect, IGoalEstimate } from '@/fsd/3-features/goals';
+import { IGoalEstimate } from '@/fsd/3-features/goals';
+import { TypedGoalSelect } from '@/fsd/3-features/goals/goals.models';
 
 import { GoalCardActions } from './actions';
 import { GoalCardAscend } from './ascend';
@@ -18,14 +21,17 @@ import { GoalCardCharacterAbilities } from './character-abilities';
 import { GoalCardMowAbilities } from './mow-abilities';
 import { GoalCardRaidsButton } from './raids-button';
 import { GoalCardUnlock } from './unlock';
+import { GoalCardUpgradeMaterial } from './upgrade-material';
 import { GoalCardUpgradeRank } from './upgrade-rank';
 
 /** Returns true if the goal type has an associated daily-raids shortcut button. */
-const showRaidsButton = (goal: CharacterRaidGoalSelect): boolean =>
-    goal.type === PersonalGoalType.UpgradeRank || goal.type === PersonalGoalType.MowAbilities;
+const showRaidsButton = (goal: TypedGoalSelect): boolean =>
+    goal.type === PersonalGoalType.UpgradeRank ||
+    goal.type === PersonalGoalType.MowAbilities ||
+    goal.type === PersonalGoalType.UpgradeMaterial;
 
 interface Props {
-    goal: CharacterRaidGoalSelect;
+    goal: TypedGoalSelect;
     goalEstimate?: IGoalEstimate;
     menuItemSelect?: (item: 'edit' | 'delete' | 'moveUp' | 'moveDown') => void;
     onToggleInclude?: () => void;
@@ -88,6 +94,9 @@ export const GoalCard: React.FC<Props> = ({
             case PersonalGoalType.Unlock: {
                 return <GoalCardUnlock goal={goal} goalEstimate={goalEstimate} calendarDate={calendarDate} />;
             }
+            case PersonalGoalType.UpgradeMaterial: {
+                return <GoalCardUpgradeMaterial goalEstimate={goalEstimate} calendarDate={calendarDate} />;
+            }
         }
     };
 
@@ -100,6 +109,11 @@ export const GoalCard: React.FC<Props> = ({
                   backgroundImage: `linear-gradient(${bgColor}, ${bgColor})`,
               };
 
+    const material =
+        goal.type === PersonalGoalType.UpgradeMaterial
+            ? UpgradesService.getUpgradeMaterial(goal.upgradeMaterialId)
+            : undefined;
+
     return (
         <div
             className="flex min-h-[200px] w-[350px] flex-col overflow-hidden rounded-xl border border-(--border) text-(--fg) shadow-sm transition-colors"
@@ -110,11 +124,24 @@ export const GoalCard: React.FC<Props> = ({
                     <span className="text-[1.35rem] leading-none font-semibold text-(--muted-fg)">
                         #{goal.priority}
                     </span>
-                    <UnitShardIcon icon={goal.unitRoundIcon} height={40} />
+                    {goal.type === PersonalGoalType.UpgradeMaterial && (
+                        <UpgradeImage
+                            material={goal.upgradeMaterialId}
+                            iconPath={material?.icon ?? ''}
+                            rarity={RarityMapper.stringToRarityString(material?.rarity ?? '')}
+                            size={40}
+                        />
+                    )}
+                    {goal.type !== PersonalGoalType.UpgradeMaterial && (
+                        <UnitShardIcon icon={goal.unitRoundIcon} height={40} />
+                    )}
                 </div>
                 <div className="flex min-w-0 flex-col flex-wrap justify-start">
                     <span className="text-[1.05rem] leading-snug font-semibold text-(--fg)">
-                        {goal.unitName ?? goal.unitId}
+                        {goal.type === PersonalGoalType.UpgradeMaterial && (
+                            <span>{UpgradesService.getUpgradeMaterial(goal.upgradeMaterialId)?.material}</span>
+                        )}
+                        {goal.type !== PersonalGoalType.UpgradeMaterial && (goal.unitName ?? goal.unitId)}
                     </span>
                     {calendarDate && <span className="text-xs text-(--muted-fg)">{calendarDate}</span>}
                 </div>
@@ -152,7 +179,15 @@ export const GoalCard: React.FC<Props> = ({
                                     {goal.include ? 'Active' : 'Inactive'}
                                 </Button>
                             )}
-                            {showRaidsButton(goal) && <GoalCardRaidsButton unitId={goal.unitId} />}
+                            {showRaidsButton(goal) && (
+                                <GoalCardRaidsButton
+                                    unitId={
+                                        goal.type === PersonalGoalType.UpgradeMaterial
+                                            ? goal.upgradeMaterialId
+                                            : goal.unitId
+                                    }
+                                />
+                            )}
                         </div>
                     </>
                 )}

--- a/src/fsd/1-pages/goals/goal-card/upgrade-material.tsx
+++ b/src/fsd/1-pages/goals/goal-card/upgrade-material.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import { IGoalEstimate } from '@/fsd/3-features/goals';
+
+import { GoalEstimateRow } from './estimate-row';
+
+interface Props {
+    goalEstimate: IGoalEstimate;
+    calendarDate?: string;
+}
+
+/** Renders the body of an UpgradeMaterial goal card, showing an energy and date estimate. */
+export const GoalCardUpgradeMaterial: React.FC<Props> = ({ goalEstimate, calendarDate }) => {
+    return (
+        <div className="flex flex-col gap-2">
+            {goalEstimate.included && (
+                <div className="flex-box wrap gap-2">
+                    <GoalEstimateRow
+                        daysLeft={goalEstimate.daysLeft ?? 0}
+                        calendarDate={calendarDate}
+                        energyTotal={goalEstimate.energyTotal}
+                    />
+                </div>
+            )}
+        </div>
+    );
+};

--- a/src/fsd/1-pages/home/goals-section.tsx
+++ b/src/fsd/1-pages/home/goals-section.tsx
@@ -80,7 +80,7 @@ export function GoalsSection() {
         [gameModeTokens]
     );
 
-    const { shardsGoals, upgradeRankOrMowGoals, upgradeAbilities } = useMemo(
+    const { shardsGoals, upgradeMaterialGoals, upgradeRankOrMowGoals, upgradeAbilities } = useMemo(
         () => GoalsService.prepareGoals(goals, units, false),
         [goals, units]
     );
@@ -119,11 +119,19 @@ export function GoalsSection() {
             GoalsService.buildGoalEstimates(
                 estimatedUpgradesTotal,
                 shardsGoals,
+                upgradeMaterialGoals,
                 upgradeRankOrMowGoals,
                 upgradeAbilities,
                 resolvedCharacters
             ),
-        [estimatedUpgradesTotal, shardsGoals, upgradeRankOrMowGoals, upgradeAbilities, resolvedCharacters]
+        [
+            estimatedUpgradesTotal,
+            shardsGoals,
+            upgradeMaterialGoals,
+            upgradeRankOrMowGoals,
+            upgradeAbilities,
+            resolvedCharacters,
+        ]
     );
 
     const totalOnslaught = useMemo(

--- a/src/fsd/1-pages/home/goals-section.tsx
+++ b/src/fsd/1-pages/home/goals-section.tsx
@@ -98,7 +98,7 @@ export function GoalsSection() {
                 },
                 resolvedCharacters,
                 resolvedMows,
-                ...[upgradeRankOrMowGoals, shardsGoals].flat().filter(x => x.include)
+                ...[upgradeMaterialGoals, upgradeRankOrMowGoals, shardsGoals].flat().filter(x => x.include)
             ),
 
         [
@@ -109,6 +109,7 @@ export function GoalsSection() {
             onslaughtTokensToday,
             resolvedCharacters,
             resolvedMows,
+            upgradeMaterialGoals,
             upgradeRankOrMowGoals,
             shardsGoals,
         ]

--- a/src/fsd/1-pages/plan-campaign-progression/campaign-progression.tsx
+++ b/src/fsd/1-pages/plan-campaign-progression/campaign-progression.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable boundaries/element-types */
+/* eslint-disable import-x/no-internal-modules */
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import Accordion from '@mui/material/Accordion';
 import AccordionDetails from '@mui/material/AccordionDetails';
@@ -5,11 +7,9 @@ import AccordionSummary from '@mui/material/AccordionSummary';
 import React, { useContext, useMemo } from 'react';
 import { isMobile } from 'react-device-detect';
 
-// eslint-disable-next-line import-x/no-internal-modules
 import { DispatchContext, StoreContext } from 'src/reducers/store.provider';
 
 import { CampaignImage } from '@/fsd/4-entities/campaign';
-// eslint-disable-next-line boundaries/element-types
 import { CharactersService } from '@/fsd/4-entities/character/@x/npc';
 import {
     ICharacterUpgradeRankGoal,
@@ -20,11 +20,8 @@ import {
 import { MowsService } from '@/fsd/4-entities/mow';
 import { IUnit } from '@/fsd/4-entities/unit';
 
-// eslint-disable-next-line import-x/no-internal-modules
 import { ActiveGoalsDialog } from '@/fsd/3-features/goals/active-goals-dialog';
-// eslint-disable-next-line import-x/no-internal-modules
-import { CharacterRaidGoalSelect } from '@/fsd/3-features/goals/goals.models';
-// eslint-disable-next-line import-x/no-internal-modules
+import { TypedGoalSelect } from '@/fsd/3-features/goals/goals.models';
 import { GoalsService } from '@/fsd/3-features/goals/goals.service';
 
 import { CampaignProgressionAscensionGoals } from './campaign-progression-ascension-goals';
@@ -71,7 +68,7 @@ export const CampaignProgression = () => {
         return { allGoals, shardsGoals: filteredShardsGoals, upgradeRankOrMowGoals: filteredUpgradeRankOrMowGoals };
     }, [goals, resolvedCharacters, resolvedMows]);
 
-    const handleGoalsSelectionChange = (selection: CharacterRaidGoalSelect[]) => {
+    const handleGoalsSelectionChange = (selection: TypedGoalSelect[]) => {
         dispatch.goals({
             type: 'UpdateDailyRaids',
             value: selection.map(x => ({ goalId: x.goalId, include: x.include })),

--- a/src/fsd/1-pages/plan-ces/ces.tsx
+++ b/src/fsd/1-pages/plan-ces/ces.tsx
@@ -2,7 +2,7 @@
 import { orderBy } from 'lodash';
 import { useCallback, useContext, useMemo } from 'react';
 
-import { DailyRaidsStrategy } from '@/models/enums';
+import { DailyRaidsStrategy, PersonalGoalType } from '@/models/enums';
 import { ICustomDailyRaidsSettings } from '@/models/interfaces';
 import { DispatchContext, StoreContext } from '@/reducers/store.provider';
 
@@ -11,11 +11,12 @@ import { UnitShardIcon } from '@/fsd/5-shared/ui/icons';
 
 import { CampaignImage, CampaignsService, CampaignType } from '@/fsd/4-entities/campaign';
 import { CharactersService } from '@/fsd/4-entities/character';
+import { IUpgradeMaterialGoal } from '@/fsd/4-entities/goal/model';
 import { MowsService } from '@/fsd/4-entities/mow/mows.service';
 import { UpgradesService as FsdUpgradesService, UpgradeImage } from '@/fsd/4-entities/upgrade';
 
 import { ActiveGoalsDialog } from '@/fsd/3-features/goals/active-goals-dialog';
-import { CharacterRaidGoalSelect } from '@/fsd/3-features/goals/goals.models';
+import { CharacterRaidGoalSelect, TypedGoalSelect } from '@/fsd/3-features/goals/goals.models';
 import { GoalsService } from '@/fsd/3-features/goals/goals.service';
 import { UpgradesService } from '@/fsd/3-features/goals/upgrades.service';
 
@@ -45,6 +46,20 @@ interface MaterialAvailability {
 interface MaterialNeedInfo {
     needed: number;
     relatedGoalIds: Set<string>;
+}
+
+function getNameAndIconForCharGoal(goal: CharacterRaidGoalSelect): { name: string; icon: string } {
+    return { name: goal.unitName, icon: goal.unitRoundIcon };
+}
+
+function getNameAndIconForMaterialGoal(goal: IUpgradeMaterialGoal): { name: string; icon: string } {
+    const material = FsdUpgradesService.getUpgradeMaterial(goal.upgradeMaterialId);
+    return { name: material?.label ?? goal.upgradeMaterialId, icon: material?.icon ?? '' };
+}
+
+function getNameAndIcon(goal: TypedGoalSelect): { name: string; icon: string } {
+    if (goal.type === PersonalGoalType.UpgradeMaterial) return getNameAndIconForMaterialGoal(goal);
+    return getNameAndIconForCharGoal(goal);
 }
 
 export const CEs = () => {
@@ -77,7 +92,7 @@ export const CEs = () => {
     );
 
     const handleGoalsSelectionChange = useCallback(
-        (selection: CharacterRaidGoalSelect[]) => {
+        (selection: TypedGoalSelect[]) => {
             dispatch.goals({
                 type: 'UpdateDailyRaids',
                 value: selection.map(x => ({ goalId: x.goalId, include: x.include })),
@@ -131,7 +146,7 @@ export const CEs = () => {
     }, [upgradesEstimates.inProgressMaterials, upgradesEstimates.blockedMaterials]);
 
     const goalUnitById = useMemo(() => {
-        return new Map(allGoals.map(goal => [goal.goalId, { name: goal.unitName, icon: goal.unitRoundIcon }]));
+        return new Map(allGoals.map(goal => [goal.goalId, getNameAndIcon(goal)]));
     }, [allGoals]);
 
     const campaignPlans = useMemo(() => {

--- a/src/fsd/1-pages/plan-ces/ces.tsx
+++ b/src/fsd/1-pages/plan-ces/ces.tsx
@@ -80,12 +80,16 @@ export const CEs = () => {
 
     const onslaughtTokensToday = UpgradesService.computeOnslaughtTokensToday(gameModeTokens);
 
-    const { allGoals, shardsGoals, upgradeRankOrMowGoals } = useMemo(
+    const { allGoals, shardsGoals, upgradeMaterialGoals, upgradeRankOrMowGoals } = useMemo(
         () => GoalsService.prepareGoals(goals, units, false),
         [goals, units]
     );
 
     const includedShardsGoals = useMemo(() => shardsGoals.filter(x => x.include), [shardsGoals]);
+    const includedUpgradeMaterialGoals = useMemo(
+        () => upgradeMaterialGoals.filter(x => x.include),
+        [upgradeMaterialGoals]
+    );
     const includedUpgradeRankOrMowGoals = useMemo(
         () => upgradeRankOrMowGoals.filter(x => x.include),
         [upgradeRankOrMowGoals]
@@ -115,7 +119,7 @@ export const CEs = () => {
             },
             chars,
             mows,
-            ...[includedUpgradeRankOrMowGoals, includedShardsGoals].flat()
+            ...[includedUpgradeMaterialGoals, includedUpgradeRankOrMowGoals, includedShardsGoals].flat()
         );
     }, [
         dailyRaidsPreferences,
@@ -125,6 +129,7 @@ export const CEs = () => {
         onslaughtTokensToday,
         chars,
         mows,
+        includedUpgradeMaterialGoals,
         includedUpgradeRankOrMowGoals,
         includedShardsGoals,
     ]);

--- a/src/fsd/3-features/goals/active-goals-dialog.tsx
+++ b/src/fsd/3-features/goals/active-goals-dialog.tsx
@@ -26,10 +26,6 @@ export const ActiveGoalsDialog: React.FC<Props> = ({ goals, units, onGoalsSelect
 
     const [currentGoalsSelect, setCurrentGoalsSelect] = useState<TypedGoalSelect[]>(goals);
 
-    const unitId =
-        editGoal === undefined || editGoal?.type === PersonalGoalType.UpgradeMaterial ? undefined : editGoal.unitId;
-
-    // Sync currentGoalsSelect with goals prop when goals change while dialog is open
     useEffect(() => {
         if (openGoals) {
             setCurrentGoalsSelect(previousGoals =>
@@ -41,6 +37,7 @@ export const ActiveGoalsDialog: React.FC<Props> = ({ goals, units, onGoalsSelect
             );
         }
     }, [goals, openGoals]);
+
     const handleSelectAll = (event: React.ChangeEvent<HTMLInputElement>) => {
         setCurrentGoalsSelect(value => value.map(x => ({ ...x, include: event.target.checked })));
     };
@@ -56,9 +53,13 @@ export const ActiveGoalsDialog: React.FC<Props> = ({ goals, units, onGoalsSelect
 
     const handleGoalEdit = (goalId: string) => {
         const goalToEdit = goals.find(x => x.goalId === goalId);
-        const characterToEdit = units.find(x => x.id === unitId || x.snowprintId === unitId);
+        if (!goalToEdit) return;
 
-        if (goalToEdit && characterToEdit) {
+        const unitId = goalToEdit.type === PersonalGoalType.UpgradeMaterial ? undefined : goalToEdit.unitId;
+        const characterToEdit =
+            unitId === undefined ? undefined : units.find(x => x.id === unitId || x.snowprintId === unitId);
+
+        if (goalToEdit.type === PersonalGoalType.UpgradeMaterial || characterToEdit) {
             setEditGoal(goalToEdit);
             setEditUnit(characterToEdit);
         }
@@ -164,16 +165,17 @@ export const ActiveGoalsDialog: React.FC<Props> = ({ goals, units, onGoalsSelect
                 </DialogActions>
             </Dialog>
 
-            {editGoal && editUnit && (
-                <EditGoalDialog
-                    isOpen={true}
-                    goal={editGoal}
-                    unit={editUnit}
-                    onClose={() => {
-                        setEditGoal(undefined);
-                    }}
-                />
-            )}
+            {editGoal !== undefined &&
+                (editUnit !== undefined || editGoal.type === PersonalGoalType.UpgradeMaterial) && (
+                    <EditGoalDialog
+                        isOpen={true}
+                        goal={editGoal}
+                        unit={editUnit}
+                        onClose={() => {
+                            setEditGoal(undefined);
+                        }}
+                    />
+                )}
         </>
     );
 };

--- a/src/fsd/3-features/goals/active-goals-dialog.tsx
+++ b/src/fsd/3-features/goals/active-goals-dialog.tsx
@@ -1,33 +1,33 @@
-﻿import TrackChangesIcon from '@mui/icons-material/TrackChanges';
+﻿/* eslint-disable boundaries/element-types */
+/* eslint-disable import-x/no-internal-modules */
+import TrackChangesIcon from '@mui/icons-material/TrackChanges';
 import { Checkbox, DialogActions, DialogContent, DialogTitle, FormControlLabel } from '@mui/material';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import React, { useEffect, useMemo, useState } from 'react';
 
-// eslint-disable-next-line import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure
 import { PersonalGoalType } from 'src/models/enums';
-// eslint-disable-next-line import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure
 import { EditGoalDialog } from 'src/shared-components/goals/edit-goal-dialog';
 
-// eslint-disable-next-line import-x/no-internal-modules, boundaries/element-types -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure
 import { IUnit } from '@/fsd/3-features/characters/characters.models';
-// eslint-disable-next-line import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure
-import { CharactersRaidsGoal } from '@/fsd/3-features/goals/characters-raids-goal';
-// eslint-disable-next-line import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure
-import { CharacterRaidGoalSelect } from '@/fsd/3-features/goals/goals.models';
+import { TypedGoalSelect } from '@/fsd/3-features/goals/goals.models';
+import { RaidsGoal } from '@/fsd/3-features/goals/raids-goal';
 
 interface Props {
-    goals: CharacterRaidGoalSelect[];
+    goals: TypedGoalSelect[];
     units: IUnit[];
-    onGoalsSelectChange: (chars: CharacterRaidGoalSelect[]) => void;
+    onGoalsSelectChange: (chars: TypedGoalSelect[]) => void;
 }
 
 export const ActiveGoalsDialog: React.FC<Props> = ({ goals, units, onGoalsSelectChange }) => {
     const [openGoals, setOpenGoals] = useState<boolean>(false);
-    const [editGoal, setEditGoal] = useState<CharacterRaidGoalSelect>();
-    const [editUnit, setEditUnit] = useState<IUnit>();
+    const [editGoal, setEditGoal] = useState<TypedGoalSelect>();
+    const [editUnit, setEditUnit] = useState<IUnit | undefined>();
 
-    const [currentGoalsSelect, setCurrentGoalsSelect] = useState<CharacterRaidGoalSelect[]>(goals);
+    const [currentGoalsSelect, setCurrentGoalsSelect] = useState<TypedGoalSelect[]>(goals);
+
+    const unitId =
+        editGoal === undefined || editGoal?.type === PersonalGoalType.UpgradeMaterial ? undefined : editGoal.unitId;
 
     // Sync currentGoalsSelect with goals prop when goals change while dialog is open
     useEffect(() => {
@@ -56,12 +56,7 @@ export const ActiveGoalsDialog: React.FC<Props> = ({ goals, units, onGoalsSelect
 
     const handleGoalEdit = (goalId: string) => {
         const goalToEdit = goals.find(x => x.goalId === goalId);
-        // August 2025: we're transitioning between IDs for characters. Previously be used a short version
-        // of the character's name (i.e. Ragnar, Darkstrider). Now we're moving to IDs from snowprints internal data (datamined).
-        // During this transition, it's possibly for legacy goals to have legacy IDs, which are then overwritten with
-        // Snowprint IDs. For this reason, we cater to both IDs for lookup here, with the expectation we can consolidate
-        // on snowprintIDs down the track.
-        const characterToEdit = units.find(x => x.id === goalToEdit?.unitId || x.snowprintId === goalToEdit?.unitId);
+        const characterToEdit = units.find(x => x.id === unitId || x.snowprintId === unitId);
 
         if (goalToEdit && characterToEdit) {
             setEditGoal(goalToEdit);
@@ -81,6 +76,7 @@ export const ActiveGoalsDialog: React.FC<Props> = ({ goals, units, onGoalsSelect
         return currentSelected !== initialSelected;
     }, [currentGoalsSelect, goals]);
 
+    const upgradeMaterialGoals = currentGoalsSelect.filter(x => x.type === PersonalGoalType.UpgradeMaterial);
     const upgradeRankGoals = currentGoalsSelect.filter(x => x.type === PersonalGoalType.UpgradeRank);
     const upgradeMowGoals = currentGoalsSelect.filter(x => x.type === PersonalGoalType.MowAbilities);
     const ascendGoals = currentGoalsSelect.filter(x => x.type === PersonalGoalType.Ascend);
@@ -89,12 +85,12 @@ export const ActiveGoalsDialog: React.FC<Props> = ({ goals, units, onGoalsSelect
     const selectedGoalsCount = goals.filter(x => x.include).length;
     const currentSelectedGoalsCount = currentGoalsSelect.filter(x => x.include).length;
 
-    const renderGoalsGroup = (name: string, goals: CharacterRaidGoalSelect[]) => {
+    const renderGoalsGroup = (name: string, goals: TypedGoalSelect[]) => {
         return (
             <div className="flex-box column gap5 start">
                 <h5 className="mt-0">{name}</h5>
                 {goals.map(goal => (
-                    <CharactersRaidsGoal
+                    <RaidsGoal
                         key={goal.goalId}
                         goal={goal}
                         onSelectChange={handleChildChange}
@@ -154,6 +150,7 @@ export const ActiveGoalsDialog: React.FC<Props> = ({ goals, units, onGoalsSelect
                         {upgradeMowGoals.length > 0 && renderGoalsGroup('Upgrade MoW', upgradeMowGoals)}
                         {ascendGoals.length > 0 && renderGoalsGroup('Ascend/Promote', ascendGoals)}
                         {unlockGoals.length > 0 && renderGoalsGroup('Unlock', unlockGoals)}
+                        {upgradeMaterialGoals.length > 0 && renderGoalsGroup('Upgrade Material', upgradeMaterialGoals)}
                     </div>
                 </DialogContent>
 

--- a/src/fsd/3-features/goals/goals.models.ts
+++ b/src/fsd/3-features/goals/goals.models.ts
@@ -19,6 +19,7 @@ import {
     ICharacterUpgradeMow,
     ICharacterUpgradeRankGoal,
 } from '@/fsd/4-entities/goal';
+import { IUpgradeMaterialGoal } from '@/fsd/4-entities/goal/model';
 import { IBaseUpgrade } from '@/fsd/4-entities/upgrade';
 
 import {
@@ -42,6 +43,8 @@ export type CharacterRaidGoalSelect =
     | ICharacterUnlockGoal
     | ICharacterUpgradeMow
     | ICharacterUpgradeAbilities;
+
+export type TypedGoalSelect = CharacterRaidGoalSelect | IUpgradeMaterialGoal;
 
 /**
  * Personal goal payload for upgrading a character's abilities.
@@ -198,6 +201,7 @@ export interface IUnitUpgrade {
     goalId: string;
     unitId: string;
     label: string;
+    upgradeMaterials: Record<string, number>;
     upgradeRanks: IUnitUpgradeRank[];
     upgradeShards: IUnitShards | undefined;
     baseUpgradesTotal: Record<string, number>;

--- a/src/fsd/3-features/goals/goals.service.spec.ts
+++ b/src/fsd/3-features/goals/goals.service.spec.ts
@@ -68,6 +68,7 @@ describe('Goal service', () => {
                 xp: characterMock.xp,
                 rarity: characterMock.rarity,
                 type: PersonalGoalType.UpgradeRank,
+                manuallyFarmXp: false,
                 upgradesRarity: [],
             };
 
@@ -164,6 +165,7 @@ describe('Goal service', () => {
                 starsEnd: RarityStars.RedThreeStars,
                 onslaughtShards: 1,
                 onslaughtMythicShards: 0,
+                farmType: 'both',
                 campaignsUsage: CampaignsLocationsUsage.LeastEnergy,
                 mythicCampaignsUsage: CampaignsLocationsUsage.LeastEnergy,
                 type: PersonalGoalType.Ascend,

--- a/src/fsd/3-features/goals/goals.service.ts
+++ b/src/fsd/3-features/goals/goals.service.ts
@@ -489,6 +489,7 @@ export class GoalsService {
             case PersonalGoalType.Unlock: {
                 return {
                     ...base,
+                    character: goal.unitId,
                     campaignsUsage: goal.campaignsUsage,
                 };
             }

--- a/src/fsd/3-features/goals/goals.service.ts
+++ b/src/fsd/3-features/goals/goals.service.ts
@@ -10,6 +10,7 @@ import { Alliance, Rank, Rarity, XP_BOOK_VALUE, XP_BOOK_ORDER } from '@/fsd/5-sh
 
 import { CharactersService } from '@/fsd/4-entities/character';
 import { ICharacter2 } from '@/fsd/4-entities/character/model';
+import { IUpgradeMaterialGoal } from '@/fsd/4-entities/goal/model';
 import { IMow2, MowsService } from '@/fsd/4-entities/mow';
 import { OrbAscensionCalculator } from '@/fsd/4-entities/unit/unit-ascension.service';
 import { isCharacter, isMow } from '@/fsd/4-entities/unit/units.functions';
@@ -27,6 +28,7 @@ import {
     ICharacterUpgradeRankGoal,
     IEstimatedUpgrades,
     IGoalEstimate,
+    TypedGoalSelect,
 } from '@/fsd/3-features/goals/goals.models';
 import { UpgradesService } from '@/fsd/3-features/goals/upgrades.service';
 
@@ -93,6 +95,7 @@ export class GoalsService {
     public static buildGoalEstimates(
         estimatedUpgradesTotal: IEstimatedUpgrades,
         shardsGoals: Array<ICharacterUnlockGoal | ICharacterAscendGoal>,
+        upgradeMaterialGoals: IUpgradeMaterialGoal[],
         upgradeRankOrMowGoals: Array<ICharacterUpgradeRankGoal | ICharacterUpgradeMow>,
 
         upgradeAbilities: Array<ICharacterUpgradeAbilities>,
@@ -101,7 +104,7 @@ export class GoalsService {
     ): IGoalEstimate[] {
         const result: IGoalEstimate[] = [];
 
-        for (const goal of [shardsGoals, upgradeRankOrMowGoals].flat()) {
+        for (const goal of [shardsGoals, upgradeMaterialGoals, upgradeRankOrMowGoals].flat()) {
             const estimate: IGoalEstimate = {
                 goalId: goal.goalId,
                 energyTotal: 0,
@@ -137,7 +140,7 @@ export class GoalsService {
                     estimate.daysLeft = index + 1;
                 }
             }
-            if (goal.type === PersonalGoalType.UpgradeRank) {
+            if (goal.type === PersonalGoalType.UpgradeRank && !goal.manuallyFarmXp) {
                 const targetLevel = rankToLevel[(goal.rankEnd ?? Rank.Stone2) as Rank];
                 const currentXp = this.currentCharacterXp(
                     goal.unitId,
@@ -184,7 +187,7 @@ export class GoalsService {
                 estimate.blocked = false;
             } else if (isGoalPriority) {
                 const available = blockedEntry.acquiredCount ?? 0;
-                const allGoals = [...shardsGoals, ...upgradeRankOrMowGoals];
+                const allGoals = [...shardsGoals, ...upgradeMaterialGoals, ...upgradeRankOrMowGoals];
                 const goalPriorityMap = new Map(allGoals.map(g => [g.goalId, g.priority]));
 
                 const requiredForThisGoal = sum(
@@ -249,14 +252,16 @@ export class GoalsService {
         return result;
     }
 
+    // TODO - fix all callers
     static prepareGoals(
         goals: IPersonalGoal[],
         characters: IUnit[],
         onlySelected: boolean
     ): {
-        allGoals: CharacterRaidGoalSelect[];
+        allGoals: TypedGoalSelect[];
         shardsGoals: Array<ICharacterUnlockGoal | ICharacterAscendGoal>;
         upgradeRankOrMowGoals: Array<ICharacterUpgradeRankGoal | ICharacterUpgradeMow>;
+        upgradeMaterialGoals: IUpgradeMaterialGoal[];
         upgradeAbilities: Array<ICharacterUpgradeAbilities>;
         ascendGoals: Array<ICharacterAscendGoal>;
     } {
@@ -270,7 +275,9 @@ export class GoalsService {
                         x.snowprintId === (resolvedChar?.snowprintId ?? '') ||
                         x.snowprintId === (resolvedMow?.snowprintId ?? '')
                 );
-                if (
+                if (g.type === PersonalGoalType.UpgradeMaterial) {
+                    return this.convertToTypedGoal(g);
+                } else if (
                     ![
                         PersonalGoalType.UpgradeRank,
                         PersonalGoalType.Ascend,
@@ -285,7 +292,7 @@ export class GoalsService {
                 }
                 return this.convertToTypedGoal(g, relatedCharacter);
             })
-            .filter(g => !!g) as CharacterRaidGoalSelect[];
+            .filter(g => !!g) as TypedGoalSelect[];
 
         const selectedGoals = onlySelected ? allGoals.filter(x => x.include) : allGoals;
 
@@ -296,6 +303,8 @@ export class GoalsService {
         const upgradeRankOrMowGoals = selectedGoals.filter(x =>
             [PersonalGoalType.UpgradeRank, PersonalGoalType.MowAbilities].includes(x.type)
         ) as Array<ICharacterUpgradeRankGoal>;
+
+        const upgradeMaterialGoals = selectedGoals.filter(x => x.type === PersonalGoalType.UpgradeMaterial);
 
         const upgradeAbilities = selectedGoals.filter(x =>
             [PersonalGoalType.CharacterAbilities].includes(x.type)
@@ -309,11 +318,26 @@ export class GoalsService {
             allGoals,
             shardsGoals,
             upgradeRankOrMowGoals,
+            upgradeMaterialGoals,
             upgradeAbilities,
             ascendGoals,
         };
     }
-    static convertToTypedGoal(g: IPersonalGoal, unit?: IUnit): CharacterRaidGoalSelect | undefined {
+    static convertToTypedGoal(g: IPersonalGoal, unit?: IUnit): TypedGoalSelect | undefined {
+        if (g.type === PersonalGoalType.UpgradeMaterial) {
+            if (g.upgradeMaterialId === undefined) return;
+            if ((g.upgradeMaterialQuantity ?? 0) < 1) return;
+            return {
+                type: PersonalGoalType.UpgradeMaterial,
+                priority: g.priority,
+                goalId: g.id,
+                include: true,
+                upgradeMaterialId: g.upgradeMaterialId,
+                quantity: g.upgradeMaterialQuantity,
+                notes: g.notes,
+            } as IUpgradeMaterialGoal;
+        }
+
         if (!unit) {
             return;
         }
@@ -361,6 +385,7 @@ export class GoalsService {
                     onslaughtMythicShards: g.mythicShardsPerToken ?? 1,
                     campaignsUsage: g.campaignsUsage ?? CampaignsLocationsUsage.LeastEnergy,
                     mythicCampaignsUsage: g.mythicCampaignsUsage ?? CampaignsLocationsUsage.LeastEnergy,
+                    farmType: g.shardFarmType ?? 'both',
                     ...base,
                 };
                 return result;
@@ -393,6 +418,7 @@ export class GoalsService {
                     onslaughtMythicShards: g.mythicShardsPerToken ?? 0,
                     campaignsUsage: g.campaignsUsage ?? CampaignsLocationsUsage.LeastEnergy,
                     mythicCampaignsUsage: g.mythicCampaignsUsage ?? CampaignsLocationsUsage.LeastEnergy,
+                    farmType: g.shardFarmType ?? 'both',
                     ...base,
                 };
                 return result;
@@ -440,6 +466,7 @@ export class GoalsService {
                     level: unit.level,
                     xp: unit.xp,
                     rarity: unit.rarity,
+                    manuallyFarmXp: g.manuallyFarmXp ?? false,
                     ...base,
                 };
                 return result;
@@ -449,13 +476,13 @@ export class GoalsService {
         return;
     }
 
-    static convertToGenericGoal(goal: CharacterRaidGoalSelect): IPersonalGoal | undefined {
+    static convertToGenericGoal(goal: TypedGoalSelect): IPersonalGoal | undefined {
         const base: IPersonalGoal = {
             id: goal.goalId,
             type: goal.type,
             priority: goal.priority,
             dailyRaids: goal.include,
-            character: goal.unitId,
+            character: '',
             notes: goal.notes,
         };
         switch (goal.type) {
@@ -468,27 +495,32 @@ export class GoalsService {
             case PersonalGoalType.UpgradeRank: {
                 return {
                     ...base,
+                    character: goal.unitId,
                     startingRank: goal.rankStart,
                     startingRankPoint5: goal.rankStartPoint5,
                     targetRank: goal.rankEnd,
                     rankPoint5: goal.rankPoint5,
                     upgradesRarity: goal.upgradesRarity,
+                    manuallyFarmXp: goal.manuallyFarmXp,
                 };
             }
             case PersonalGoalType.Ascend: {
                 return {
                     ...base,
+                    character: goal.unitId,
                     targetRarity: goal.rarityEnd,
                     targetStars: goal.starsEnd,
                     campaignsUsage: goal.campaignsUsage,
                     mythicCampaignsUsage: goal.mythicCampaignsUsage,
                     shardsPerToken: goal.onslaughtShards,
                     mythicShardsPerToken: goal.onslaughtMythicShards,
+                    shardFarmType: goal.farmType,
                 };
             }
             case PersonalGoalType.MowAbilities: {
                 return {
                     ...base,
+                    character: goal.unitId,
                     firstAbilityLevel: goal.primaryEnd,
                     secondAbilityLevel: goal.secondaryEnd,
                     upgradesRarity: goal.upgradesRarity,
@@ -497,8 +529,16 @@ export class GoalsService {
             case PersonalGoalType.CharacterAbilities: {
                 return {
                     ...base,
+                    character: goal.unitId,
                     firstAbilityLevel: goal.activeEnd,
                     secondAbilityLevel: goal.passiveEnd,
+                };
+            }
+            case PersonalGoalType.UpgradeMaterial: {
+                return {
+                    ...base,
+                    upgradeMaterialId: goal.upgradeMaterialId,
+                    upgradeMaterialQuantity: goal.quantity,
                 };
             }
             default: {

--- a/src/fsd/3-features/goals/goals.service.ts
+++ b/src/fsd/3-features/goals/goals.service.ts
@@ -331,7 +331,7 @@ export class GoalsService {
                 type: PersonalGoalType.UpgradeMaterial,
                 priority: g.priority,
                 goalId: g.id,
-                include: true,
+                include: g.dailyRaids,
                 upgradeMaterialId: g.upgradeMaterialId,
                 quantity: g.upgradeMaterialQuantity,
                 notes: g.notes,

--- a/src/fsd/3-features/goals/raids-goal.tsx
+++ b/src/fsd/3-features/goals/raids-goal.tsx
@@ -1,26 +1,34 @@
-﻿import { ArrowForward, Edit } from '@mui/icons-material';
+﻿/* eslint-disable import-x/no-internal-modules */
+import { ArrowForward, Edit } from '@mui/icons-material';
 import { Checkbox, FormControlLabel, IconButton } from '@mui/material';
 import React from 'react';
 
-// eslint-disable-next-line import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure
 import { rarityToStars } from 'src/models/constants';
-// eslint-disable-next-line import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure
 import { PersonalGoalType } from 'src/models/enums';
 
+import { RarityMapper } from '@/fsd/5-shared/model';
 import { AccessibleTooltip } from '@/fsd/5-shared/ui';
 import { RankIcon, RarityIcon, StarsIcon, UnitShardIcon } from '@/fsd/5-shared/ui/icons';
 
-// eslint-disable-next-line import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure
-import { CharacterRaidGoalSelect } from '@/fsd/3-features/goals/goals.models';
+import { UpgradeImage, UpgradesService } from '@/fsd/4-entities/upgrade';
+
+import { TypedGoalSelect } from '@/fsd/3-features/goals/goals.models';
 
 interface Props {
-    goal: CharacterRaidGoalSelect;
+    goal: TypedGoalSelect;
     onSelectChange: (goalId: string, selected: boolean) => void;
     onGoalEdit: () => void;
 }
 
-export const CharactersRaidsGoal: React.FC<Props> = ({ goal, onSelectChange, onGoalEdit }) => {
-    const getGoalInfo = (goal: CharacterRaidGoalSelect) => {
+export const RaidsGoal: React.FC<Props> = ({ goal, onSelectChange, onGoalEdit }) => {
+    const material =
+        goal.type === PersonalGoalType.UpgradeMaterial
+            ? UpgradesService.getUpgradeMaterial(goal.upgradeMaterialId ?? '')
+            : undefined;
+
+    const tooltopText = goal.type === PersonalGoalType.UpgradeMaterial ? material?.label : goal.unitName;
+
+    const getGoalInfo = (goal: TypedGoalSelect) => {
         switch (goal.type) {
             case PersonalGoalType.Ascend: {
                 const isSameRarity = goal.rarityStart === goal.rarityEnd;
@@ -98,6 +106,17 @@ export const CharactersRaidsGoal: React.FC<Props> = ({ goal, onSelectChange, onG
             case PersonalGoalType.Unlock: {
                 return <span>Unlock</span>;
             }
+            case PersonalGoalType.UpgradeMaterial: {
+                return (
+                    <AccessibleTooltip title={'Upgrade material goal'}>
+                        <div className="flex-box gap5">
+                            <span>
+                                {goal.quantity}× {material?.label ?? ''}
+                            </span>
+                        </div>
+                    </AccessibleTooltip>
+                );
+            }
         }
     };
 
@@ -109,9 +128,19 @@ export const CharactersRaidsGoal: React.FC<Props> = ({ goal, onSelectChange, onG
                     <IconButton onClick={onGoalEdit}>
                         <Edit fontSize="small" />
                     </IconButton>
-                    <AccessibleTooltip title={goal.unitName}>
+                    <AccessibleTooltip title={tooltopText}>
                         <div>
-                            <UnitShardIcon icon={goal.unitRoundIcon} name={goal.unitName} />
+                            {goal.type === PersonalGoalType.UpgradeMaterial && (
+                                <UpgradeImage
+                                    material={material!.snowprintId}
+                                    iconPath={material!.icon!}
+                                    rarity={RarityMapper.stringToRarityString(material?.rarity ?? '')}
+                                    size={40}
+                                />
+                            )}
+                            {goal.type !== PersonalGoalType.UpgradeMaterial && (
+                                <UnitShardIcon icon={goal.unitRoundIcon} name={goal.unitName} />
+                            )}
                         </div>
                     </AccessibleTooltip>
                     {getGoalInfo(goal)}

--- a/src/fsd/3-features/goals/upgrades.service.spec.ts
+++ b/src/fsd/3-features/goals/upgrades.service.spec.ts
@@ -59,6 +59,7 @@ const createAscendGoal = (overrides: Partial<ICharacterAscendGoal> = {}): IChara
     campaignsUsage: CampaignsLocationsUsage.LeastEnergy,
     mythicCampaignsUsage: CampaignsLocationsUsage.LeastEnergy,
     type: PersonalGoalType.Ascend,
+    farmType: 'both',
     ...overrides,
 });
 
@@ -114,6 +115,7 @@ const createRankGoal = (
     rarity: baseChar.initialRarity ?? Rarity.Common,
     level: 1,
     xp: 0,
+    manuallyFarmXp: false,
     ...overrides,
 });
 
@@ -195,6 +197,7 @@ const createUnitUpgrade = (overrides: Partial<IUnitUpgrade> = {}): IUnitUpgrade 
     upgradeShards: undefined,
     baseUpgradesTotal: {},
     relatedUpgrades: [],
+    upgradeMaterials: {},
     ...overrides,
 });
 
@@ -2081,6 +2084,7 @@ describe('UpgradesService.handleFirstDayCompletedRaids', () => {
         rarity: kharn.initialRarity ?? Rarity.Legendary,
         level: 1,
         xp: 0,
+        manuallyFarmXp: false,
     };
 
     const worldEatersRewards = ['upgDmgR038', 'upgHpR038', 'upgArmR038', 'upgHpL118'];

--- a/src/fsd/3-features/goals/upgrades.service.ts
+++ b/src/fsd/3-features/goals/upgrades.service.ts
@@ -18,6 +18,7 @@ import { CampaignsService, CampaignType, Campaign, ICampaignBattleComposed } fro
 import { campaignEventsLocations, campaignsByGroup } from '@/fsd/4-entities/campaign/campaigns.constants';
 import { CharactersService, CharacterUpgradesService, IUnitUpgradeRank } from '@/fsd/4-entities/character';
 import { ICharacter2, IUnitShards } from '@/fsd/4-entities/character/model';
+import { IUpgradeMaterialGoal } from '@/fsd/4-entities/goal/model';
 import { IMow2, mows2Data, MowsService } from '@/fsd/4-entities/mow';
 import { NpcService } from '@/fsd/4-entities/npc/@x/unit';
 import {
@@ -116,7 +117,13 @@ export class UpgradesService {
     static readonly rankEntries: number[] = getEnumValues(Rank).filter(x => x > 0);
 
     private static readonly goalPriorityByIdCache = new WeakMap<
-        ReadonlyArray<ICharacterUpgradeRankGoal | ICharacterUpgradeMow | ICharacterAscendGoal | ICharacterUnlockGoal>,
+        ReadonlyArray<
+            | ICharacterUpgradeRankGoal
+            | ICharacterUpgradeMow
+            | ICharacterAscendGoal
+            | ICharacterUnlockGoal
+            | IUpgradeMaterialGoal
+        >,
         Map<string, number>
     >();
 
@@ -127,7 +134,13 @@ export class UpgradesService {
     >();
 
     private static getGoalPriorityById(
-        goals: Array<ICharacterUpgradeRankGoal | ICharacterUpgradeMow | ICharacterAscendGoal | ICharacterUnlockGoal>
+        goals: Array<
+            | ICharacterUpgradeRankGoal
+            | ICharacterUpgradeMow
+            | ICharacterAscendGoal
+            | ICharacterUnlockGoal
+            | IUpgradeMaterialGoal
+        >
     ): Map<string, number> {
         const cached = this.goalPriorityByIdCache.get(goals);
         if (cached) {
@@ -157,7 +170,13 @@ export class UpgradesService {
 
     private static precomputeHigherPriorityNeeds(
         combinedBaseMaterials: Record<string, ICombinedUpgrade>,
-        goals: Array<ICharacterUpgradeRankGoal | ICharacterUpgradeMow | ICharacterAscendGoal | ICharacterUnlockGoal>,
+        goals: Array<
+            | ICharacterUpgradeRankGoal
+            | ICharacterUpgradeMow
+            | ICharacterAscendGoal
+            | ICharacterUnlockGoal
+            | IUpgradeMaterialGoal
+        >,
         cache: Map<string, { neededByHigherPriorityGoals: number; stillNeededForGoal: number; totalRemaining: number }>
     ): void {
         const goalPriorityById = this.getGoalPriorityById(goals);
@@ -274,11 +293,17 @@ export class UpgradesService {
         return returnValue;
     }
 
-    static getUpgradesEstimatedDays(
+    public static getUpgradesEstimatedDays(
         settings: IEstimatedRanksSettings,
         chars: ICharacter2[],
         mows: IMow2[],
-        ...goals: Array<ICharacterUpgradeRankGoal | ICharacterUpgradeMow | ICharacterAscendGoal | ICharacterUnlockGoal>
+        ...goals: Array<
+            | ICharacterUpgradeRankGoal
+            | ICharacterUpgradeMow
+            | ICharacterAscendGoal
+            | ICharacterUnlockGoal
+            | IUpgradeMaterialGoal
+        >
     ): IEstimatedUpgrades {
         performance.mark('getUpgradesEstimatedDays-start');
         const inventoryUpgrades = this.canonicalizeInventoryUpgrades(settings.upgrades, chars, mows);
@@ -412,30 +437,39 @@ export class UpgradesService {
         mat: ICombinedUpgrade,
         characters: ICharacter2[],
         mows: IMow2[],
-        goals: Array<ICharacterUpgradeRankGoal | ICharacterUpgradeMow | ICharacterAscendGoal | ICharacterUnlockGoal>
+        goals: Array<
+            | ICharacterUpgradeRankGoal
+            | ICharacterUpgradeMow
+            | ICharacterAscendGoal
+            | ICharacterUnlockGoal
+            | IUpgradeMaterialGoal
+        >
     ): boolean {
         if (!mat.id.startsWith('shards_') && !mat.id.startsWith('mythicShards_')) {
             return mat.locations.some(loc => loc.isSuggested);
         } else if (!mat.locations.some(loc => loc.isSuggested)) {
             // We have shard goals but no place to farm them, check for onslaught.
-            const goal = goals.find(goal => mat.relatedGoals.find(relatedGoal => goal.goalId === relatedGoal));
+            const rawGoal = goals.find(goal => mat.relatedGoals.find(relatedGoal => goal.goalId === relatedGoal));
+            if (rawGoal === undefined) return false;
+            if (rawGoal.type === PersonalGoalType.UpgradeMaterial) {
+                return mat.locations.some(loc => loc.isSuggested);
+            }
+            const goal = rawGoal as Exclude<
+                ICharacterUpgradeRankGoal | ICharacterUpgradeMow | ICharacterAscendGoal | ICharacterUnlockGoal,
+                IUpgradeMaterialGoal
+            >;
             if (goal === undefined || goal.type === PersonalGoalType.Unlock) {
                 // we either don't have a goal, or we have an unlock goal that we can't farm, so the goal is blocked.
                 return false;
             } else if (
                 mat.id.startsWith('shards_') &&
-                !this.canOnslaughtCharacterForRegularShards(
-                    goal?.unitId,
-                    characters,
-                    mows,
-                    goal as ICharacterAscendGoal
-                )
+                !this.canOnslaughtCharacterForRegularShards(goal.unitId, characters, mows, goal as ICharacterAscendGoal)
             ) {
                 // We have an ascension goal requiring regular shards, but we can't farm them with onslaught, so the goal is blocked.
                 return false;
             } else if (
                 mat.id.startsWith('mythicShards_') &&
-                !this.canOnslaughtCharacterForMythicShards(goal?.unitId, characters, mows, goal as ICharacterAscendGoal)
+                !this.canOnslaughtCharacterForMythicShards(goal.unitId, characters, mows, goal as ICharacterAscendGoal)
             ) {
                 // We have an ascension goal requiring mythic shards, but we can't farm them with onslaught, so the goal is blocked.
                 return false;
@@ -520,7 +554,13 @@ export class UpgradesService {
         settings: IEstimatedRanksSettings,
         characters: ICharacter2[],
         mows: IMow2[],
-        goals: Array<ICharacterUpgradeRankGoal | ICharacterUpgradeMow | ICharacterAscendGoal | ICharacterUnlockGoal>,
+        goals: Array<
+            | ICharacterUpgradeRankGoal
+            | ICharacterUpgradeMow
+            | ICharacterAscendGoal
+            | ICharacterUnlockGoal
+            | IUpgradeMaterialGoal
+        >,
         combinedBaseMaterials: Record<string, ICombinedUpgrade>,
         inventoryUpgrades: Record<string, number>,
         remainingNeededCache: Map<
@@ -642,7 +682,13 @@ export class UpgradesService {
     public static postProcessRaidsForHse(
         day: IUpgradesRaidsDay,
         settings: IEstimatedRanksSettings,
-        goals: Array<ICharacterUpgradeRankGoal | ICharacterUpgradeMow | ICharacterAscendGoal | ICharacterUnlockGoal>,
+        goals: Array<
+            | ICharacterUpgradeRankGoal
+            | ICharacterUpgradeMow
+            | ICharacterAscendGoal
+            | ICharacterUnlockGoal
+            | IUpgradeMaterialGoal
+        >,
         combinedBaseMaterials: Record<string, ICombinedUpgrade>,
         inventory: Record<string, number>,
         remainingNeededCache: Map<
@@ -733,7 +779,13 @@ export class UpgradesService {
 
     private static precomputeGoalPriorityLocations(
         settings: IEstimatedRanksSettings,
-        goals: Array<ICharacterUpgradeRankGoal | ICharacterUpgradeMow | ICharacterAscendGoal | ICharacterUnlockGoal>,
+        goals: Array<
+            | ICharacterUpgradeRankGoal
+            | ICharacterUpgradeMow
+            | ICharacterAscendGoal
+            | ICharacterUnlockGoal
+            | IUpgradeMaterialGoal
+        >,
         remainingMats: Record<string, ICombinedUpgrade>
     ): Map<string, GoalPriorityLocationsState> | undefined {
         if (settings.preferences.farmPreferences?.order !== IDailyRaidsFarmOrder.goalPriority) {
@@ -781,7 +833,13 @@ export class UpgradesService {
         locs: ICampaignBattleComposed[],
         remainingMats: Record<string, ICombinedUpgrade>,
         inventory: Record<string, number>,
-        goals: Array<ICharacterUpgradeRankGoal | ICharacterUpgradeMow | ICharacterAscendGoal | ICharacterUnlockGoal>,
+        goals: Array<
+            | ICharacterUpgradeRankGoal
+            | ICharacterUpgradeMow
+            | ICharacterAscendGoal
+            | ICharacterUnlockGoal
+            | IUpgradeMaterialGoal
+        >,
         remainingNeededCache: Map<
             string,
             { neededByHigherPriorityGoals: number; stillNeededForGoal: number; totalRemaining: number }
@@ -825,7 +883,7 @@ export class UpgradesService {
                             .filter(([_, mat]) => mat.relatedGoals.includes(goal.goalId))
                             .map(([upgradeId]) => upgradeId)
                     );
-                const candidateLocs = (
+                let candidateLocs = (
                     precomputedState?.locs ??
                     locs.filter(loc => loc.rewards.potential.some(reward => matsForGoalIds.has(reward.id)))
                 ).filter(loc => {
@@ -847,6 +905,9 @@ export class UpgradesService {
                     );
                     return stillNeededForGoal > 0;
                 });
+                if (goal.type === PersonalGoalType.Ascend && goal.farmType === 'onslaught') {
+                    candidateLocs = [];
+                }
 
                 let sortedCandidateLocs: ICampaignBattleComposed[];
 
@@ -893,6 +954,7 @@ export class UpgradesService {
                 for (const loc of sortedCandidateLocs) {
                     if (energy < minEnergy) break;
                     const raidKey = `${loc.rewards.potential[0].id}::${goal.goalId}`;
+                    const unitId = goal.type === PersonalGoalType.UpgradeMaterial ? '' : goal.unitId;
                     energy = this.raidLocation(
                         day,
                         energy,
@@ -901,7 +963,7 @@ export class UpgradesService {
                         remainingMats,
                         goals,
                         goal.goalId,
-                        { raidKey, goal: { goalId: goal.goalId, unitId: goal.unitId } },
+                        { raidKey, goal: { goalId: goal.goalId, unitId } },
                         remainingNeededCache
                     );
                 }
@@ -932,7 +994,13 @@ export class UpgradesService {
         needed: number,
         mat: ICombinedUpgrade,
         upgradeId: string,
-        goals: Array<ICharacterUpgradeRankGoal | ICharacterUpgradeMow | ICharacterAscendGoal | ICharacterUnlockGoal>,
+        goals: Array<
+            | ICharacterUpgradeRankGoal
+            | ICharacterUpgradeMow
+            | ICharacterAscendGoal
+            | ICharacterUnlockGoal
+            | IUpgradeMaterialGoal
+        >,
         goalId: string | undefined,
         options: { raidKey?: string; goal?: { goalId: string; unitId: string } } | undefined,
         remainingNeededCache: Map<
@@ -1065,7 +1133,13 @@ export class UpgradesService {
         inventory: Record<string, number>,
         loc: ICampaignBattleComposed,
         remainingMats: Record<string, ICombinedUpgrade>,
-        goals: Array<ICharacterUpgradeRankGoal | ICharacterUpgradeMow | ICharacterAscendGoal | ICharacterUnlockGoal>,
+        goals: Array<
+            | ICharacterUpgradeRankGoal
+            | ICharacterUpgradeMow
+            | ICharacterAscendGoal
+            | ICharacterUnlockGoal
+            | IUpgradeMaterialGoal
+        >,
         goalId: string | undefined,
         options: { raidKey?: string; goal?: { goalId: string; unitId: string } } | undefined,
         remainingNeededCache: Map<
@@ -1148,7 +1222,13 @@ export class UpgradesService {
         upgradeId: string,
         mat: ICombinedUpgrade,
         inventory: Record<string, number>,
-        goals: Array<ICharacterUpgradeRankGoal | ICharacterUpgradeMow | ICharacterAscendGoal | ICharacterUnlockGoal>,
+        goals: Array<
+            | ICharacterUpgradeRankGoal
+            | ICharacterUpgradeMow
+            | ICharacterAscendGoal
+            | ICharacterUnlockGoal
+            | IUpgradeMaterialGoal
+        >,
         goalId: string | undefined,
         cache?: Map<string, { neededByHigherPriorityGoals: number; stillNeededForGoal: number; totalRemaining: number }>
     ): { neededByHigherPriorityGoals: number; stillNeededForGoal: number; totalRemaining: number } {
@@ -1214,7 +1294,13 @@ export class UpgradesService {
         upgradeId: string,
         combinedBaseMaterials: Record<string, ICombinedUpgrade>,
         inventory: Record<string, number>,
-        goals: Array<ICharacterUpgradeRankGoal | ICharacterUpgradeMow | ICharacterAscendGoal | ICharacterUnlockGoal>,
+        goals: Array<
+            | ICharacterUpgradeRankGoal
+            | ICharacterUpgradeMow
+            | ICharacterAscendGoal
+            | ICharacterUnlockGoal
+            | IUpgradeMaterialGoal
+        >,
         cache?: Map<string, { neededByHigherPriorityGoals: number; stillNeededForGoal: number; totalRemaining: number }>
     ): string | undefined {
         const mat = combinedBaseMaterials[upgradeId];
@@ -1257,7 +1343,13 @@ export class UpgradesService {
         upgradeId: string,
         combinedBaseMaterials: Record<string, ICombinedUpgrade>,
         inventory: Record<string, number>,
-        goals: Array<ICharacterUpgradeRankGoal | ICharacterUpgradeMow | ICharacterAscendGoal | ICharacterUnlockGoal>,
+        goals: Array<
+            | ICharacterUpgradeRankGoal
+            | ICharacterUpgradeMow
+            | ICharacterAscendGoal
+            | ICharacterUnlockGoal
+            | IUpgradeMaterialGoal
+        >,
         highestPriorityGoalId?: string,
         cache: Map<
             string,
@@ -1289,7 +1381,13 @@ export class UpgradesService {
      */
     public static tagLocationsWithGoalPriorityAndDaysToCompletion(
         locs: ICampaignBattleComposed[],
-        goals: Array<ICharacterUpgradeRankGoal | ICharacterUpgradeMow | ICharacterAscendGoal | ICharacterUnlockGoal>,
+        goals: Array<
+            | ICharacterUpgradeRankGoal
+            | ICharacterUpgradeMow
+            | ICharacterAscendGoal
+            | ICharacterUnlockGoal
+            | IUpgradeMaterialGoal
+        >,
         combinedBaseMaterials: Record<string, ICombinedUpgrade>,
         inventory: Record<string, number>,
         settings: IEstimatedRanksSettings,
@@ -1371,7 +1469,13 @@ export class UpgradesService {
      */
     public static sortLocationsForRaiding(
         locs: ICampaignBattleComposed[],
-        goals: Array<ICharacterUpgradeRankGoal | ICharacterUpgradeMow | ICharacterAscendGoal | ICharacterUnlockGoal>,
+        goals: Array<
+            | ICharacterUpgradeRankGoal
+            | ICharacterUpgradeMow
+            | ICharacterAscendGoal
+            | ICharacterUnlockGoal
+            | IUpgradeMaterialGoal
+        >,
         combinedBaseMaterials: Record<string, ICombinedUpgrade>,
         inventory: Record<string, number>,
         settings: IEstimatedRanksSettings,
@@ -1542,12 +1646,14 @@ export class UpgradesService {
     ): ICharacterAscendGoal | undefined {
         const shardGoal = minBy(
             goals
+                .filter(goal => goal.farmType !== 'energy')
                 .filter(goal => this.canOnslaughtCharacterForRegularShards(goal.unitId, characters, mows, goal))
                 .filter(goal => this.getOnslaughtTokensForGoal(inventory, characters, mows, goal) > 0),
             'priority'
         );
         const mythicShardGoal = minBy(
             goals
+                .filter(goal => goal.farmType !== 'energy')
                 .filter(goal => this.canOnslaughtCharacterForMythicShards(goal.unitId, characters, mows, goal))
                 .filter(goal => this.getOnslaughtTokensForGoal(inventory, characters, mows, goal) > 0),
             'priority'
@@ -1573,6 +1679,7 @@ export class UpgradesService {
         // First filter out any goals that need either type of shard but don't allow onslaught for
         // that type.
         return goals
+            .filter(goal => goal.farmType !== 'energy')
             .map(goal => ({
                 goal,
                 tokens: this.getOnslaughtTokensForGoal(inventory, characters, mows, goal),
@@ -1983,11 +2090,21 @@ export class UpgradesService {
         inventoryUpgrades: Record<string, number>,
         chars: ICharacter2[],
         mows: IMow2[],
-        goals: Array<ICharacterUpgradeRankGoal | ICharacterUpgradeMow | ICharacterAscendGoal | ICharacterUnlockGoal>
+        goals: Array<
+            | ICharacterUpgradeRankGoal
+            | ICharacterUpgradeMow
+            | ICharacterAscendGoal
+            | ICharacterUnlockGoal
+            | IUpgradeMaterialGoal
+        >
     ): IUnitUpgrade[] {
         const result: IUnitUpgrade[] = [];
         const clonedUpgrades = { ...inventoryUpgrades };
         for (const goal of goals) {
+            const upgradeMaterials = (() => {
+                if (goal.type !== PersonalGoalType.UpgradeMaterial) return {};
+                return { [goal.upgradeMaterialId]: goal.quantity };
+            })();
             const upgradeRanks =
                 (() => {
                     switch (goal.type) {
@@ -2014,6 +2131,7 @@ export class UpgradesService {
                 }
             })();
             const baseUpgradesTotal: Record<string, number> = this.getBaseUpgradesTotal(
+                upgradeMaterials,
                 upgradeRanks,
                 upgradeShards,
                 clonedUpgrades
@@ -2049,8 +2167,12 @@ export class UpgradesService {
 
             result.push({
                 goalId: goal.goalId,
-                unitId: goal.unitId,
-                label: goal.unitName,
+                unitId: goal.type === PersonalGoalType.UpgradeMaterial ? '' : goal.unitId,
+                label:
+                    goal.type === PersonalGoalType.UpgradeMaterial
+                        ? (FsdUpgradesService.getUpgradeMaterial(goal.upgradeMaterialId)?.label ?? '')
+                        : goal.unitName,
+                upgradeMaterials,
                 upgradeRanks,
                 upgradeShards,
                 baseUpgradesTotal,
@@ -2128,7 +2250,13 @@ export class UpgradesService {
     private static getGoalPriorityEstimates(
         upgrades: Record<string, ICombinedUpgrade>,
         inventoryUpgrades: Record<string, number>,
-        goals: Array<ICharacterUpgradeRankGoal | ICharacterUpgradeMow | ICharacterAscendGoal | ICharacterUnlockGoal>,
+        goals: Array<
+            | ICharacterUpgradeRankGoal
+            | ICharacterUpgradeMow
+            | ICharacterAscendGoal
+            | ICharacterUnlockGoal
+            | IUpgradeMaterialGoal
+        >,
         chars: ICharacter2[],
         mows: IMow2[]
     ): ICharacterUpgradeEstimate[] {
@@ -2152,7 +2280,7 @@ export class UpgradesService {
                     requiredCount,
                     countByGoalId: { [goal.goalId]: requiredCount },
                     relatedGoals: [goal.goalId],
-                    relatedCharacters: [goal.unitId],
+                    relatedCharacters: goal.type === PersonalGoalType.UpgradeMaterial ? [] : [goal.unitId],
                 };
 
                 const estimate = this.getUpgradeEstimate(perGoalUpgrade, requiredCount, acquiredCount);
@@ -2553,9 +2681,10 @@ export class UpgradesService {
 
     /**
      * Applies all existing inventory in `inventoryUpgrades`, then returns the total
-     * count, per non-craftable material, required to reach the rank-up goal.
+     * count, per non-craftable material, required to reach the goal.
      */
     private static getBaseUpgradesTotal(
+        upgradeMaterials: Record<string, number>,
         upgradeRanks: IUnitUpgradeRank[],
         upgradeShards: IUnitShards | undefined,
         inventoryUpgrades: Record<string, number>
@@ -2565,6 +2694,10 @@ export class UpgradesService {
 
         // Top-level crafted upgrades are gathered from the rank-up list and expanded afterward.
         const topLevelCraftedUpgrades: Record<string, number> = {};
+
+        for (const materialId in upgradeMaterials) {
+            this.addBaseUpgrade(baseUpgradesTotal, materialId, upgradeMaterials[materialId]);
+        }
 
         for (const upgradeRank of upgradeRanks) {
             for (const upgrade of upgradeRank.upgrades) {

--- a/src/fsd/4-entities/goal/enums.ts
+++ b/src/fsd/4-entities/goal/enums.ts
@@ -4,6 +4,7 @@ export enum PersonalGoalType {
     Unlock = 3,
     MowAbilities = 4,
     CharacterAbilities = 5,
+    UpgradeMaterial = 6,
 }
 
 export enum CampaignsLocationsUsage {

--- a/src/fsd/4-entities/goal/model.ts
+++ b/src/fsd/4-entities/goal/model.ts
@@ -1,19 +1,25 @@
+/* eslint-disable import-x/no-internal-modules */
+import { ShardFarmType } from '@/models/interfaces';
+
 import { Alliance, FactionId, Rank, Rarity, RarityStars } from '@/fsd/5-shared/model';
 
 import { IRankLookup } from '@/fsd/4-entities/character/@x/goal';
 
 import { CampaignsLocationsUsage, PersonalGoalType } from './enums';
 
-export interface ICharacterRaidGoalSelectBase {
+export interface IGenericGoal {
     priority: number;
     include: boolean;
     goalId: string;
+    notes: string;
+}
+
+export interface ICharacterRaidGoalSelectBase extends IGenericGoal {
     unitId: string;
     unitName: string;
     unitIcon: string;
     unitRoundIcon: string;
     unitAlliance: Alliance;
-    notes: string;
 }
 
 export interface ICharacterUpgradeRankGoal extends ICharacterRaidGoalSelectBase, IRankLookup {
@@ -22,6 +28,13 @@ export interface ICharacterUpgradeRankGoal extends ICharacterRaidGoalSelectBase,
     rarity: Rarity;
     level: number;
     xp: number;
+    manuallyFarmXp: boolean;
+}
+
+export interface IUpgradeMaterialGoal extends IGenericGoal {
+    type: PersonalGoalType.UpgradeMaterial;
+    upgradeMaterialId: string;
+    quantity: number;
 }
 
 export interface ICharacterUpgradeMow extends ICharacterRaidGoalSelectBase {
@@ -63,4 +76,5 @@ export interface ICharacterAscendGoal extends ICharacterRaidGoalSelectBase {
     onslaughtMythicShards: number;
     campaignsUsage: CampaignsLocationsUsage;
     mythicCampaignsUsage: CampaignsLocationsUsage;
+    farmType: ShardFarmType;
 }

--- a/src/fsd/4-entities/upgrade/index.ts
+++ b/src/fsd/4-entities/upgrade/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import-x/no-internal-modules */
 export type {
     IUpgradeRecipe,
     ICraftedUpgrade,
@@ -12,3 +13,4 @@ export { UpgradeImage } from './upgrade-image';
 export { recipeDataByName } from './data';
 export { UpgradeControl } from './upgrade-control';
 export { UpgradesService } from './upgrades.service';
+export { UpgradeMaterialAutocomplete } from './ui/upgrade-material-autocomplete';

--- a/src/fsd/4-entities/upgrade/ui/upgrade-material-autocomplete.tsx
+++ b/src/fsd/4-entities/upgrade/ui/upgrade-material-autocomplete.tsx
@@ -1,0 +1,96 @@
+import { Autocomplete, TextField } from '@mui/material';
+import { useState } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+import { RarityString } from '@/fsd/5-shared/model';
+
+import { IMaterial } from '../model';
+import { UpgradeImage } from '../upgrade-image';
+
+interface Props {
+    value: IMaterial | undefined;
+    options: IMaterial[];
+    onChange?: (value: IMaterial | undefined) => void;
+    label?: string;
+    className?: string;
+}
+
+const normalizeSearchText = (text: string | undefined | null): string =>
+    (text ?? '')
+        .normalize('NFD')
+        .replaceAll(/[\u0300-\u036F]/g, '')
+        .toLowerCase()
+        .trim();
+
+export const UpgradeMaterialAutocomplete = ({
+    options,
+    value,
+    onChange = () => {},
+    label = 'Material',
+    className = '',
+}: Props) => {
+    const [openAutocomplete, setOpenAutocomplete] = useState(false);
+
+    return (
+        <Autocomplete
+            fullWidth
+            className={twMerge('min-w-[200px]', className)}
+            options={options}
+            value={value ?? options[0]}
+            open={openAutocomplete}
+            onFocus={() => setOpenAutocomplete(true)}
+            onBlur={() => setOpenAutocomplete(false)}
+            filterOptions={(filterOptions, state) => {
+                const q = normalizeSearchText(state.inputValue);
+                if (!q) return filterOptions;
+                return filterOptions.filter(
+                    x => normalizeSearchText(x.material).includes(q) || normalizeSearchText(x.snowprintId).includes(q)
+                );
+            }}
+            getOptionLabel={option => option.material}
+            isOptionEqualToValue={(option, value) => option.snowprintId === value.snowprintId}
+            renderOption={(props, option) => (
+                <li {...props} key={option.snowprintId} className="flex items-center gap-2 px-3 py-1">
+                    <UpgradeImage
+                        material={option.material}
+                        iconPath={option.icon ?? ''}
+                        rarity={option.rarity as RarityString}
+                        size={36}
+                        showTooltip={false}
+                    />
+                    <span>{option.material}</span>
+                </li>
+            )}
+            onChange={(_, value) => {
+                setOpenAutocomplete(false);
+                onChange(value ?? undefined);
+            }}
+            renderInput={params => (
+                <TextField
+                    {...params}
+                    fullWidth
+                    label={label}
+                    onClick={() => setOpenAutocomplete(open => !open)}
+                    onChange={() => setOpenAutocomplete(true)}
+                    InputProps={{
+                        ...params.InputProps,
+                        startAdornment: value ? (
+                            <>
+                                <UpgradeImage
+                                    material={value.material}
+                                    iconPath={value.icon ?? ''}
+                                    rarity={value.rarity as RarityString}
+                                    size={28}
+                                    showTooltip={false}
+                                />
+                                {params.InputProps.startAdornment}
+                            </>
+                        ) : (
+                            params.InputProps.startAdornment
+                        ),
+                    }}
+                />
+            )}
+        />
+    );
+};

--- a/src/fsd/4-entities/upgrade/ui/upgrade-material-autocomplete.tsx
+++ b/src/fsd/4-entities/upgrade/ui/upgrade-material-autocomplete.tsx
@@ -36,7 +36,9 @@ export const UpgradeMaterialAutocomplete = ({
             fullWidth
             className={twMerge('min-w-[200px]', className)}
             options={options}
-            value={value ?? options[0]}
+            // We have to use null, not undefined, otherwise MUI complains about managed stuff going unmanaged.
+            // eslint-disable-next-line unicorn/no-null
+            value={value ?? null}
             open={openAutocomplete}
             onFocus={() => setOpenAutocomplete(true)}
             onBlur={() => setOpenAutocomplete(false)}

--- a/src/models/interfaces.ts
+++ b/src/models/interfaces.ts
@@ -353,6 +353,10 @@ export interface ICharProgression {
     rarity?: Rarity;
 }
 
+export const SHARD_FARM_TYPE_VALUES = ['onslaught', 'energy', 'both'] as const;
+
+export type ShardFarmType = (typeof SHARD_FARM_TYPE_VALUES)[number];
+
 export interface IPersonalGoal {
     id: string;
     character: string;
@@ -371,6 +375,8 @@ export interface IPersonalGoal {
     targetStars?: RarityStars;
     shardsPerToken?: number;
     mythicShardsPerToken?: number;
+    manuallyFarmXp?: boolean;
+    shardFarmType?: ShardFarmType;
 
     // unlock
     campaignsUsage?: CampaignsLocationsUsage;
@@ -380,6 +386,10 @@ export interface IPersonalGoal {
     unitId?: string;
     firstAbilityLevel?: number;
     secondAbilityLevel?: number;
+
+    // farm specifc upgrade material
+    upgradeMaterialId?: string;
+    upgradeMaterialQuantity?: number;
 }
 
 export interface IEstimatedRanksSettings {

--- a/src/reducers/goals.reducer.ts
+++ b/src/reducers/goals.reducer.ts
@@ -1,4 +1,4 @@
-﻿import { CharacterRaidGoalSelect } from '@/fsd/3-features/goals/goals.models';
+﻿import { TypedGoalSelect } from '@/fsd/3-features/goals/goals.models';
 import { GoalsService } from '@/fsd/3-features/goals/goals.service';
 
 import { IPersonalGoal, SetStateAction } from '../models/interfaces';
@@ -6,7 +6,7 @@ import { IPersonalGoal, SetStateAction } from '../models/interfaces';
 export type GoalsAction =
     | {
           type: 'Update';
-          goal: CharacterRaidGoalSelect;
+          goal: TypedGoalSelect;
       }
     | {
           type: 'Swap';

--- a/src/routes/goals/goals-table.tsx
+++ b/src/routes/goals/goals-table.tsx
@@ -26,13 +26,15 @@ import { RarityMapper } from '@/fsd/5-shared/model';
 import { RarityIcon, StarsIcon, RankIcon, UnitShardIcon } from '@/fsd/5-shared/ui/icons';
 import { AccessibleTooltip } from '@/fsd/5-shared/ui/tooltip';
 
+import { UpgradeImage, UpgradesService } from '@/fsd/4-entities/upgrade';
+
 import { CharacterAbilitiesTotal } from '@/fsd/3-features/characters/components/character-abilities-total';
 import { OrbsTotal } from '@/fsd/3-features/characters/components/orbs-total';
 import {
-    CharacterRaidGoalSelect,
     ICharacterUpgradeMow,
     ICharacterUpgradeRankGoal,
     IGoalEstimate,
+    TypedGoalSelect,
 } from '@/fsd/3-features/goals/goals.models';
 import { ShardsService } from '@/fsd/3-features/goals/shards.service';
 import { XpTooltip } from '@/fsd/3-features/goals/xp-tooltip';
@@ -43,8 +45,8 @@ import { GoalColorMode } from './goal-color-coding-toggle';
 import { GoalService } from './goal-service';
 
 interface Props {
-    rows: CharacterRaidGoalSelect[]; // The filtered subset (e.g., just Abilities)
-    allGoals: CharacterRaidGoalSelect[]; // The full list for global priority checks
+    rows: TypedGoalSelect[]; // The filtered subset (e.g., just Abilities)
+    allGoals: TypedGoalSelect[]; // The full list for global priority checks
     estimate: IGoalEstimate[];
     goalsColorCoding: GoalColorMode;
     menuItemSelect: (goalId: string, item: 'edit' | 'delete') => void;
@@ -87,7 +89,7 @@ export const GoalsTable: React.FC<Props> = ({ rows, allGoals, estimate, goalsCol
         );
     };
 
-    const getGoalInfo = (goal: CharacterRaidGoalSelect, goalEstimate: IGoalEstimate) => {
+    const getGoalInfo = (goal: TypedGoalSelect, goalEstimate: IGoalEstimate) => {
         switch (goal.type) {
             case PersonalGoalType.Ascend: {
                 const isSameRarity = goal.rarityStart === goal.rarityEnd;
@@ -190,6 +192,15 @@ export const GoalsTable: React.FC<Props> = ({ rows, allGoals, estimate, goalsCol
                     </div>
                 );
             }
+
+            case PersonalGoalType.UpgradeMaterial: {
+                return (
+                    <div className="flex-box between">
+                        <div className="flex-box gap-[3px]">{goal.quantity}</div>
+                    </div>
+                );
+            }
+
             case PersonalGoalType.MowAbilities: {
                 const hasPrimaryGoal = goal.primaryEnd > goal.primaryStart;
                 const hasSecondaryGoal = goal.secondaryEnd > goal.secondaryStart;
@@ -291,12 +302,12 @@ export const GoalsTable: React.FC<Props> = ({ rows, allGoals, estimate, goalsCol
         }
     };
     const orderedAllGoals = useMemo(() => allGoals.toSorted((a, b) => a.priority - b.priority), [allGoals]);
-    const columnDefs = useMemo<Array<ColDef<CharacterRaidGoalSelect>>>(() => {
+    const columnDefs = useMemo<Array<ColDef<TypedGoalSelect>>>(() => {
         return [
             {
                 field: 'priority',
                 maxWidth: 100,
-                cellRenderer: (params: ICellRendererParams<CharacterRaidGoalSelect>) => {
+                cellRenderer: (params: ICellRendererParams<TypedGoalSelect>) => {
                     const { data } = params;
                     if (!data) return;
 
@@ -331,7 +342,7 @@ export const GoalsTable: React.FC<Props> = ({ rows, allGoals, estimate, goalsCol
             },
             {
                 headerName: 'Actions',
-                cellRenderer: (params: ICellRendererParams<CharacterRaidGoalSelect>) => {
+                cellRenderer: (params: ICellRendererParams<TypedGoalSelect>) => {
                     const { data } = params;
                     if (data) {
                         return (
@@ -351,9 +362,24 @@ export const GoalsTable: React.FC<Props> = ({ rows, allGoals, estimate, goalsCol
             {
                 field: 'unitIcon',
                 headerName: 'Unit',
-                cellRenderer: (params: ICellRendererParams<CharacterRaidGoalSelect>) => {
+                cellRenderer: (params: ICellRendererParams<TypedGoalSelect>) => {
                     const { data } = params;
                     if (data) {
+                        if (data.type === PersonalGoalType.UpgradeMaterial) {
+                            const mat = UpgradesService.getUpgradeMaterial(data.upgradeMaterialId);
+                            if (mat !== undefined) {
+                                return (
+                                    <UpgradeImage
+                                        material={mat.snowprintId}
+                                        iconPath={mat.icon ?? ''}
+                                        size={30}
+                                        rarity={RarityMapper.stringToRarityString(mat.rarity)}
+                                        tooltip={mat?.label ?? ''}
+                                    />
+                                );
+                            }
+                            return '(unknown material goal)';
+                        }
                         return (
                             <UnitShardIcon icon={data.unitRoundIcon} height={30} width={30} tooltip={data.unitName} />
                         );
@@ -366,7 +392,7 @@ export const GoalsTable: React.FC<Props> = ({ rows, allGoals, estimate, goalsCol
                 headerName: 'Status',
                 autoHeight: true,
                 width: 60,
-                cellRenderer: (params: ICellRendererParams<CharacterRaidGoalSelect>) => {
+                cellRenderer: (params: ICellRendererParams<TypedGoalSelect>) => {
                     const { data } = params;
                     const goalEstimate = estimate.find(x => x.goalId === data?.goalId);
                     if (data && goalEstimate) {
@@ -381,7 +407,7 @@ export const GoalsTable: React.FC<Props> = ({ rows, allGoals, estimate, goalsCol
                 headerName: 'Details',
                 autoHeight: true,
                 width: 300,
-                cellRenderer: (params: ICellRendererParams<CharacterRaidGoalSelect>) => {
+                cellRenderer: (params: ICellRendererParams<TypedGoalSelect>) => {
                     const { data } = params;
                     const goalEstimate = estimate.find(x => x.goalId === data?.goalId);
                     if (data && goalEstimate) {
@@ -392,7 +418,7 @@ export const GoalsTable: React.FC<Props> = ({ rows, allGoals, estimate, goalsCol
             {
                 headerName: 'Estimated Date',
                 // valueGetter handles the underlying data for sorting, filtering, and clipboard
-                valueGetter: (params: ValueGetterParams<CharacterRaidGoalSelect>) => {
+                valueGetter: (params: ValueGetterParams<TypedGoalSelect>) => {
                     const goalEstimate = estimate.find(x => x.goalId === params.data?.goalId);
                     // Only return blank if both estimates are missing/undefined
                     if (
@@ -416,7 +442,7 @@ export const GoalsTable: React.FC<Props> = ({ rows, allGoals, estimate, goalsCol
                     return '';
                 },
                 // cellRenderer handles the actual visual UI
-                cellRenderer: (params: ICellRendererParams<CharacterRaidGoalSelect>) => {
+                cellRenderer: (params: ICellRendererParams<TypedGoalSelect>) => {
                     const goalEstimate = estimate.find(x => x.goalId === params.data?.goalId);
                     // Remove early guard !goalEstimate.daysLeft to allow XP-only rendering
                     if (!goalEstimate) return;

--- a/src/routes/goals/goals.tsx
+++ b/src/routes/goals/goals.tsx
@@ -109,7 +109,7 @@ export const Goals = () => {
 
     // Add these sorts to ensure the UI matches the global priority order
     const sortedShards = shardsGoals.toSorted((a, b) => a.priority - b.priority);
-    const sortedUpgrades = [upgradeRankOrMowGoals, upgradeMaterialGoals]
+    const sortedUpgrades = [upgradeMaterialGoals, upgradeRankOrMowGoals]
         .flat()
         .toSorted((a, b) => a.priority - b.priority);
     const sortedAbilities = upgradeAbilities.toSorted((a, b) => a.priority - b.priority);
@@ -490,7 +490,7 @@ export const Goals = () => {
                     </AccordionDetails>
                 </Accordion>
             </div>
-            {upgradeRankOrMowGoals.length > 0 && (
+            {upgradeRankOrMowGoals.length + upgradeMaterialGoals.length > 0 && (
                 <Accordion
                     expanded={sectionsExpanded.upgrades}
                     onChange={(_, expanded) => setSectionsExpanded(previous => ({ ...previous, upgrades: expanded }))}

--- a/src/routes/goals/goals.tsx
+++ b/src/routes/goals/goals.tsx
@@ -35,7 +35,7 @@ import { IUnit } from '@/fsd/4-entities/unit';
 import { BadgesTotal } from '@/fsd/3-features/characters/components/badges-total';
 import { OrbsTotal } from '@/fsd/3-features/characters/components/orbs-total';
 import { ActiveGoalsDialog } from '@/fsd/3-features/goals/active-goals-dialog';
-import { CharacterRaidGoalSelect, IGoalEstimate } from '@/fsd/3-features/goals/goals.models';
+import { IGoalEstimate, TypedGoalSelect } from '@/fsd/3-features/goals/goals.models';
 import { GoalsService } from '@/fsd/3-features/goals/goals.service';
 import { UpgradesService } from '@/fsd/3-features/goals/upgrades.service';
 
@@ -83,8 +83,8 @@ export const Goals = () => {
         () => CharactersService.resolveStoredCharacters(unresolvedCharacters),
         [unresolvedCharacters]
     );
-    const [editGoal, setEditGoal] = useState<CharacterRaidGoalSelect>();
-    const [editUnit, setEditUnit] = useState<IUnit>(characters[0]);
+    const [editGoal, setEditGoal] = useState<TypedGoalSelect>();
+    const [editUnit, setEditUnit] = useState<IUnit | undefined>(characters[0]);
     const [openSettings, setOpenSettings] = useState<boolean>(false);
     const [resourcesExpanded, setResourcesExpanded] = useState(false);
     const [sectionsExpanded, setSectionsExpanded] = useState({ upgrades: true, shards: true, abilities: true });
@@ -104,14 +104,14 @@ export const Goals = () => {
     const resolvedMows = useMemo(() => MowsService.resolveAllFromStorage(mows), [mows]);
     const units = useMemo(() => [...characters, ...resolvedMows], [characters, resolvedMows]);
 
-    const { allGoals, shardsGoals, upgradeRankOrMowGoals, ascendGoals, upgradeAbilities } = useMemo(
-        () => GoalsService.prepareGoals(goals, units, false),
-        [goals, units]
-    );
+    const { allGoals, shardsGoals, upgradeRankOrMowGoals, upgradeMaterialGoals, ascendGoals, upgradeAbilities } =
+        useMemo(() => GoalsService.prepareGoals(goals, units, false), [goals, units]);
 
     // Add these sorts to ensure the UI matches the global priority order
     const sortedShards = shardsGoals.toSorted((a, b) => a.priority - b.priority);
-    const sortedUpgrades = upgradeRankOrMowGoals.toSorted((a, b) => a.priority - b.priority);
+    const sortedUpgrades = [upgradeRankOrMowGoals, upgradeMaterialGoals]
+        .flat()
+        .toSorted((a, b) => a.priority - b.priority);
     const sortedAbilities = upgradeAbilities.toSorted((a, b) => a.priority - b.priority);
 
     const onslaughtTokensToday = useMemo(
@@ -132,7 +132,7 @@ export const Goals = () => {
         },
         characters,
         resolvedMows,
-        ...[upgradeRankOrMowGoals, shardsGoals].flat().filter(x => x.include)
+        ...[upgradeMaterialGoals, upgradeRankOrMowGoals, shardsGoals].flat().filter(x => x.include)
     );
 
     const energyAlreadySpent = useMemo(() => {
@@ -193,15 +193,13 @@ export const Goals = () => {
 
         if (item === 'edit') {
             const goal = allGoals.find(x => x.goalId === goalId);
-            const relatedUnit = [...characters, ...resolvedMows].find(
-                // August 2025: we're transitioning between IDs for characters. Previously be used a short version
-                // of the character's name (i.e. Ragnar, Darkstrider). Now we're moving to IDs from snowprints internal data (datamined).
-                // During this transition, it's possibly for legacy goals to have legacy IDs, which are then overwritten with
-                // Snowprint IDs. For this reason, we cater to both IDs for lookup here, with the expectation we can consolidate
-                // on snowprintIDs down the track.
-                x => x.snowprintId === goal?.unitId || x.id === goal?.unitId
-            );
-            if (relatedUnit && goal) {
+            const relatedUnit =
+                goal?.type === PersonalGoalType.UpgradeMaterial
+                    ? undefined
+                    : [...characters, ...resolvedMows].find(
+                          x => x.snowprintId === goal?.unitId || x.id === goal?.unitId
+                      );
+            if (goal && (goal.type === PersonalGoalType.UpgradeMaterial || relatedUnit !== undefined)) {
                 setEditUnit(relatedUnit);
                 setEditGoal(goal);
             }
@@ -234,6 +232,7 @@ export const Goals = () => {
             GoalsService.buildGoalEstimates(
                 estimatedUpgradesTotal,
                 shardsGoals,
+                upgradeMaterialGoals,
                 upgradeRankOrMowGoals,
                 upgradeAbilities,
                 characters,
@@ -321,7 +320,7 @@ export const Goals = () => {
         dispatch.goals({ type: 'DeleteAll' });
     };
 
-    const handleGoalsSelectionChange = (selection: CharacterRaidGoalSelect[]) => {
+    const handleGoalsSelectionChange = (selection: TypedGoalSelect[]) => {
         dispatch.goals({
             type: 'UpdateDailyRaids',
             value: selection.map(x => ({ goalId: x.goalId, include: x.include })),
@@ -517,7 +516,6 @@ export const Goals = () => {
                         {!viewPreferences.goalsTableView && (
                             <div className="flex flex-wrap gap-3">
                                 {sortedUpgrades.map(goal => {
-                                    // Search the NEW merged collection for this goal's estimate
                                     const finalEstimate = mergedGoalEstimates.find(x => x.goalId === goal.goalId);
 
                                     return (
@@ -548,7 +546,7 @@ export const Goals = () => {
 
                         {viewPreferences.goalsTableView && (
                             <GoalsTable
-                                rows={sortedUpgrades}
+                                rows={sortedUpgrades} // Filter out material goals for this section
                                 allGoals={allGoals} // Pass the global flattened list here
                                 estimate={mergedGoalEstimates} // Pass the merged estimates to the table
                                 menuItemSelect={handleMenuItemSelect}
@@ -668,7 +666,7 @@ export const Goals = () => {
                         {viewPreferences.goalsTableView && (
                             <GoalsTable
                                 rows={sortedAbilities}
-                                allGoals={allGoals} // Pass the global flattened list here
+                                allGoals={allGoals.filter(g => g.type !== PersonalGoalType.UpgradeMaterial)}
                                 estimate={mergedGoalEstimates}
                                 menuItemSelect={handleMenuItemSelect}
                                 goalsColorCoding={viewPreferences.goalColorMode}
@@ -677,16 +675,17 @@ export const Goals = () => {
                     </AccordionDetails>
                 </Accordion>
             )}
-            {!!editGoal && !!editUnit && (
-                <EditGoalDialog
-                    isOpen={true}
-                    goal={editGoal}
-                    unit={editUnit}
-                    onClose={() => {
-                        setEditGoal(undefined);
-                    }}
-                />
-            )}
+            {editGoal !== undefined &&
+                (editUnit !== undefined || editGoal.type === PersonalGoalType.UpgradeMaterial) && (
+                    <EditGoalDialog
+                        isOpen={true}
+                        goal={editGoal}
+                        unit={editUnit}
+                        onClose={() => {
+                            setEditGoal(undefined);
+                        }}
+                    />
+                )}
         </div>
     );
 };

--- a/src/routes/goals/goals.tsx
+++ b/src/routes/goals/goals.tsx
@@ -546,7 +546,7 @@ export const Goals = () => {
 
                         {viewPreferences.goalsTableView && (
                             <GoalsTable
-                                rows={sortedUpgrades} // Filter out material goals for this section
+                                rows={sortedUpgrades}
                                 allGoals={allGoals} // Pass the global flattened list here
                                 estimate={mergedGoalEstimates} // Pass the merged estimates to the table
                                 menuItemSelect={handleMenuItemSelect}

--- a/src/routes/tables/daily-raids.tsx
+++ b/src/routes/tables/daily-raids.tsx
@@ -16,7 +16,7 @@ import { MowsService } from '@/fsd/4-entities/mow';
 
 import { IUnit } from '@/fsd/3-features/characters/characters.models';
 import { ActiveGoalsDialog } from '@/fsd/3-features/goals/active-goals-dialog';
-import { CharacterRaidGoalSelect, IEstimatedUpgrades } from '@/fsd/3-features/goals/goals.models';
+import { IEstimatedUpgrades, TypedGoalSelect } from '@/fsd/3-features/goals/goals.models';
 import { GoalsService } from '@/fsd/3-features/goals/goals.service';
 import { LocationsFilter } from '@/fsd/3-features/goals/locations-filter';
 import { UpgradesService } from '@/fsd/3-features/goals/upgrades.service';
@@ -62,7 +62,7 @@ export const DailyRaids = () => {
         [inventory.upgrades, storeCharacters, resolvedMows]
     );
     const units = useMemo(() => [...storeCharacters, ...resolvedMows], [storeCharacters, resolvedMows]);
-    const { allGoals, shardsGoals, upgradeRankOrMowGoals } = useMemo(() => {
+    const { allGoals, shardsGoals, upgradeMaterialGoals, upgradeRankOrMowGoals } = useMemo(() => {
         return GoalsService.prepareGoals(goals, units, true);
     }, [goals, units]);
 
@@ -78,7 +78,7 @@ export const DailyRaids = () => {
         setCharSnowprintId(searchParams.get('charSnowprintId') ?? undefined);
     }, [location]);
 
-    const handleGoalsSelectionChange = (selection: CharacterRaidGoalSelect[]) => {
+    const handleGoalsSelectionChange = (selection: TypedGoalSelect[]) => {
         dispatch.goals({
             type: 'UpdateDailyRaids',
             value: selection.map(x => ({ goalId: x.goalId, include: x.include })),
@@ -133,6 +133,7 @@ export const DailyRaids = () => {
             },
             resolvedCharacters,
             resolvedMows,
+            ...upgradeMaterialGoals,
             ...upgradeRankOrMowGoals,
             ...shardsGoals
         );
@@ -162,6 +163,7 @@ export const DailyRaids = () => {
             },
             resolvedCharacters,
             resolvedMows,
+            ...upgradeMaterialGoals,
             ...upgradeRankOrMowGoals,
             ...shardsGoals
         );

--- a/src/shared-components/goals/edit-ascend-goal.tsx
+++ b/src/shared-components/goals/edit-ascend-goal.tsx
@@ -1,7 +1,8 @@
-﻿import React, { useMemo } from 'react';
+﻿import { MenuItem, Select } from '@mui/material';
+import React, { useMemo } from 'react';
 
 import { rarityToMaxStars, rarityToStars } from 'src/models/constants';
-import { ICampaignBattleComposed } from 'src/models/interfaces';
+import { ICampaignBattleComposed, SHARD_FARM_TYPE_VALUES, ShardFarmType } from 'src/models/interfaces';
 import { NumbersInput } from 'src/shared-components/goals/numbers-input';
 
 import { getEnumValues } from '@/fsd/5-shared/lib';
@@ -16,10 +17,17 @@ interface Props {
     unlockedLocations: string[];
     possibleMythicLocations: ICampaignBattleComposed[];
     unlockedMythicLocations: string[];
-    onChange: (key: keyof ICharacterAscendGoal, value: number) => void;
+    farmType: ShardFarmType;
+    onChange: (key: keyof ICharacterAscendGoal, value: number | ShardFarmType) => void;
 }
 
-export const EditAscendGoal: React.FC<Props> = ({ goal, possibleLocations, possibleMythicLocations, onChange }) => {
+export const EditAscendGoal: React.FC<Props> = ({
+    goal,
+    possibleLocations,
+    possibleMythicLocations,
+    farmType,
+    onChange,
+}) => {
     const rarityValues = useMemo(() => {
         return getEnumValues(Rarity).filter(x => x >= goal.rarityStart);
     }, [goal.rarityStart]);
@@ -123,6 +131,26 @@ export const EditAscendGoal: React.FC<Props> = ({ goal, possibleLocations, possi
                     )}
                 </>
             )}
+
+            <div className="flex items-center gap-3">
+                <div className="flex-1">
+                    <label className="mb-1 block text-sm font-medium">Farm Type</label>
+                    <Select
+                        label="Farm Type"
+                        value={farmType}
+                        onChange={event => onChange('farmType', event.target.value as ShardFarmType)}
+                        fullWidth>
+                        {SHARD_FARM_TYPE_VALUES.map(type => (
+                            <MenuItem key={type} value={type}>
+                                {type
+                                    .split('_')
+                                    .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+                                    .join(' ')}
+                            </MenuItem>
+                        ))}
+                    </Select>
+                </div>
+            </div>
         </>
     );
 };

--- a/src/shared-components/goals/edit-goal-dialog.tsx
+++ b/src/shared-components/goals/edit-goal-dialog.tsx
@@ -26,7 +26,7 @@ import { MowUpgrades } from '@/fsd/4-entities/mow/mow-upgrades';
 import { MowUpgradesUpdate } from '@/fsd/4-entities/mow/mow-upgrades-update';
 import { IUnit } from '@/fsd/4-entities/unit';
 import { isCharacter, isMow } from '@/fsd/4-entities/unit/units.functions';
-import { IUpgradeRecipe, UpgradeImage, UpgradesService } from '@/fsd/4-entities/upgrade';
+import { UpgradeImage, UpgradesService } from '@/fsd/4-entities/upgrade';
 
 import { CharactersAbilitiesService } from '@/fsd/3-features/characters/characters-abilities.service';
 import { ICharacterAscendGoal, TypedGoalSelect } from '@/fsd/3-features/goals/goals.models';
@@ -47,7 +47,6 @@ export const EditGoalDialog: React.FC<Props> = ({ isOpen, onClose, goal, unit })
     const [openDialog, setOpenDialog] = React.useState(isOpen);
 
     const [form, setForm] = useState<TypedGoalSelect>(goal);
-    const [_inventoryUpdate, setInventoryUpdate] = useState<Array<IUpgradeRecipe>>([]);
 
     const handleClose = (updatedGoal?: TypedGoalSelect | undefined): void => {
         if (updatedGoal) {
@@ -277,9 +276,7 @@ export const EditGoalDialog: React.FC<Props> = ({ isOpen, onClose, goal, unit })
                                 currSecondaryLevel={form.secondaryStart}
                                 originalPrimaryLevel={unit.primaryAbilityLevel}
                                 originalSecondaryLevel={unit.secondaryAbilityLevel}
-                                inventoryDecrement={value => {
-                                    setInventoryUpdate(Object.entries(value).map(([id, count]) => ({ id, count })));
-                                }}
+                                inventoryDecrement={() => {}}
                             />
                         </>
                     )}
@@ -384,6 +381,7 @@ export const EditGoalDialog: React.FC<Props> = ({ isOpen, onClose, goal, unit })
                             fullWidth
                             label="Upgrade Material Quantity"
                             min={0}
+                            max={10_000}
                             value={form.quantity ?? 0}
                             valueChange={quantity => {
                                 setForm(current => ({

--- a/src/shared-components/goals/edit-goal-dialog.tsx
+++ b/src/shared-components/goals/edit-goal-dialog.tsx
@@ -6,6 +6,7 @@ import { enqueueSnackbar } from 'notistack';
 import React, { useContext, useMemo, useState } from 'react';
 
 import { PersonalGoalType } from '@/models/enums';
+import { ShardFarmType } from '@/models/interfaces';
 import { DispatchContext, StoreContext } from 'src/reducers/store.provider';
 import { StaticDataService } from 'src/services';
 import { EditAscendGoal } from 'src/shared-components/goals/edit-ascend-goal';
@@ -21,23 +22,22 @@ import { NumberInput } from '@/fsd/5-shared/ui/input/number-input';
 
 import { ICampaignBattleComposed, ICampaignsProgress } from '@/fsd/4-entities/campaign';
 import { CampaignLocation } from '@/fsd/4-entities/campaign/campaign-location';
-import { CharactersService } from '@/fsd/4-entities/character';
 import { MowUpgrades } from '@/fsd/4-entities/mow/mow-upgrades';
 import { MowUpgradesUpdate } from '@/fsd/4-entities/mow/mow-upgrades-update';
 import { IUnit } from '@/fsd/4-entities/unit';
 import { isCharacter, isMow } from '@/fsd/4-entities/unit/units.functions';
-import { IUpgradeRecipe } from '@/fsd/4-entities/upgrade';
+import { IUpgradeRecipe, UpgradeImage, UpgradesService } from '@/fsd/4-entities/upgrade';
 
 import { CharactersAbilitiesService } from '@/fsd/3-features/characters/characters-abilities.service';
-import { CharacterRaidGoalSelect, ICharacterAscendGoal } from '@/fsd/3-features/goals/goals.models';
+import { ICharacterAscendGoal, TypedGoalSelect } from '@/fsd/3-features/goals/goals.models';
 
 import { IgnoreRankRarity } from './ignore-rank-rarity';
 
 interface Props {
     isOpen: boolean;
-    goal: CharacterRaidGoalSelect;
-    unit: IUnit;
-    onClose?: (goal?: CharacterRaidGoalSelect) => void;
+    goal: TypedGoalSelect;
+    unit: IUnit | undefined;
+    onClose?: (goal?: TypedGoalSelect) => void;
 }
 
 export const EditGoalDialog: React.FC<Props> = ({ isOpen, onClose, goal, unit }) => {
@@ -46,77 +46,23 @@ export const EditGoalDialog: React.FC<Props> = ({ isOpen, onClose, goal, unit })
 
     const [openDialog, setOpenDialog] = React.useState(isOpen);
 
-    const [form, setForm] = useState<CharacterRaidGoalSelect>(goal);
-    const [inventoryUpdate, setInventoryUpdate] = useState<Array<IUpgradeRecipe>>([]);
+    const [form, setForm] = useState<TypedGoalSelect>(goal);
+    const [_inventoryUpdate, setInventoryUpdate] = useState<Array<IUpgradeRecipe>>([]);
 
-    const handleClose = (updatedGoal?: CharacterRaidGoalSelect | undefined): void => {
+    const handleClose = (updatedGoal?: TypedGoalSelect | undefined): void => {
         if (updatedGoal) {
             dispatch.goals({ type: 'Update', goal: updatedGoal });
 
-            switch (updatedGoal.type) {
-                case PersonalGoalType.Ascend: {
-                    if (CharactersService.getUnit(updatedGoal.unitId) !== undefined) {
-                        dispatch.characters({
-                            type: 'UpdateRarity',
-                            character: updatedGoal.unitId,
-                            value: updatedGoal.rarityStart,
-                        });
-
-                        dispatch.characters({
-                            type: 'UpdateShards',
-                            character: updatedGoal.unitId,
-                            value: updatedGoal.shards,
-                        });
-
-                        dispatch.characters({
-                            type: 'UpdateStars',
-                            character: updatedGoal.unitId,
-                            value: updatedGoal.starsStart,
-                        });
-                    }
-                    break;
-                }
-                case PersonalGoalType.Unlock: {
-                    dispatch.characters({
-                        type: 'UpdateShards',
-                        character: updatedGoal.unitId,
-                        value: updatedGoal.shards,
-                    });
-                    break;
-                }
-                case PersonalGoalType.UpgradeRank: {
-                    // Do nothing, users can sync if they want to update their characters.
-                    break;
-                }
-                case PersonalGoalType.MowAbilities: {
-                    dispatch.mows({
-                        type: 'UpdateAbilities',
-                        mowId: updatedGoal.unitId,
-                        abilities: [updatedGoal.primaryStart, updatedGoal.secondaryStart],
-                    });
-                    break;
-                }
-
-                case PersonalGoalType.CharacterAbilities: {
-                    dispatch.characters({
-                        type: 'UpdateAbilities',
-                        characterId: updatedGoal.unitId,
-                        abilities: [updatedGoal.activeStart, updatedGoal.passiveStart],
-                    });
-                    break;
-                }
-            }
-
-            if (inventoryUpdate.length > 0) {
-                dispatch.inventory({
-                    type: 'DecrementUpgradeQuantity',
-                    upgrades: inventoryUpdate.map(x => ({ id: x.id, count: x.count })),
+            if (updatedGoal.type === PersonalGoalType.UpgradeMaterial) {
+                const material = UpgradesService.getUpgradeMaterial(updatedGoal.upgradeMaterialId);
+                enqueueSnackbar(`Goal for ${material?.material ?? 'unknown material'} was updated`, {
+                    variant: 'success',
+                });
+            } else {
+                enqueueSnackbar(`Goal for ${updatedGoal.unitName ?? updatedGoal.unitId} was updated`, {
+                    variant: 'success',
                 });
             }
-
-            enqueueSnackbar(`Goal for ${updatedGoal.unitName ?? updatedGoal.unitId} was updated`, {
-                variant: 'success',
-            });
         }
         setOpenDialog(false);
         if (onClose) {
@@ -124,7 +70,7 @@ export const EditGoalDialog: React.FC<Props> = ({ isOpen, onClose, goal, unit })
         }
     };
 
-    const handleAscendGoalChanges = (key: keyof ICharacterAscendGoal, value: number) => {
+    const handleAscendGoalChanges = (key: keyof ICharacterAscendGoal, value: number | ShardFarmType) => {
         setForm(current => ({ ...current, [key]: value }));
     };
 
@@ -172,13 +118,29 @@ export const EditGoalDialog: React.FC<Props> = ({ isOpen, onClose, goal, unit })
         })
         .map(x => x.id);
 
+    const material =
+        form.type === PersonalGoalType.UpgradeMaterial
+            ? UpgradesService.getUpgradeMaterial(form.upgradeMaterialId)
+            : undefined;
+
     return (
         <Dialog open={openDialog} onClose={() => handleClose()} fullWidth>
             <DialogTitle className="flex items-center gap-[3px]">
-                <span>Edit {PersonalGoalType[goal.type]} Goal</span> <UnitShardIcon icon={goal.unitRoundIcon} />
+                <span>Edit {PersonalGoalType[goal.type]} Goal</span>
+                {goal.type === PersonalGoalType.UpgradeMaterial ? (
+                    <UpgradeImage
+                        material={material?.snowprintId ?? ''}
+                        iconPath={material?.icon ?? ''}
+                        size={40}
+                        rarity={RarityMapper.stringToRarityString(material?.rarity ?? '')}
+                    />
+                ) : (
+                    <UnitShardIcon icon={goal.unitRoundIcon} />
+                )}
             </DialogTitle>
             <DialogContent className="pt-5">
                 <Box id="edit-goal-form" className="flex flex-col gap-5">
+                    <div className="min-h-[10px]" />
                     <PrioritySelect
                         value={form.priority}
                         maxValue={goals.length}
@@ -218,6 +180,18 @@ export const EditGoalDialog: React.FC<Props> = ({ isOpen, onClose, goal, unit })
                                     }));
                                 }}
                             />
+
+                            <label className="flex items-center gap-2">
+                                <input
+                                    type="checkbox"
+                                    checked={form.manuallyFarmXp ?? false}
+                                    onChange={event => {
+                                        setForm(current => ({ ...current, manuallyFarmXp: event.target.checked }));
+                                    }}
+                                    className="h-4 w-4"
+                                />
+                                <span className="text-sm">Manually Farm XP</span>
+                            </label>
                         </>
                     )}
 
@@ -399,9 +373,25 @@ export const EditGoalDialog: React.FC<Props> = ({ isOpen, onClose, goal, unit })
                                 possibleMythicLocations={possibleMythicLocations}
                                 unlockedLocations={unlockedLocations}
                                 unlockedMythicLocations={unlockedMythicLocations}
+                                farmType={form.farmType ?? 'both'}
                                 onChange={handleAscendGoalChanges}
                             />
                         </>
+                    )}
+
+                    {form.type === PersonalGoalType.UpgradeMaterial && (
+                        <NumberInput
+                            fullWidth
+                            label="Upgrade Material Quantity"
+                            min={0}
+                            value={form.quantity ?? 0}
+                            valueChange={quantity => {
+                                setForm(current => ({
+                                    ...current,
+                                    quantity: quantity,
+                                }));
+                            }}
+                        />
                     )}
 
                     <TextField

--- a/src/shared-components/goals/edit-goal-dialog.tsx
+++ b/src/shared-components/goals/edit-goal-dialog.tsx
@@ -386,7 +386,7 @@ export const EditGoalDialog: React.FC<Props> = ({ isOpen, onClose, goal, unit })
                             valueChange={quantity => {
                                 setForm(current => ({
                                     ...current,
-                                    quantity: quantity,
+                                    quantity: Math.max(1, quantity),
                                 }));
                             }}
                         />

--- a/src/shared-components/goals/set-ascend-goal.tsx
+++ b/src/shared-components/goals/set-ascend-goal.tsx
@@ -1,8 +1,9 @@
-﻿import React, { useMemo } from 'react';
+﻿import { MenuItem, Select } from '@mui/material';
+import React, { useMemo } from 'react';
 
 import { rarityToMaxStars, rarityToStars } from 'src/models/constants';
 import { CampaignsLocationsUsage } from 'src/models/enums';
-import { ICampaignBattleComposed, IPersonalGoal } from 'src/models/interfaces';
+import { ICampaignBattleComposed, IPersonalGoal, SHARD_FARM_TYPE_VALUES, ShardFarmType } from 'src/models/interfaces';
 import { NumbersInput } from 'src/shared-components/goals/numbers-input';
 
 import { getEnumValues } from '@/fsd/5-shared/lib';
@@ -22,7 +23,8 @@ interface Props {
     mythicCampaignsUsage: CampaignsLocationsUsage;
     shardsPerToken: number;
     mythicShardsPerToken: number;
-    onChange: (key: keyof IPersonalGoal, value: number) => void;
+    farmType: ShardFarmType;
+    onChange: (key: keyof IPersonalGoal, value: number | ShardFarmType) => void;
 }
 
 export const SetAscendGoal: React.FC<Props> = ({
@@ -34,6 +36,7 @@ export const SetAscendGoal: React.FC<Props> = ({
     possibleMythicLocations,
     shardsPerToken,
     mythicShardsPerToken,
+    farmType,
     onChange,
 }) => {
     const rarityValues = useMemo(() => {
@@ -122,6 +125,26 @@ export const SetAscendGoal: React.FC<Props> = ({
                     )}
                 </>
             )}
+
+            <div className="flex items-center gap-3">
+                <div className="flex-1">
+                    <label className="mb-1 block text-sm font-medium">Farm Type</label>
+                    <Select
+                        label="Farm Type"
+                        value={farmType}
+                        onChange={event => onChange('shardFarmType', event.target.value as ShardFarmType)}
+                        fullWidth>
+                        {SHARD_FARM_TYPE_VALUES.map(type => (
+                            <MenuItem key={type} value={type}>
+                                {type
+                                    .split('_')
+                                    .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+                                    .join(' ')}
+                            </MenuItem>
+                        ))}
+                    </Select>
+                </div>
+            </div>
         </>
     );
 };

--- a/src/shared-components/goals/set-goal-dialog.tsx
+++ b/src/shared-components/goals/set-goal-dialog.tsx
@@ -498,6 +498,7 @@ export const SetGoalDialog = ({ onClose }: { onClose?: (goal?: IPersonalGoal) =>
                                     fullWidth
                                     label="Upgrade Material Quantity"
                                     min={0}
+                                    max={10_000}
                                     value={form.upgradeMaterialQuantity ?? 0}
                                     valueChange={quantity => {
                                         setForm(current => ({

--- a/src/shared-components/goals/set-goal-dialog.tsx
+++ b/src/shared-components/goals/set-goal-dialog.tsx
@@ -18,7 +18,7 @@ import { v4 } from 'uuid';
 
 import { goalsLimit, rarityToMaxRank } from 'src/models/constants';
 import { CampaignsLocationsUsage, PersonalGoalType } from 'src/models/enums';
-import { ICampaignsProgress, IPersonalGoal } from 'src/models/interfaces';
+import { ICampaignsProgress, IPersonalGoal, ShardFarmType } from 'src/models/interfaces';
 import { DispatchContext, StoreContext } from 'src/reducers/store.provider';
 import { StaticDataService } from 'src/services';
 import { PrioritySelect } from 'src/shared-components/goals/priority-select';
@@ -36,6 +36,7 @@ import { MowsService } from '@/fsd/4-entities/mow/mows.service';
 import { UnitTitle } from '@/fsd/4-entities/unit/ui/unit-title';
 import { UnitsAutocomplete } from '@/fsd/4-entities/unit/ui/units-autocomplete';
 import { isCharacter, isMow } from '@/fsd/4-entities/unit/units.functions';
+import { IMaterial, UpgradeMaterialAutocomplete, UpgradesService } from '@/fsd/4-entities/upgrade';
 
 import { CharactersAbilitiesService } from '@/fsd/3-features/characters/characters-abilities.service';
 import { ICharacter2, IUnit } from '@/fsd/3-features/characters/characters.models';
@@ -59,12 +60,23 @@ const getDefaultForm = (priority: number): IPersonalGoal => ({
     dailyRaids: true,
     rankPoint5: false,
     upgradesRarity: [],
+    upgradeMaterialId: undefined,
+    upgradeMaterialQuantity: 0,
 });
 
 export const SetGoalDialog = ({ onClose }: { onClose?: (goal?: IPersonalGoal) => void }) => {
     const { characters, mows, goals, campaignsProgress } = useContext(StoreContext);
 
     const resolvedMows = useMemo(() => MowsService.resolveAllFromStorage(mows), [mows]);
+
+    const allAvailableMaterials = useMemo(
+        () =>
+            Object.entries(UpgradesService.recipeDataByName)
+                .filter(object => !object[1].craftable)
+                .map(object => UpgradesService.getUpgradeMaterial(object[0]))
+                .filter(x => x !== undefined) as IMaterial[],
+        []
+    );
 
     const dispatch = useContext(DispatchContext);
 
@@ -80,11 +92,20 @@ export const SetGoalDialog = ({ onClose }: { onClose?: (goal?: IPersonalGoal) =>
         if (goal) {
             goal.dailyRaids = true;
             dispatch.goals({ type: 'Add', goal });
-            const character = characters.find(c => c.snowprintId === goal.character);
-            const mow = resolvedMows.find(m => m.snowprintId === goal.character);
-            enqueueSnackbar(`Goal for ${character?.shortName ?? mow?.name ?? goal.character} is added`, {
-                variant: 'success',
-            });
+            if (goal.type == PersonalGoalType.UpgradeMaterial) {
+                enqueueSnackbar(
+                    `Goal to farm ${goal.upgradeMaterialQuantity}x ${UpgradesService.getUpgradeMaterial(goal.upgradeMaterialId ?? '(none)')?.material} is added`,
+                    {
+                        variant: 'success',
+                    }
+                );
+            } else {
+                const character = characters.find(c => c.snowprintId === goal.character);
+                const mow = resolvedMows.find(m => m.snowprintId === goal.character);
+                enqueueSnackbar(`Goal for ${character?.shortName ?? mow?.name ?? goal.character} is added`, {
+                    variant: 'success',
+                });
+            }
         }
         setOpenDialog(false);
         setUnit(undefined);
@@ -94,7 +115,7 @@ export const SetGoalDialog = ({ onClose }: { onClose?: (goal?: IPersonalGoal) =>
         }
     };
 
-    const handleAscendGoalChanges = (key: keyof IPersonalGoal, value: number) => {
+    const handleAscendGoalChanges = (key: keyof IPersonalGoal, value: number | ShardFarmType) => {
         setForm(current => ({ ...current, [key]: value }));
     };
 
@@ -178,7 +199,8 @@ export const SetGoalDialog = ({ onClose }: { onClose?: (goal?: IPersonalGoal) =>
             (newGoalType === PersonalGoalType.Unlock && form.type !== PersonalGoalType.Unlock) ||
             (newGoalType !== PersonalGoalType.Unlock && form.type === PersonalGoalType.Unlock) ||
             (newGoalType === PersonalGoalType.MowAbilities && form.type !== PersonalGoalType.MowAbilities) ||
-            (newGoalType !== PersonalGoalType.MowAbilities && form.type === PersonalGoalType.MowAbilities)
+            (newGoalType !== PersonalGoalType.MowAbilities && form.type === PersonalGoalType.MowAbilities) ||
+            newGoalType === PersonalGoalType.UpgradeMaterial
         ) {
             setUnit(undefined);
         }
@@ -220,9 +242,7 @@ export const SetGoalDialog = ({ onClose }: { onClose?: (goal?: IPersonalGoal) =>
     };
 
     const isDisabled = () => {
-        if (!unit) {
-            return true;
-        }
+        if (unit === undefined && form.type !== PersonalGoalType.UpgradeMaterial) return true;
 
         if (form.type === PersonalGoalType.UpgradeRank && isCharacter(unit)) {
             const startRank =
@@ -232,6 +252,7 @@ export const SetGoalDialog = ({ onClose }: { onClose?: (goal?: IPersonalGoal) =>
         }
 
         if (form.type === PersonalGoalType.Ascend) {
+            if (unit === undefined) return true;
             return (
                 (unit.rarity === form.targetRarity && unit.stars === form.targetStars) ||
                 (hasNonMythicAscension() && unlockedLocations.length === 0 && form.shardsPerToken! <= 0) ||
@@ -250,6 +271,14 @@ export const SetGoalDialog = ({ onClose }: { onClose?: (goal?: IPersonalGoal) =>
             return (
                 (form.firstAbilityLevel ?? 0) <= unit.activeAbilityLevel &&
                 (form.secondAbilityLevel ?? 0) <= unit.passiveAbilityLevel
+            );
+        }
+
+        if (form.type === PersonalGoalType.UpgradeMaterial) {
+            return (
+                UpgradesService.getUpgradeMaterial(form.upgradeMaterialId ?? '(none)')?.material === undefined ||
+                form.upgradeMaterialQuantity === undefined ||
+                form.upgradeMaterialQuantity <= 0
             );
         }
 
@@ -300,6 +329,9 @@ export const SetGoalDialog = ({ onClose }: { onClose?: (goal?: IPersonalGoal) =>
                                     <MenuItem value={PersonalGoalType.Unlock}>Unlock</MenuItem>
                                     <MenuItem value={PersonalGoalType.MowAbilities}>MoW Abilities</MenuItem>
                                     <MenuItem value={PersonalGoalType.CharacterAbilities}>Character Abilities</MenuItem>
+                                    <MenuItem value={PersonalGoalType.UpgradeMaterial}>
+                                        Specific Upgrade Material
+                                    </MenuItem>
                                 </Select>
                             </FormControl>
                             <PrioritySelect
@@ -309,12 +341,14 @@ export const SetGoalDialog = ({ onClose }: { onClose?: (goal?: IPersonalGoal) =>
                             />
                         </div>
 
-                        <UnitsAutocomplete
-                            // eslint-disable-next-line unicorn/no-null -- Autocomplete requires null
-                            unit={unit ?? null}
-                            options={allowedCharacters}
-                            onUnitChange={handleUnitChange}
-                        />
+                        <Conditional condition={form.type !== PersonalGoalType.UpgradeMaterial}>
+                            <UnitsAutocomplete
+                                // eslint-disable-next-line unicorn/no-null -- Autocomplete requires null
+                                unit={unit ?? null}
+                                options={allowedCharacters}
+                                onUnitChange={handleUnitChange}
+                            />
+                        </Conditional>
 
                         <Conditional condition={!!unit && form.type === PersonalGoalType.UpgradeRank}>
                             <RankGoalSelect
@@ -339,6 +373,17 @@ export const SetGoalDialog = ({ onClose }: { onClose?: (goal?: IPersonalGoal) =>
                                     }));
                                 }}
                             />
+                            <label className="flex items-center gap-2">
+                                <input
+                                    type="checkbox"
+                                    checked={form.manuallyFarmXp ?? false}
+                                    onChange={event => {
+                                        setForm(current => ({ ...current, manuallyFarmXp: event.target.checked }));
+                                    }}
+                                    className="h-4 w-4"
+                                />
+                                <span className="text-sm">Manually Farm XP</span>
+                            </label>
                         </Conditional>
 
                         {form.type === PersonalGoalType.MowAbilities && isMow(unit) && (
@@ -434,8 +479,38 @@ export const SetGoalDialog = ({ onClose }: { onClose?: (goal?: IPersonalGoal) =>
                                 mythicCampaignsUsage={form.mythicCampaignsUsage!}
                                 shardsPerToken={form.shardsPerToken!}
                                 mythicShardsPerToken={form.mythicShardsPerToken!}
+                                farmType={form.shardFarmType ?? 'both'}
                                 onChange={handleAscendGoalChanges}
                             />
+                        )}
+
+                        {form.type === PersonalGoalType.UpgradeMaterial && (
+                            <div>
+                                <UpgradeMaterialAutocomplete
+                                    value={UpgradesService.getUpgradeMaterial(form.upgradeMaterialId ?? '(none)')}
+                                    options={allAvailableMaterials}
+                                    onChange={material =>
+                                        setForm(current => ({ ...current, upgradeMaterialId: material?.snowprintId }))
+                                    }
+                                />
+                                <div className="min-h-[16px]" />
+                                <NumberInput
+                                    fullWidth
+                                    label="Upgrade Material Quantity"
+                                    min={0}
+                                    value={form.upgradeMaterialQuantity ?? 0}
+                                    valueChange={quantity => {
+                                        setForm(current => ({
+                                            ...current,
+                                            upgradeMaterialQuantity: quantity,
+                                        }));
+                                    }}
+                                />
+                                <Conditional
+                                    condition={!form.upgradeMaterialId || (form.upgradeMaterialQuantity ?? 0) <= 0}>
+                                    <div className="text-sm text-red-600">Please select material and quantity</div>
+                                </Conditional>
+                            </div>
                         )}
 
                         <Conditional condition={!!unit && form.type === PersonalGoalType.Unlock}>

--- a/src/shared-components/goals/set-goal-dialog.tsx
+++ b/src/shared-components/goals/set-goal-dialog.tsx
@@ -503,7 +503,7 @@ export const SetGoalDialog = ({ onClose }: { onClose?: (goal?: IPersonalGoal) =>
                                     valueChange={quantity => {
                                         setForm(current => ({
                                             ...current,
-                                            upgradeMaterialQuantity: quantity,
+                                            upgradeMaterialQuantity: Math.max(1, quantity),
                                         }));
                                     }}
                                 />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Upgrade Material goal type with material icon/rank display and quantity tracking.
  * Upgrade material goals integrated into goals list, estimates, daily raids planning, and edit/set dialogs.
  * New Material autocomplete selector and image badges for materials.
  * Farm Type selector for ascend goals and "Manually Farm XP" toggle for rank upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->