### PR TITLE
Add the ability to invert HSE raiding

### DIFF
--- a/src/fsd/3-features/goals/upgrades.service.ts
+++ b/src/fsd/3-features/goals/upgrades.service.ts
@@ -1573,14 +1573,16 @@ export class UpgradesService {
                 if (campaignType === CampaignType.Elite) return 5;
                 return 3;
             };
+            const invertHse = settings.preferences.invertHse ?? false;
+            const hsePointsDirection = invertHse ? ('asc' as const) : ('desc' as const);
             const orderingFields =
                 settings.preferences.farmPreferences?.order === IDailyRaidsFarmOrder.totalMaterials
                     ? ['hsePoints', 'daysToComplete']
                     : ['priority', 'hsePoints', 'daysToComplete'];
             const orderingDirections =
                 settings.preferences.farmPreferences?.order === IDailyRaidsFarmOrder.totalMaterials
-                    ? (['desc', 'desc'] as const)
-                    : (['asc', 'desc', 'desc'] as const);
+                    ? ([hsePointsDirection, 'desc'] as const)
+                    : (['asc', hsePointsDirection, 'desc'] as const);
             switch (settings.preferences.farmPreferences.homeScreenEvent) {
                 case IDailyRaidsHomeScreenEvent.purgeOrder: {
                     taggedLocs = taggedLocs.map(x => ({

--- a/src/models/interfaces.ts
+++ b/src/models/interfaces.ts
@@ -290,6 +290,7 @@ export interface IDailyRaidsPreferences {
     farmStrategy: DailyRaidsStrategy;
     customSettings?: ICustomDailyRaidsSettings;
     campaignEvent?: CampaignGroupType | 'none';
+    invertHse?: boolean;
 }
 
 export type ICustomDailyRaidsSettings = Record<Rarity | 'Shard' | 'Mythic Shard', CampaignType[]>;

--- a/src/shared-components/daily-raids-settings.tsx
+++ b/src/shared-components/daily-raids-settings.tsx
@@ -1,5 +1,6 @@
 ﻿import InfoIcon from '@mui/icons-material/Info';
 import {
+    Checkbox,
     DialogActions,
     DialogContent,
     DialogTitle,
@@ -302,6 +303,33 @@ const DailyRaidsSettings: React.FC<Props> = ({ close, open }) => {
                             </Select>
                             <FormHelperText>Select your current Home Screen Event.</FormHelperText>
                         </FormControl>
+                        {(dailyRaidsPreferencesForm.farmPreferences.homeScreenEvent ??
+                            IDailyRaidsHomeScreenEvent.none) !== IDailyRaidsHomeScreenEvent.none && (
+                            <FormControl>
+                                <FormControlLabel
+                                    control={
+                                        <Checkbox
+                                            checked={dailyRaidsPreferencesForm.invertHse ?? false}
+                                            onChange={event_ =>
+                                                setDailyRaidsPreferencesForm(current => ({
+                                                    ...current,
+                                                    invertHse: event_.target.checked,
+                                                }))
+                                            }
+                                        />
+                                    }
+                                    label={
+                                        <div className="flex items-center gap-1">
+                                            Invert
+                                            <AccessibleTooltip title="When selected, prioritize raids that award the fewest points for the selected HSE">
+                                                <InfoIcon color="primary" fontSize="small" />
+                                            </AccessibleTooltip>
+                                        </div>
+                                    }
+                                />
+                            </FormControl>
+                        )}
+
                         {/*}
                         {dailyRaidsPreferencesForm.farmPreferences.homeScreenEvent ===
                             IDailyRaidsHomeScreenEvent.trainingRush && (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an "Invert" checkbox to daily raids settings that appears when a homescreen event is active, allowing users to toggle the sorting direction of HSE points with an explanatory tooltip.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->