### PR TITLE
Fix onslaught shard rewards for goals that cross the blue-star boundary.

### DIFF
--- a/src/fsd/1-pages/input-onslaught/onslaught-rewards.spec.ts
+++ b/src/fsd/1-pages/input-onslaught/onslaught-rewards.spec.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest';
+
+import { Alliance, Rarity, RarityStars } from '@/fsd/5-shared/model';
+
+import {
+    formatOnslaughtRewardRange,
+    getOnslaughtReward,
+    getOnslaughtRewardForCharacter,
+    defaultOnslaughtPreferences,
+} from './onslaught-rewards';
+
+// Helpers
+const stone1 = { sector: 'stone', tier: 1 } as const;
+const adamantine3 = { sector: 'adamantine', tier: 3 } as const;
+
+describe('getOnslaughtReward', () => {
+    describe('regular shard buckets', () => {
+        it('Legendary (no blue star) returns regular shards', () => {
+            const reward = getOnslaughtReward(Rarity.Legendary, RarityStars.None, stone1.sector, stone1.tier);
+            expect(reward.isMythic).toBe(false);
+        });
+
+        it('Epic returns regular shards', () => {
+            const reward = getOnslaughtReward(Rarity.Epic, RarityStars.None, stone1.sector, stone1.tier);
+            expect(reward.isMythic).toBe(false);
+        });
+    });
+
+    describe('mythic shard buckets', () => {
+        it('Legendary + OneBlueStar returns mythic shards (legendaryBlue bucket)', () => {
+            const reward = getOnslaughtReward(Rarity.Legendary, RarityStars.OneBlueStar, stone1.sector, stone1.tier);
+            expect(reward.isMythic).toBe(true);
+        });
+
+        it('Mythic returns mythic shards (mythicShards bucket)', () => {
+            const reward = getOnslaughtReward(Rarity.Mythic, RarityStars.None, stone1.sector, stone1.tier);
+            expect(reward.isMythic).toBe(true);
+        });
+    });
+
+    describe('cross-boundary: Legendary 0-stars vs Legendary OneBlueStar produce DIFFERENT results', () => {
+        it('Legendary no-star gives regular shards, not mythic', () => {
+            const reward = getOnslaughtReward(Rarity.Legendary, RarityStars.None, adamantine3.sector, adamantine3.tier);
+            expect(reward.isMythic).toBe(false);
+        });
+
+        it('Legendary OneBlueStar gives mythic shards', () => {
+            const reward = getOnslaughtReward(
+                Rarity.Legendary,
+                RarityStars.OneBlueStar,
+                adamantine3.sector,
+                adamantine3.tier
+            );
+            expect(reward.isMythic).toBe(true);
+        });
+
+        it('using Legendary no-star incorrectly for the mythic-shards label gives the wrong (regular) bucket', () => {
+            const wrongReward = getOnslaughtReward(
+                Rarity.Legendary,
+                RarityStars.None,
+                adamantine3.sector,
+                adamantine3.tier
+            );
+            const correctReward = getOnslaughtReward(
+                Rarity.Legendary,
+                RarityStars.OneBlueStar,
+                adamantine3.sector,
+                adamantine3.tier
+            );
+            // isMythic differs: wrong is regular shards, correct is mythic shards
+            expect(wrongReward.isMythic).toBe(false);
+            expect(correctReward.isMythic).toBe(true);
+        });
+    });
+});
+
+describe('formatOnslaughtRewardRange', () => {
+    it('regular shards has no "mythic" suffix', () => {
+        const label = formatOnslaughtRewardRange(Rarity.Legendary, RarityStars.None, stone1.sector, stone1.tier);
+        expect(label).not.toContain('mythic');
+    });
+
+    it('legendaryBlue shards include "mythic" suffix', () => {
+        const label = formatOnslaughtRewardRange(Rarity.Legendary, RarityStars.OneBlueStar, stone1.sector, stone1.tier);
+        expect(label).toContain('mythic');
+    });
+
+    it('Mythic shards include "mythic" suffix', () => {
+        const label = formatOnslaughtRewardRange(Rarity.Mythic, RarityStars.None, stone1.sector, stone1.tier);
+        expect(label).toContain('mythic');
+    });
+
+    describe('adamantine tier 3 — legendaryBlue and mythicShards are distinct', () => {
+        it('legendaryBlue is 1-2 mythic', () => {
+            const label = formatOnslaughtRewardRange(
+                Rarity.Legendary,
+                RarityStars.OneBlueStar,
+                adamantine3.sector,
+                adamantine3.tier
+            );
+            expect(label).toBe('1-2 mythic');
+        });
+
+        it('mythicShards is 2-3 mythic', () => {
+            const label = formatOnslaughtRewardRange(
+                Rarity.Mythic,
+                RarityStars.None,
+                adamantine3.sector,
+                adamantine3.tier
+            );
+            expect(label).toBe('2-3 mythic');
+        });
+    });
+});
+
+describe('cross-boundary ascension goal: mythic shard rate selection', () => {
+    /**
+     * For a goal starting at Legendary (below OneBlueStar) targeting Mythic, the UI should
+     * display the mythic shard rate using Legendary+OneBlueStar params (not the current 0-star
+     * params), because that is when mythic shard farming begins.
+     */
+    it('using OneBlueStar threshold gives mythic rate for a cross-boundary goal', () => {
+        const currentRarity = Rarity.Legendary;
+        const currentStars = RarityStars.None; // below threshold
+
+        // The fix: when currentStars < OneBlueStar, clamp up to OneBlueStar for the mythic label
+        const mythicRarity = currentStars >= RarityStars.OneBlueStar ? currentRarity : Rarity.Legendary;
+        const mythicStars = Math.max(currentStars, RarityStars.OneBlueStar);
+
+        const label = formatOnslaughtRewardRange(mythicRarity, mythicStars, adamantine3.sector, adamantine3.tier);
+        expect(label).toContain('mythic');
+        expect(label).toBe('1-2 mythic');
+    });
+
+    it('already-at-OneBlueStar character passes through unchanged', () => {
+        const currentRarity = Rarity.Legendary;
+        const currentStars = RarityStars.OneBlueStar;
+
+        const mythicRarity = currentStars >= RarityStars.OneBlueStar ? currentRarity : Rarity.Legendary;
+        const mythicStars = Math.max(currentStars, RarityStars.OneBlueStar);
+
+        expect(mythicRarity).toBe(Rarity.Legendary);
+        expect(mythicStars).toBe(RarityStars.OneBlueStar);
+        const label = formatOnslaughtRewardRange(mythicRarity, mythicStars, adamantine3.sector, adamantine3.tier);
+        expect(label).toContain('mythic');
+    });
+
+    it('already-Mythic character uses Mythic params unchanged', () => {
+        const currentRarity = Rarity.Mythic;
+        const currentStars = RarityStars.OneBlueStar;
+
+        const mythicRarity = currentStars >= RarityStars.OneBlueStar ? currentRarity : Rarity.Legendary;
+        const mythicStars = Math.max(currentStars, RarityStars.OneBlueStar);
+
+        expect(mythicRarity).toBe(Rarity.Mythic);
+        const label = formatOnslaughtRewardRange(mythicRarity, mythicStars, adamantine3.sector, adamantine3.tier);
+        expect(label).toContain('mythic');
+        expect(label).toBe('2-3 mythic'); // mythicShards bucket in adamantine T3
+    });
+});
+
+describe('getOnslaughtRewardForCharacter', () => {
+    it('uses alliance preferences to look up reward', () => {
+        const prefs = {
+            ...defaultOnslaughtPreferences,
+            [Alliance.Imperial]: { sector: 'adamantine' as const, tier: 3 as const },
+        };
+
+        const reward = getOnslaughtRewardForCharacter(Rarity.Mythic, RarityStars.None, Alliance.Imperial, prefs);
+        expect(reward.isMythic).toBe(true);
+        expect(reward.min).toBe(2);
+        expect(reward.max).toBe(3);
+    });
+});

--- a/src/fsd/3-features/goals/goals.service.spec.ts
+++ b/src/fsd/3-features/goals/goals.service.spec.ts
@@ -19,6 +19,7 @@ import {
 } from '@/fsd/3-features/goals/goals.models';
 import { GoalsService } from '@/fsd/3-features/goals/goals.service';
 
+import { IOnslaughtPreferences } from '@/fsd/1-pages/input-onslaught/onslaught-rewards';
 import { XpUseState } from '@/fsd/1-pages/input-resources';
 import { ArenaLeague, XpIncomeState } from '@/fsd/1-pages/input-xp-income';
 
@@ -220,6 +221,118 @@ describe('Goal service', () => {
             const result = GoalsService.convertToTypedGoal(goalMock, characterMock);
 
             expect(result).toEqual(expectedResult);
+        });
+
+        describe('cross-boundary Ascend (character below OneBlueStar targeting Mythic)', () => {
+            // At adamantine tier 3:
+            //   legendary (no blue star) = regularShards(18, 22) → midpoint 20
+            //   legendaryBlue (OneBlueStar) = mythicShards(1, 2) → midpoint 1.5
+            // Without the fix, defaultMythicShards would be 20 (using regular shard rate).
+            // With the fix, it must be 1.5.
+            const adamantine3Prefs: IOnslaughtPreferences = {
+                [Alliance.Imperial]: { sector: 'adamantine', tier: 3 },
+                [Alliance.Xenos]: { sector: 'adamantine', tier: 3 },
+                [Alliance.Chaos]: { sector: 'adamantine', tier: 3 },
+            };
+
+            it('uses the legendaryBlue midpoint for onslaughtMythicShards when stars < OneBlueStar', () => {
+                const characterMock: ICharacter2 = {
+                    unitType: UnitType.character,
+                    id: 'roswitha',
+                    snowprintId: 'roswitha',
+                    name: 'Roswitha',
+                    shortName: 'Roswitha',
+                    alliance: Alliance.Imperial,
+                    shards: 65,
+                    mythicShards: 0,
+                    rarity: Rarity.Legendary,
+                    stars: RarityStars.RedThreeStars, // below OneBlueStar
+                } as ICharacter2;
+
+                const goalMock: IPersonalGoal = {
+                    id: 'g1',
+                    character: 'roswitha',
+                    type: PersonalGoalType.Ascend,
+                    priority: 1,
+                    dailyRaids: true,
+                    targetRarity: Rarity.Mythic,
+                };
+
+                const result = GoalsService.convertToTypedGoal(
+                    goalMock,
+                    characterMock,
+                    adamantine3Prefs
+                ) as ICharacterAscendGoal;
+
+                // Regular shards: adamantine 3 legendary = regularShards(18,22) → midpoint 20
+                expect(result?.onslaughtShards).toBe(20);
+                // Mythic shards MUST use legendaryBlue bucket = mythicShards(1,2) → midpoint 1.5, NOT 20
+                expect(result?.onslaughtMythicShards).toBe(1.5);
+            });
+
+            it('uses the same rate when character is already at OneBlueStar (no clamping needed)', () => {
+                const characterMock: ICharacter2 = {
+                    unitType: UnitType.character,
+                    id: 'character2',
+                    snowprintId: 'character2',
+                    name: 'Character 2',
+                    shortName: 'char2',
+                    alliance: Alliance.Imperial,
+                    shards: 0,
+                    mythicShards: 0,
+                    rarity: Rarity.Legendary,
+                    stars: RarityStars.OneBlueStar,
+                } as ICharacter2;
+
+                const goalMock: IPersonalGoal = {
+                    id: 'g2',
+                    character: 'character2',
+                    type: PersonalGoalType.Ascend,
+                    priority: 1,
+                    dailyRaids: true,
+                    targetRarity: Rarity.Mythic,
+                };
+
+                const result = GoalsService.convertToTypedGoal(
+                    goalMock,
+                    characterMock,
+                    adamantine3Prefs
+                ) as ICharacterAscendGoal;
+
+                // Already at OneBlueStar, so clamping has no effect — still 1.5
+                expect(result?.onslaughtMythicShards).toBe(1.5);
+            });
+
+            it('returns onslaughtMythicShards 0 for a non-mythic target (target is Legendary, no blue star)', () => {
+                const characterMock: ICharacter2 = {
+                    unitType: UnitType.character,
+                    id: 'character3',
+                    snowprintId: 'character3',
+                    name: 'Character 3',
+                    shortName: 'char3',
+                    alliance: Alliance.Imperial,
+                    shards: 0,
+                    rarity: Rarity.Epic,
+                    stars: RarityStars.FiveStars,
+                } as ICharacter2;
+
+                const goalMock: IPersonalGoal = {
+                    id: 'g3',
+                    character: 'character3',
+                    type: PersonalGoalType.Ascend,
+                    priority: 1,
+                    dailyRaids: true,
+                    targetRarity: Rarity.Legendary,
+                };
+
+                const result = GoalsService.convertToTypedGoal(
+                    goalMock,
+                    characterMock,
+                    adamantine3Prefs
+                ) as ICharacterAscendGoal;
+
+                expect(result?.onslaughtMythicShards).toBe(0);
+            });
         });
     });
 

--- a/src/fsd/3-features/goals/goals.service.ts
+++ b/src/fsd/3-features/goals/goals.service.ts
@@ -436,7 +436,16 @@ export class GoalsService {
                                   onslaughtPreferences
                               )
                             : 0),
-                    onslaughtMythicShards: (g.mythicShardsPerToken || undefined) ?? 1,
+                    onslaughtMythicShards:
+                        (g.mythicShardsPerToken || undefined) ??
+                        (unit.alliance
+                            ? getOnslaughtMidpointForCharacter(
+                                  Math.max(unit.rarity, Rarity.Legendary) as Rarity,
+                                  Math.max(unit.stars, RarityStars.OneBlueStar) as RarityStars,
+                                  unit.alliance as Alliance,
+                                  onslaughtPreferences
+                              )
+                            : 1),
                     campaignsUsage: g.campaignsUsage ?? CampaignsLocationsUsage.LeastEnergy,
                     mythicCampaignsUsage: g.mythicCampaignsUsage ?? CampaignsLocationsUsage.LeastEnergy,
                     farmType: g.shardFarmType ?? 'both',
@@ -464,9 +473,16 @@ export class GoalsService {
                 const targetNeedsMythicShards =
                     g.targetRarity! >= Rarity.Mythic ||
                     (g.targetRarity! === Rarity.Legendary && targetStars >= RarityStars.OneBlueStar);
+                // Mythic shards are earned once the character reaches Legendary+OneBlueStar.
+                // Clamp to that threshold so cross-boundary goals don't use the regular shard rate.
                 const defaultMythicShards =
                     targetNeedsMythicShards && unit.alliance
-                        ? getOnslaughtMidpointForCharacter(unit.rarity, unit.stars, unit.alliance, onslaughtPreferences)
+                        ? getOnslaughtMidpointForCharacter(
+                              Math.max(unit.rarity, Rarity.Legendary) as Rarity,
+                              Math.max(unit.stars, RarityStars.OneBlueStar) as RarityStars,
+                              unit.alliance,
+                              onslaughtPreferences
+                          )
                         : 0;
                 const result: ICharacterAscendGoal = {
                     type: PersonalGoalType.Ascend,

--- a/src/shared-components/goals/edit-ascend-goal.tsx
+++ b/src/shared-components/goals/edit-ascend-goal.tsx
@@ -113,7 +113,7 @@ export const EditAscendGoal: React.FC<Props> = ({
                 </>
             )}
 
-            {goal.starsStart >= RarityStars.OneBlueStar && (
+            {(goal.starsStart >= RarityStars.OneBlueStar || goal.rarityEnd >= Rarity.Mythic) && (
                 <>
                     {alliance && (
                         <div className="flex items-center gap-2 text-sm">
@@ -125,8 +125,8 @@ export const EditAscendGoal: React.FC<Props> = ({
                             <span className="text-gray-500">Estimated mythic shards per onslaught:</span>
                             <span className="font-medium text-purple-600">
                                 {formatOnslaughtRewardRange(
-                                    goal.rarityStart,
-                                    goal.starsStart,
+                                    goal.starsStart >= RarityStars.OneBlueStar ? goal.rarityStart : Rarity.Legendary,
+                                    Math.max(goal.starsStart, RarityStars.OneBlueStar),
                                     onslaughtPreferences[alliance].sector,
                                     onslaughtPreferences[alliance].tier
                                 )}

--- a/src/shared-components/goals/set-ascend-goal.tsx
+++ b/src/shared-components/goals/set-ascend-goal.tsx
@@ -63,6 +63,20 @@ export const SetAscendGoal: React.FC<Props> = ({
         );
     }, [alliance, currentRarity, currentStars, onslaughtPreferences]);
 
+    const mythicShardRangeLabel = useMemo(() => {
+        if (!alliance) return;
+        // Mythic shards are earned once the character is at Legendary+OneBlueStar or above.
+        // Use that threshold when the current stars are below it (cross-boundary goal).
+        const mythicRarity = currentStars >= RarityStars.OneBlueStar ? currentRarity : Rarity.Legendary;
+        const mythicStars = Math.max(currentStars, RarityStars.OneBlueStar);
+        return formatOnslaughtRewardRange(
+            mythicRarity,
+            mythicStars,
+            onslaughtPreferences[alliance].sector,
+            onslaughtPreferences[alliance].tier
+        );
+    }, [alliance, currentRarity, currentStars, onslaughtPreferences]);
+
     return (
         <>
             <div className="flex items-center gap-3">
@@ -110,16 +124,7 @@ export const SetAscendGoal: React.FC<Props> = ({
                         size={50}
                     />
                     <span className="text-gray-500">Estimated mythic shards per onslaught:</span>
-                    <span className="font-medium text-purple-600">
-                        {alliance
-                            ? formatOnslaughtRewardRange(
-                                  currentRarity,
-                                  currentStars,
-                                  onslaughtPreferences[alliance].sector,
-                                  onslaughtPreferences[alliance].tier
-                              )
-                            : '—'}
-                    </span>
+                    <span className="font-medium text-purple-600">{mythicShardRangeLabel ?? '—'}</span>
                 </div>
             )}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for onslaught reward calculations and ascend goal scenarios.

* **Bug Fixes**
  * Fixed mythic shard rate calculations for ascending legendary characters to mythic tier.
  * Improved UI display of estimated mythic shard rates in ascend goals.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/svehera/tacticusplanner/pull/935?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->