### PR TITLE
Add new filters for CanPromote and CanAscendPromote to WYO page

### DIFF
--- a/src/fsd/3-features/characters/characters.service.ts
+++ b/src/fsd/3-features/characters/characters.service.ts
@@ -1,46 +1,33 @@
-﻿import { groupBy, orderBy, sum } from 'lodash';
+﻿/* eslint-disable import-x/no-internal-modules */
 
-// eslint-disable-next-line import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure
+import { groupBy, orderBy, sum } from 'lodash';
+
 import factionsData from 'src/data/factions.json';
-// eslint-disable-next-line import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure
 import { charsUnlockShards, charsProgression } from 'src/models/constants';
-// eslint-disable-next-line import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure
 import { IPersonalCharacterData2, ICharProgression } from 'src/models/interfaces';
 
 import { filterMap } from '@/fsd/5-shared/lib';
 import { Rank, Rarity, UnitType, RarityStars } from '@/fsd/5-shared/model';
 
 import { ICharacter2 } from '@/fsd/4-entities/character';
-// eslint-disable-next-line import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure
 import { CharactersFilterBy } from '@/fsd/4-entities/character/characters-filter-by.enum';
-// eslint-disable-next-line import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure
 import { CharactersOrderBy } from '@/fsd/4-entities/character/characters-order-by.enum';
 import { IMow2 } from '@/fsd/4-entities/mow';
 import { IUnit } from '@/fsd/4-entities/unit';
-// eslint-disable-next-line import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure
 import { CharactersPowerService } from '@/fsd/4-entities/unit/characters-power.service';
-// eslint-disable-next-line import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure
 import { CharactersValueService } from '@/fsd/4-entities/unit/characters-value.service';
-// eslint-disable-next-line import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure
 import { isCharacter, isMow, isUnlocked } from '@/fsd/4-entities/unit/units.functions';
 
-// eslint-disable-next-line import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure
 import { rarityCaps } from '@/fsd/3-features/characters/characters.constants';
 
 import { IFaction } from './characters.models';
-// eslint-disable-next-line import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure
 import { blueStarReady } from './functions/blue-star-ready';
-// eslint-disable-next-line import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure
 import { canAscendCharacter } from './functions/can-ascend';
-// eslint-disable-next-line import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure
+import { canPromoteUnit } from './functions/can-promote';
 import { filterChaos } from './functions/filter-by-chaos';
-// eslint-disable-next-line import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure
 import { filterImperial } from './functions/filter-by-imperial';
-// eslint-disable-next-line import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure
 import { filterXenos } from './functions/filter-by-xenos';
-// eslint-disable-next-line import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure
 import { needToAscendCharacter } from './functions/need-to-ascend';
-// eslint-disable-next-line import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure
 import { needToLevelCharacter } from './functions/need-to-level';
 
 export class CharactersService {
@@ -59,6 +46,14 @@ export class CharactersService {
             }
             case CharactersFilterBy.CanAscend: {
                 return filteredCharactersByName.filter(character => canAscendCharacter(character));
+            }
+            case CharactersFilterBy.CanPromote: {
+                return filteredCharactersByName.filter(character => canPromoteUnit(character));
+            }
+            case CharactersFilterBy.CanAscendPromote: {
+                return filteredCharactersByName.filter(
+                    character => canAscendCharacter(character) || canPromoteUnit(character)
+                );
             }
             case CharactersFilterBy.NeedToLevel: {
                 return filteredCharactersByName.filter(character => needToLevelCharacter(character));

--- a/src/fsd/3-features/characters/functions/can-promote.spec.ts
+++ b/src/fsd/3-features/characters/functions/can-promote.spec.ts
@@ -1,0 +1,109 @@
+/* eslint-disable import-x/no-internal-modules */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { Rarity, RarityStars } from '@/fsd/5-shared/model';
+
+import { IUnit } from '@/fsd/4-entities/unit';
+import { isUnlocked } from '@/fsd/4-entities/unit/units.functions';
+
+import { CharactersService } from '@/fsd/3-features/characters/characters.service';
+
+import { canPromoteUnit } from './can-promote';
+
+vi.mock('@/fsd/4-entities/unit/units.functions', () => ({
+    isUnlocked: vi.fn(),
+}));
+
+vi.mock('@/fsd/3-features/characters/characters.constants', () => ({
+    rarityCaps: {
+        [Rarity.Common]: { stars: RarityStars.TwoStars },
+        [Rarity.Legendary]: { stars: RarityStars.RedFiveStars },
+    },
+}));
+
+vi.mock('@/fsd/4-entities/character', () => ({
+    CharactersService: {
+        getTotalProgressionUntil: vi.fn(),
+    },
+}));
+
+describe('canPromoteUnit', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('should return false if the unit is not unlocked', () => {
+        vi.mocked(isUnlocked).mockReturnValue(false);
+        const unit = { rarity: Rarity.Common, stars: RarityStars.None } as IUnit;
+
+        const result = canPromoteUnit(unit);
+        expect(result).toBe(false);
+    });
+
+    it('should return false if the unit is already at the star cap for its rarity', () => {
+        vi.mocked(isUnlocked).mockReturnValue(true);
+        const unit = { rarity: Rarity.Common, stars: RarityStars.TwoStars } as IUnit;
+
+        const result = canPromoteUnit(unit);
+        expect(result).toBe(false);
+    });
+
+    it('should return false if the unit is beyond the star cap for its rarity', () => {
+        vi.mocked(isUnlocked).mockReturnValue(true);
+        const unit = { rarity: Rarity.Common, stars: RarityStars.ThreeStars } as IUnit;
+
+        const result = canPromoteUnit(unit);
+        expect(result).toBe(false);
+    });
+
+    it('should return false if the unit does not have enough shards for the next star', () => {
+        vi.mocked(isUnlocked).mockReturnValue(true);
+        vi.mocked(CharactersService.getTotalProgressionUntil)
+            .mockReturnValueOnce({ shards: 10, mythicShards: 0 }) // Current progress
+            .mockReturnValueOnce({ shards: 25, mythicShards: 0 }); // Next star requirement
+
+        const unit = {
+            rarity: Rarity.Common,
+            stars: RarityStars.OneStar,
+            shards: 14, // Needs 15 (25 - 10)
+            mythicShards: 0,
+        } as IUnit;
+
+        const result = canPromoteUnit(unit);
+        expect(result).toBe(false);
+    });
+
+    it('should return false if the unit does not have enough mythic shards for the next star', () => {
+        vi.mocked(isUnlocked).mockReturnValue(true);
+        vi.mocked(CharactersService.getTotalProgressionUntil)
+            .mockReturnValueOnce({ shards: 100, mythicShards: 5 })
+            .mockReturnValueOnce({ shards: 100, mythicShards: 15 });
+
+        const unit = {
+            rarity: Rarity.Legendary,
+            stars: RarityStars.RedFourStars,
+            shards: 0,
+            mythicShards: 9, // Needs 10 (15 - 5)
+        } as IUnit;
+
+        const result = canPromoteUnit(unit);
+        expect(result).toBe(false);
+    });
+
+    it('should return true if the unit meets both shard and mythic shard requirements', () => {
+        vi.mocked(isUnlocked).mockReturnValue(true);
+        vi.mocked(CharactersService.getTotalProgressionUntil)
+            .mockReturnValueOnce({ shards: 100, mythicShards: 5 })
+            .mockReturnValueOnce({ shards: 200, mythicShards: 15 });
+
+        const unit = {
+            rarity: Rarity.Legendary,
+            stars: RarityStars.RedFourStars,
+            shards: 100,
+            mythicShards: 10,
+        } as IUnit;
+
+        const result = canPromoteUnit(unit);
+        expect(result).toBe(true);
+    });
+});

--- a/src/fsd/3-features/characters/functions/can-promote.spec.ts
+++ b/src/fsd/3-features/characters/functions/can-promote.spec.ts
@@ -21,7 +21,7 @@ vi.mock('@/fsd/3-features/characters/characters.constants', () => ({
     },
 }));
 
-vi.mock('@/fsd/4-entities/character', () => ({
+vi.mock('@/fsd/3-features/characters/characters.service', () => ({
     CharactersService: {
         getTotalProgressionUntil: vi.fn(),
     },

--- a/src/fsd/3-features/characters/functions/can-promote.ts
+++ b/src/fsd/3-features/characters/functions/can-promote.ts
@@ -1,0 +1,29 @@
+/* eslint-disable import-x/no-internal-modules */
+
+import { IUnit } from '@/fsd/4-entities/unit';
+import { isUnlocked } from '@/fsd/4-entities/unit/units.functions';
+
+import { rarityCaps } from '@/fsd/3-features/characters/characters.constants';
+import { CharactersService } from '@/fsd/3-features/characters/characters.service';
+
+export const canPromoteUnit = (unit: IUnit) => {
+    if (!isUnlocked(unit)) {
+        return false;
+    }
+
+    const maxStarsForRarity = rarityCaps[unit.rarity].stars;
+
+    // If the unit is already at the star cap for its rarity, promotion within rarity is impossible.
+    if (unit.stars >= maxStarsForRarity) {
+        return false;
+    }
+
+    const totalShardsCurrent = CharactersService.getTotalProgressionUntil(unit.rarity, unit.stars);
+    const nextStar = unit.stars + 1;
+    const totalShardsForNextStar = CharactersService.getTotalProgressionUntil(unit.rarity, nextStar);
+
+    const neededShards = (totalShardsForNextStar.shards ?? 0) - (totalShardsCurrent.shards ?? 0);
+    const neededMythicShards = (totalShardsForNextStar.mythicShards ?? 0) - (totalShardsCurrent.mythicShards ?? 0);
+
+    return neededShards - unit.shards <= 0 && neededMythicShards - unit.mythicShards <= 0;
+};

--- a/src/fsd/3-features/view-settings/view-controls.tsx
+++ b/src/fsd/3-features/view-settings/view-controls.tsx
@@ -69,6 +69,12 @@ export const CharactersViewControls = ({
             case CharactersFilterBy.CanAscend: {
                 return 'Can Ascend';
             }
+            case CharactersFilterBy.CanPromote: {
+                return 'Can Promote';
+            }
+            case CharactersFilterBy.CanAscendPromote: {
+                return 'Can Ascend/Promote';
+            }
             case CharactersFilterBy.NeedToLevel: {
                 return 'Need to Level';
             }

--- a/src/fsd/4-entities/character/characters-filter-by.enum.ts
+++ b/src/fsd/4-entities/character/characters-filter-by.enum.ts
@@ -8,4 +8,6 @@
     Imperial,
     Xenos,
     MoW,
+    CanPromote,
+    CanAscendPromote,
 }

--- a/src/fsd/4-entities/character/characters-filter-by.enum.ts
+++ b/src/fsd/4-entities/character/characters-filter-by.enum.ts
@@ -2,8 +2,6 @@
     None,
     NeedToAscend,
     CanAscend,
-    CanPromote,
-    CanAscendPromote,
     NeedToLevel,
     BlueStarReady,
     Chaos,

--- a/src/fsd/4-entities/character/characters-filter-by.enum.ts
+++ b/src/fsd/4-entities/character/characters-filter-by.enum.ts
@@ -2,6 +2,8 @@
     None,
     NeedToAscend,
     CanAscend,
+    CanPromote,
+    CanAscendPromote,
     NeedToLevel,
     BlueStarReady,
     Chaos,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an eligibility check for unit promotion and two new character filters: "Can Promote" and "Can Ascend/Promote".
* **Bug Fixes / Improvements**
  * Filters and labels updated so these new options display and correctly filter units, including combined ascend-or-promote cases.
* **Tests**
  * Added unit tests covering locked units, rarity caps, and shard/mythic requirements for promotion eligibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->