### PR TITLE
Do not use energy for onslaught-only goals

### DIFF
--- a/src/fsd/3-features/goals/goals.service.ts
+++ b/src/fsd/3-features/goals/goals.service.ts
@@ -97,7 +97,6 @@ export class GoalsService {
         shardsGoals: Array<ICharacterUnlockGoal | ICharacterAscendGoal>,
         upgradeMaterialGoals: IUpgradeMaterialGoal[],
         upgradeRankOrMowGoals: Array<ICharacterUpgradeRankGoal | ICharacterUpgradeMow>,
-
         upgradeAbilities: Array<ICharacterUpgradeAbilities>,
         characters: ICharacter2[],
         isGoalPriority: boolean = false

--- a/src/fsd/3-features/goals/upgrades.service.ts
+++ b/src/fsd/3-features/goals/upgrades.service.ts
@@ -314,6 +314,11 @@ export class UpgradesService {
 
         this.populateLocationsData(combinedBaseMaterials, settings);
 
+        this.removeLocationsForOnslaughtOnlyGoals(
+            goals,
+            Object.values(combinedBaseMaterials).flatMap(x => x.locations)
+        );
+
         // Cache for expensive per-goal remaining computations keyed by
         // `${upgradeId}|${inventoryCount}|${goalId ?? 'total'}`.
         const remainingNeededCache = new Map<
@@ -546,6 +551,56 @@ export class UpgradesService {
         };
     }
 
+    private static removeLocationsForOnslaughtOnlyGoals(
+        goals: Array<
+            | ICharacterUpgradeRankGoal
+            | ICharacterUpgradeMow
+            | ICharacterAscendGoal
+            | ICharacterUnlockGoal
+            | IUpgradeMaterialGoal
+        >,
+        locs: ICampaignBattleComposed[]
+    ): void {
+        const energyAllowedCharacterIds = new Map<string, 'regular' | 'mythic' | 'both'>();
+        for (const goal of goals) {
+            if (goal.type !== PersonalGoalType.Ascend) continue;
+            if (goal.farmType === 'onslaught') continue;
+            if (goal.rarityStart < Rarity.Mythic) {
+                if (energyAllowedCharacterIds.has(goal.unitId)) {
+                    const current = energyAllowedCharacterIds.get(goal.unitId);
+                    const newValue = current === 'regular' ? 'regular' : 'both';
+                    energyAllowedCharacterIds.set(goal.unitId, newValue as 'regular' | 'mythic' | 'both');
+                } else {
+                    energyAllowedCharacterIds.set(goal.unitId, 'regular');
+                }
+            }
+            if (goal.rarityEnd === Rarity.Mythic) {
+                if (energyAllowedCharacterIds.has(goal.unitId)) {
+                    const current = energyAllowedCharacterIds.get(goal.unitId);
+                    const newValue = current === 'mythic' ? 'mythic' : 'both';
+                    energyAllowedCharacterIds.set(goal.unitId, newValue as 'regular' | 'mythic' | 'both');
+                } else {
+                    energyAllowedCharacterIds.set(goal.unitId, 'mythic');
+                }
+            }
+        }
+        for (const loc of locs) {
+            const reward = loc.rewards.potential.find(
+                r => r.id.startsWith('shards_') || r.id.startsWith('mythicShards_')
+            );
+            if (reward === undefined) continue;
+            const unitId = reward.id.split('_')[1];
+            const allowed = energyAllowedCharacterIds.get(unitId);
+            if (!allowed) {
+                loc.isSuggested = false;
+            } else if (reward.id.startsWith('shards_') && allowed === 'mythic') {
+                loc.isSuggested = false;
+            } else if (reward.id.startsWith('mythicShards_') && allowed === 'regular') {
+                loc.isSuggested = false;
+            }
+        }
+    }
+
     /*
      * @returns An array of `IUpgradesRaidsDay`, where each object represents a single day's
      * raiding plan. Returns an empty array if daily energy is too low to perform any raids.
@@ -611,7 +666,6 @@ export class UpgradesService {
             const locs = Object.values(remainingMats)
                 .flatMap(mat => mat.locations)
                 .filter(loc => loc.isSuggested);
-
             this.planDayRaiding(
                 day,
                 settings,

--- a/src/fsd/3-features/goals/upgrades.service.ts
+++ b/src/fsd/3-features/goals/upgrades.service.ts
@@ -563,8 +563,12 @@ export class UpgradesService {
     ): void {
         const energyAllowedCharacterIds = new Map<string, 'regular' | 'mythic' | 'both'>();
         for (const goal of goals) {
-            if (goal.type !== PersonalGoalType.Ascend) continue;
-            if (goal.farmType === 'onslaught') continue;
+            if (goal.type !== PersonalGoalType.Ascend && goal.type !== PersonalGoalType.Unlock) continue;
+            if (goal.type === PersonalGoalType.Ascend && goal.farmType === 'onslaught') continue;
+            if (goal.type === PersonalGoalType.Unlock) {
+                energyAllowedCharacterIds.set(goal.unitId, 'regular');
+                continue;
+            }
             if (goal.rarityStart < Rarity.Mythic) {
                 if (energyAllowedCharacterIds.has(goal.unitId)) {
                     const current = energyAllowedCharacterIds.get(goal.unitId);

--- a/src/routes/goals/goals.tsx
+++ b/src/routes/goals/goals.tsx
@@ -238,7 +238,15 @@ export const Goals = () => {
                 characters,
                 isGoalPriority
             ),
-        [estimatedUpgradesTotal, shardsGoals, upgradeRankOrMowGoals, upgradeAbilities, characters, isGoalPriority]
+        [
+            estimatedUpgradesTotal,
+            shardsGoals,
+            upgradeMaterialGoals,
+            upgradeRankOrMowGoals,
+            upgradeAbilities,
+            characters,
+            isGoalPriority,
+        ]
     );
 
     const adjustedGoalsEstimates = GoalsService.adjustGoalEstimates(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed raid location suggestions to better account for ascend goals not available through onslaught farming.

* **Chores**
  * Internal optimization of goal estimate dependency tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->