### PR TITLE
Fix a bug where unlock goals were not marked as completed. 

### DIFF
--- a/src/fsd/3-features/goals/upgrades.service.spec.ts
+++ b/src/fsd/3-features/goals/upgrades.service.spec.ts
@@ -1400,6 +1400,42 @@ describe('UpgradesService.getUpgrades', () => {
         expect(upgrades[0].baseUpgradesTotal[shardName]).toBe(80);
     });
 
+    it('requires zero shards for an unlock goal when the character is already unlocked', () => {
+        const abraxas = CharactersService.getUnit('thousInfernalMaster')!;
+        const character = createCharacter(abraxas, { rank: Rank.Stone1, shards: 0 });
+        const goal = createUnlockGoal(abraxas, {
+            goalId: 'goal-abraxas-already-unlocked',
+            unitId: abraxas.snowprintId,
+            unitName: abraxas.shortName ?? abraxas.name,
+            unitIcon: abraxas.icon ?? '',
+            unitRoundIcon: abraxas.roundIcon ?? '',
+            unitAlliance: abraxas.alliance ?? Alliance.Chaos,
+        });
+
+        const upgrades = UpgradesService.getUpgrades({}, [character], [], [goal]);
+        const shardName = `shards_${abraxas.snowprintId}`;
+
+        expect(upgrades[0].baseUpgradesTotal[shardName] ?? 0).toBe(0);
+    });
+
+    it('still requires shards for an unlock goal when the character is not yet unlocked', () => {
+        const abraxas = CharactersService.getUnit('thousInfernalMaster')!;
+        const character = createCharacter(abraxas, { rank: Rank.Locked, shards: 50 });
+        const goal = createUnlockGoal(abraxas, {
+            goalId: 'goal-abraxas-not-yet-unlocked',
+            unitId: abraxas.snowprintId,
+            unitName: abraxas.shortName ?? abraxas.name,
+            unitIcon: abraxas.icon ?? '',
+            unitRoundIcon: abraxas.roundIcon ?? '',
+            unitAlliance: abraxas.alliance ?? Alliance.Chaos,
+        });
+
+        const upgrades = UpgradesService.getUpgrades({}, [character], [], [goal]);
+        const shardName = `shards_${abraxas.snowprintId}`;
+
+        expect(upgrades[0].baseUpgradesTotal[shardName]).toBe(130);
+    });
+
     it('counts World Eaters rares and legendaries across two Kharn goals', () => {
         const kharn = CharactersService.getUnit('worldKharn')!;
         const character = createCharacter(kharn);

--- a/src/fsd/3-features/goals/upgrades.service.ts
+++ b/src/fsd/3-features/goals/upgrades.service.ts
@@ -2078,6 +2078,8 @@ export class UpgradesService {
         const unit = char ?? mow;
         if (!unit) return 0;
         if (goal.type === PersonalGoalType.Unlock) {
+            const alreadyUnlocked = char ? char.rank > Rank.Locked : (mow?.unlocked ?? false);
+            if (alreadyUnlocked) return 0;
             return this.getTotalShardsNeededForGoal(chars, mows, goal);
         }
         const locked = char ? char.rank === Rank.Locked : !mow?.unlocked;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed character unlock goal calculations to correctly identify when an unlock goal is already satisfied, returning zero shards needed instead of incorrectly calculating shard requirements.

* **Tests**
  * Added comprehensive unit tests verifying unlock goal behavior for both unlocked characters (zero shards required) and locked characters (expected shard requirements).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/svehera/tacticusplanner/pull/922?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->