### PR TITLE
SP changed the guild API to return millis instead of seconds

### DIFF
--- a/src/fsd/3-features/tacticus-integration/guild-raid-v2.tsx
+++ b/src/fsd/3-features/tacticus-integration/guild-raid-v2.tsx
@@ -60,8 +60,7 @@ export const TacticusGuildRaidVisualization: React.FC<{ userIdMapper: (userId: s
         const now = currentTime;
 
         // Worst case scenario: season started at first damage
-        const firstEntryStart =
-            (raidData.entries.find(entry => Number.isFinite(entry.startedOn))?.startedOn ?? 0) * 1000;
+        const firstEntryStart = raidData.entries.find(entry => Number.isFinite(entry.startedOn))?.startedOn ?? 0;
         const seasonStart = firstEntryStart === 0 ? now : firstEntryStart;
 
         const userMap = new Map<string, UserSummary>();
@@ -99,7 +98,7 @@ export const TacticusGuildRaidVisualization: React.FC<{ userIdMapper: (userId: s
             if (entry.damageType === TacticusDamageType.Bomb) {
                 userSummary.bombCount += 1;
                 if (entry.completedOn !== undefined) {
-                    userSummary.lastBombTime = entry.completedOn! * 1000;
+                    userSummary.lastBombTime = entry.completedOn!;
                 }
             } else {
                 // Battle attacks
@@ -120,14 +119,14 @@ export const TacticusGuildRaidVisualization: React.FC<{ userIdMapper: (userId: s
 
                 if (entry.startedOn !== undefined) {
                     // update token status at entry.startedOn
-                    updateTokenTo(userSummary.tokenStatus, entry.startedOn! * 1000);
+                    updateTokenTo(userSummary.tokenStatus, entry.startedOn!);
                     // one token was used for this battle attack
                     userSummary.tokenStatus.count--;
 
                     if (userSummary.tokenStatus.count < 0) {
                         // Estimation was too pessimist, let's refine according to this datapoint
                         userSummary.tokenStatus.count = 0;
-                        userSummary.tokenStatus.reloadStart = entry.startedOn! * 1000;
+                        userSummary.tokenStatus.reloadStart = entry.startedOn!;
                     }
                 }
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed timestamp calculations in guild raid to correctly interpret battle start and completion times, ensuring accurate synchronization of token status updates and bomb timers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/svehera/tacticusplanner/pull/914?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->