### PR TITLE
Fix rank lookups past A1, who-you-own page, and share links cross-platform

### DIFF
--- a/src/fsd/0-app/routing/mobile-routes.tsx
+++ b/src/fsd/0-app/routing/mobile-routes.tsx
@@ -73,6 +73,13 @@ export const mobileAppRoutes: () => RouteObject[] = () => [
                 },
             },
             faqLazyRoute,
+            {
+                path: '/sharedRoster',
+                loader: ({ request }) => {
+                    const { search } = new URL(request.url);
+                    return redirect(`/mobile/sharedRoster${search}`);
+                },
+            },
             sharedRosterRoute,
         ],
     },

--- a/src/fsd/0-app/routing/mobile-routes.tsx
+++ b/src/fsd/0-app/routing/mobile-routes.tsx
@@ -73,14 +73,14 @@ export const mobileAppRoutes: () => RouteObject[] = () => [
                 },
             },
             faqLazyRoute,
-            {
-                path: '/sharedRoster',
-                loader: ({ request }) => {
-                    const { search } = new URL(request.url);
-                    return redirect(`/mobile/sharedRoster${search}`);
-                },
-            },
             sharedRosterRoute,
         ],
+    },
+    {
+        path: '/sharedRoster',
+        loader: ({ request }) => {
+            const { search } = new URL(request.url);
+            return redirect(`/mobile/sharedRoster${search}`);
+        },
     },
 ];

--- a/src/fsd/1-pages/learn-characters/rank-lookup.tsx
+++ b/src/fsd/1-pages/learn-characters/rank-lookup.tsx
@@ -72,12 +72,10 @@ export const RankLookup = () => {
 
         if (rankStart > rankEnd) return [];
 
-        const adjustedRankStart = rankStart === Rank.Adamantine2 ? Rank.Adamantine1 : rankStart;
-
         return RankLookupService.getUpgradeMaterialsToRankUp({
             unitId: character.snowprintId ?? '',
             unitName: character.id,
-            rankStart: adjustedRankStart,
+            rankStart,
             rankEnd,
             appliedUpgrades: [],
             rankPoint5,
@@ -102,10 +100,10 @@ export const RankLookup = () => {
         }> = [];
 
         let currentRank = Math.max(rankStart, Rank.Stone1);
-        const endRank = rankEnd < rankStart ? rankStart : rankEnd > Rank.Adamantine2 ? Rank.Adamantine1 : rankEnd;
+        const endRank = Math.max(rankStart, rankEnd);
         const upgradesCopy = [...upgrades];
 
-        while (currentRank !== endRank) {
+        while (currentRank < endRank) {
             const rankUpgrades = upgradesCopy.splice(0, 6);
             result.push({ rank1: currentRank, rank2: currentRank + 1, materials: rankUpgrades });
             currentRank++;

--- a/src/fsd/1-pages/who-you-own/who-you-own.tsx
+++ b/src/fsd/1-pages/who-you-own/who-you-own.tsx
@@ -3,7 +3,6 @@
 import Box from '@mui/material/Box';
 import { sum } from 'lodash';
 import { useCallback, useContext, useMemo, useState } from 'react';
-import { isMobile } from 'react-device-detect';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { DispatchContext, StoreContext } from 'src/reducers/store.provider';
@@ -59,7 +58,7 @@ export const WhoYouOwn = () => {
     const hasShareParameters = !!sharedUser && !!shareToken;
 
     if (hasShareParameters) {
-        navigate((isMobile ? '/mobile' : '') + `/sharedRoster?username=${sharedUser}&shareToken=${shareToken}`);
+        navigate(`/sharedRoster?username=${sharedUser}&shareToken=${shareToken}`);
         return <></>;
     }
 

--- a/src/fsd/3-features/share/share-roster-dialog.tsx
+++ b/src/fsd/3-features/share/share-roster-dialog.tsx
@@ -7,7 +7,6 @@ import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import { enqueueSnackbar } from 'notistack';
 import React from 'react';
-import { isMobile } from 'react-device-detect';
 
 import { useAuth } from '@/fsd/5-shared/model';
 import { LoaderWithText } from '@/fsd/5-shared/ui';
@@ -19,7 +18,7 @@ export const ShareRosterDialog = ({ isOpen, onClose }: { isOpen: boolean; onClos
 
     const { shareToken, username, setUser } = useAuth();
 
-    const shareRoute = (isMobile ? '/mobile' : '') + `/sharedRoster?username=${username}&shareToken=${shareToken}`;
+    const shareRoute = `/sharedRoster?username=${username}&shareToken=${shareToken}`;
     const shareLink = shareToken ? location.origin + shareRoute : undefined;
 
     const copyLink = () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified shared roster access across devices with consistent routing and share links (mobile and desktop now use the same sharedRoster URL, preserving query parameters).

* **Bug Fixes**
  * Corrected rank-range calculations for upgrade-material lookups and grouping, fixing how rank ranges are split and when iteration stops.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->