### PR TITLE
Fix a bug with mythic ascension goals not picking up the onslaught tier properly.

### DIFF
--- a/src/fsd/5-shared/model/enums/alliance.enum.ts
+++ b/src/fsd/5-shared/model/enums/alliance.enum.ts
@@ -3,3 +3,20 @@ export enum Alliance {
     Imperial = 'Imperial',
     Xenos = 'Xenos',
 }
+
+export function allianceFromString(value: string): Alliance | undefined {
+    switch (value.toLowerCase()) {
+        case 'imperial': {
+            return Alliance.Imperial;
+        }
+        case 'xenos': {
+            return Alliance.Xenos;
+        }
+        case 'chaos': {
+            return Alliance.Chaos;
+        }
+        default: {
+            return undefined;
+        }
+    }
+}

--- a/src/fsd/5-shared/model/enums/index.ts
+++ b/src/fsd/5-shared/model/enums/index.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import-x/no-internal-modules
 import type factions from '@/data/factions.json';
 
-export { Alliance } from './alliance.enum';
+export { Alliance, allianceFromString } from './alliance.enum';
 export { Rarity, RarityString, XP_BOOK_ORDER, XP_BOOK_VALUE } from './rarity.enum';
 export { RarityStars } from './rarity-stars.enum';
 export { Rank, rankToString } from './rank.enum';

--- a/src/shared-components/goals/edit-ascend-goal.tsx
+++ b/src/shared-components/goals/edit-ascend-goal.tsx
@@ -51,6 +51,8 @@ export const EditAscendGoal: React.FC<Props> = ({
         return getEnumValues(RarityStars).filter(x => x >= minStars && x <= maxStars);
     }, [goal.rarityEnd]);
 
+    console.log('goal:', goal);
+
     return (
         <>
             <div className="flex gap-3">
@@ -113,7 +115,7 @@ export const EditAscendGoal: React.FC<Props> = ({
                 </>
             )}
 
-            {goal.rarityEnd >= Rarity.Mythic && (
+            {goal.starsStart >= RarityStars.OneBlueStar && (
                 <>
                     {alliance && (
                         <div className="flex items-center gap-2 text-sm">

--- a/src/shared-components/goals/edit-ascend-goal.tsx
+++ b/src/shared-components/goals/edit-ascend-goal.tsx
@@ -51,8 +51,6 @@ export const EditAscendGoal: React.FC<Props> = ({
         return getEnumValues(RarityStars).filter(x => x >= minStars && x <= maxStars);
     }, [goal.rarityEnd]);
 
-    console.log('goal:', goal);
-
     return (
         <>
             <div className="flex gap-3">

--- a/src/shared-components/goals/edit-goal-dialog.tsx
+++ b/src/shared-components/goals/edit-goal-dialog.tsx
@@ -40,6 +40,23 @@ interface Props {
     onClose?: (goal?: TypedGoalSelect) => void;
 }
 
+function stringToAlliance(allianceString: string): Alliance | undefined {
+    switch (allianceString.toLowerCase()) {
+        case 'imperial': {
+            return Alliance.Imperial;
+        }
+        case 'xenos': {
+            return Alliance.Xenos;
+        }
+        case 'chaos': {
+            return Alliance.Chaos;
+        }
+        default: {
+            return undefined;
+        }
+    }
+}
+
 export const EditGoalDialog: React.FC<Props> = ({ isOpen, onClose, goal, unit }) => {
     const { goals, campaignsProgress, inventory, onslaughtPreferences } = useContext(StoreContext);
     const dispatch = useContext(DispatchContext);
@@ -367,7 +384,9 @@ export const EditGoalDialog: React.FC<Props> = ({ isOpen, onClose, goal, unit })
                                 unlockedLocations={unlockedLocations}
                                 unlockedMythicLocations={unlockedMythicLocations}
                                 farmType={form.farmType ?? 'both'}
-                                alliance={isCharacter(unit) ? unit.alliance : undefined}
+                                alliance={
+                                    isCharacter(unit) || isMow(unit) ? stringToAlliance(unit.alliance) : undefined
+                                }
                                 onslaughtPreferences={onslaughtPreferences}
                                 onChange={handleAscendGoalChanges}
                             />

--- a/src/shared-components/goals/edit-goal-dialog.tsx
+++ b/src/shared-components/goals/edit-goal-dialog.tsx
@@ -16,7 +16,7 @@ import { RankGoalSelect } from 'src/shared-components/goals/rank-goal-select';
 import { UpgradesRaritySelect } from 'src/shared-components/goals/upgrades-rarity-select';
 import { getEnumValues } from 'src/shared-logic/functions';
 
-import { Alliance, Rank, RarityMapper } from '@/fsd/5-shared/model';
+import { Alliance, allianceFromString, Rank, RarityMapper } from '@/fsd/5-shared/model';
 import { UnitShardIcon } from '@/fsd/5-shared/ui/icons';
 import { NumberInput } from '@/fsd/5-shared/ui/input/number-input';
 
@@ -38,23 +38,6 @@ interface Props {
     goal: TypedGoalSelect;
     unit: IUnit | undefined;
     onClose?: (goal?: TypedGoalSelect) => void;
-}
-
-function stringToAlliance(allianceString: string): Alliance | undefined {
-    switch (allianceString.toLowerCase()) {
-        case 'imperial': {
-            return Alliance.Imperial;
-        }
-        case 'xenos': {
-            return Alliance.Xenos;
-        }
-        case 'chaos': {
-            return Alliance.Chaos;
-        }
-        default: {
-            return undefined;
-        }
-    }
 }
 
 export const EditGoalDialog: React.FC<Props> = ({ isOpen, onClose, goal, unit }) => {
@@ -385,7 +368,7 @@ export const EditGoalDialog: React.FC<Props> = ({ isOpen, onClose, goal, unit })
                                 unlockedMythicLocations={unlockedMythicLocations}
                                 farmType={form.farmType ?? 'both'}
                                 alliance={
-                                    isCharacter(unit) || isMow(unit) ? stringToAlliance(unit.alliance) : undefined
+                                    isCharacter(unit) || isMow(unit) ? allianceFromString(unit.alliance) : undefined
                                 }
                                 onslaughtPreferences={onslaughtPreferences}
                                 onChange={handleAscendGoalChanges}

--- a/src/shared-components/goals/set-goal-dialog.tsx
+++ b/src/shared-components/goals/set-goal-dialog.tsx
@@ -27,7 +27,7 @@ import { SetAscendGoal } from 'src/shared-components/goals/set-ascend-goal';
 import { UpgradesRaritySelect } from 'src/shared-components/goals/upgrades-rarity-select';
 import { getEnumValues } from 'src/shared-logic/functions';
 
-import { Rarity, RarityStars, Rank, Alliance } from '@/fsd/5-shared/model';
+import { Rarity, RarityStars, Rank, allianceFromString } from '@/fsd/5-shared/model';
 import { AccessibleTooltip, Conditional } from '@/fsd/5-shared/ui';
 import { NumberInput } from '@/fsd/5-shared/ui/input/number-input';
 
@@ -61,23 +61,6 @@ const getDefaultForm = (priority: number): IPersonalGoal => ({
     upgradeMaterialId: undefined,
     upgradeMaterialQuantity: 0,
 });
-
-function stringToAlliance(allianceString: string): Alliance | undefined {
-    switch (allianceString.toLowerCase()) {
-        case 'imperial': {
-            return Alliance.Imperial;
-        }
-        case 'xenos': {
-            return Alliance.Xenos;
-        }
-        case 'chaos': {
-            return Alliance.Chaos;
-        }
-        default: {
-            return undefined;
-        }
-    }
-}
 
 export const SetGoalDialog = ({ onClose }: { onClose?: (goal?: IPersonalGoal) => void }) => {
     const { characters, mows, goals, campaignsProgress, onslaughtPreferences } = useContext(StoreContext);
@@ -481,7 +464,7 @@ export const SetGoalDialog = ({ onClose }: { onClose?: (goal?: IPersonalGoal) =>
                                 mythicCampaignsUsage={form.mythicCampaignsUsage!}
                                 farmType={form.shardFarmType ?? 'both'}
                                 alliance={
-                                    isCharacter(unit) || isMow(unit) ? stringToAlliance(unit.alliance) : undefined
+                                    isCharacter(unit) || isMow(unit) ? allianceFromString(unit.alliance) : undefined
                                 }
                                 onslaughtPreferences={onslaughtPreferences}
                                 onChange={handleAscendGoalChanges}

--- a/src/shared-components/goals/set-goal-dialog.tsx
+++ b/src/shared-components/goals/set-goal-dialog.tsx
@@ -27,7 +27,7 @@ import { SetAscendGoal } from 'src/shared-components/goals/set-ascend-goal';
 import { UpgradesRaritySelect } from 'src/shared-components/goals/upgrades-rarity-select';
 import { getEnumValues } from 'src/shared-logic/functions';
 
-import { Rarity, RarityStars, Rank } from '@/fsd/5-shared/model';
+import { Rarity, RarityStars, Rank, Alliance } from '@/fsd/5-shared/model';
 import { AccessibleTooltip, Conditional } from '@/fsd/5-shared/ui';
 import { NumberInput } from '@/fsd/5-shared/ui/input/number-input';
 
@@ -61,6 +61,23 @@ const getDefaultForm = (priority: number): IPersonalGoal => ({
     upgradeMaterialId: undefined,
     upgradeMaterialQuantity: 0,
 });
+
+function stringToAlliance(allianceString: string): Alliance | undefined {
+    switch (allianceString.toLowerCase()) {
+        case 'imperial': {
+            return Alliance.Imperial;
+        }
+        case 'xenos': {
+            return Alliance.Xenos;
+        }
+        case 'chaos': {
+            return Alliance.Chaos;
+        }
+        default: {
+            return undefined;
+        }
+    }
+}
 
 export const SetGoalDialog = ({ onClose }: { onClose?: (goal?: IPersonalGoal) => void }) => {
     const { characters, mows, goals, campaignsProgress, onslaughtPreferences } = useContext(StoreContext);
@@ -463,7 +480,9 @@ export const SetGoalDialog = ({ onClose }: { onClose?: (goal?: IPersonalGoal) =>
                                 unlockedMythicLocations={unlockedMythicLocations}
                                 mythicCampaignsUsage={form.mythicCampaignsUsage!}
                                 farmType={form.shardFarmType ?? 'both'}
-                                alliance={isCharacter(unit) ? unit.alliance : undefined}
+                                alliance={
+                                    isCharacter(unit) || isMow(unit) ? stringToAlliance(unit.alliance) : undefined
+                                }
                                 onslaughtPreferences={onslaughtPreferences}
                                 onChange={handleAscendGoalChanges}
                             />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected alliance handling so additional unit types show the proper alliance in goal dialogs.
  * Adjusted when the "Estimated mythic shards per onslaught" block appears to match updated rarity/start conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/svehera/tacticusplanner/pull/926?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->