### PR TITLE
fix: add guildPerformance menu item to librarySubMenu

### DIFF
--- a/src/models/menu-items.tsx
+++ b/src/models/menu-items.tsx
@@ -195,6 +195,7 @@ export const librarySubMenu: MenuItemTP[] = [
     menuItemById['guides'],
     menuItemById['dirtyDozen'],
     menuItemById['insights'],
+    menuItemById['guildPerformance'],
     menuItemById['guildApi'],
     menuItemById['guildInsights'],
 ];


### PR DESCRIPTION
Couldnt find the missing toggle tho. Not even in you commit from this morning. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Guild Performance menu option to the library submenu for quick access to guild performance lookups and insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->