### PR TITLE
Show users with bad API keys in the guild page, and allow filtering guild roster snapshots by raid teams

### DIFF
--- a/src/fsd/1-pages/input-guild-roster-snapshots/overrides-tab.tsx
+++ b/src/fsd/1-pages/input-guild-roster-snapshots/overrides-tab.tsx
@@ -4,7 +4,6 @@ import { Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { obfuscateUserId } from '@/fsd/5-shared/lib';
-import { Button } from '@/fsd/5-shared/ui/button';
 
 import { buildCsv, parseCsvText } from './guild-roster-snapshots.helpers';
 import {
@@ -164,6 +163,7 @@ export const OverridesTab = ({ members }: OverridesTabProps) => {
         setCsvImportStatus(undefined);
     };
 
+    const hasChanges = JSON.stringify(rows) !== JSON.stringify(savedRows);
     const csvPreview = buildCsv(rows);
 
     return (
@@ -195,6 +195,9 @@ export const OverridesTab = ({ members }: OverridesTabProps) => {
                     </MuiButton>
                     <MuiButton variant="outlined" size="small" onClick={handleRevert}>
                         Revert
+                    </MuiButton>
+                    <MuiButton variant="outlined" size="small" onClick={handleSave} disabled={!hasChanges || isSaving}>
+                        {isSaving ? 'Saving…' : 'Save'}
                     </MuiButton>
                 </div>
 
@@ -290,12 +293,6 @@ export const OverridesTab = ({ members }: OverridesTabProps) => {
                 </table>
 
                 {saveError && <p className="text-sm text-red-600 dark:text-red-400">{saveError}</p>}
-
-                <div>
-                    <Button intent="primary" isDisabled={isSaving} onPress={handleSave}>
-                        {isSaving ? 'Saving…' : 'Save'}
-                    </Button>
-                </div>
 
                 {/* Copyable CSV preview */}
                 <div className="flex flex-col gap-1">

--- a/src/fsd/1-pages/input-guild-roster-snapshots/raid-team-filter-dropdown.tsx
+++ b/src/fsd/1-pages/input-guild-roster-snapshots/raid-team-filter-dropdown.tsx
@@ -1,0 +1,48 @@
+import ExpandMore from '@mui/icons-material/ExpandMore';
+import { Button, Checkbox, ListItemIcon, ListItemText, Menu, MenuItem } from '@mui/material';
+import { useState } from 'react';
+
+interface RaidTeamOption {
+    name: string;
+    isSelected: boolean;
+}
+
+interface RaidTeamFilterDropdownProps {
+    teams: RaidTeamOption[];
+    onToggleTeam: (name: string) => void;
+}
+
+export const RaidTeamFilterDropdown = ({ teams, onToggleTeam }: RaidTeamFilterDropdownProps) => {
+    const [anchorElement, setAnchorElement] = useState<HTMLElement | undefined>();
+    const selectedCount = teams.filter(t => t.isSelected).length;
+    const label =
+        selectedCount === 0 ? 'All Raid Teams' : `${selectedCount} raid team${selectedCount === 1 ? '' : 's'}`;
+
+    return (
+        <>
+            <Button
+                size="small"
+                variant="outlined"
+                color="primary"
+                onClick={event => setAnchorElement(event.currentTarget)}
+                sx={{ textTransform: 'none', justifyContent: 'space-between', minWidth: 180, maxWidth: 260 }}>
+                <span>{label}</span>
+                <ExpandMore className="ml-1" />
+            </Button>
+            <Menu
+                anchorEl={anchorElement}
+                open={Boolean(anchorElement)}
+                onClose={() => setAnchorElement(undefined)}
+                PaperProps={{ sx: { width: 'min(92vw, 300px)', maxHeight: '72vh' } }}>
+                {teams.map(team => (
+                    <MenuItem key={team.name} dense onClick={() => onToggleTeam(team.name)}>
+                        <ListItemIcon>
+                            <Checkbox edge="start" checked={team.isSelected} tabIndex={-1} disableRipple />
+                        </ListItemIcon>
+                        <ListItemText primary={team.name} />
+                    </MenuItem>
+                ))}
+            </Menu>
+        </>
+    );
+};

--- a/src/fsd/1-pages/input-guild-roster-snapshots/roster-snapshots-tab.tsx
+++ b/src/fsd/1-pages/input-guild-roster-snapshots/roster-snapshots-tab.tsx
@@ -1,14 +1,19 @@
 /* eslint-disable import-x/no-internal-modules */
 /* eslint-disable boundaries/element-types */
 import { Dialog, DialogActions, DialogContent, DialogTitle } from '@mui/material';
-import { useMemo, useState } from 'react';
+import { useContext, useMemo, useState } from 'react';
 
+import { StoreContext } from '@/reducers/store.provider';
+
+import { isLikelyUserId, obfuscateUserId } from '@/fsd/5-shared/lib';
 import { DebugJson } from '@/fsd/5-shared/ui';
 import { Button } from '@/fsd/5-shared/ui/button';
 
 import { RosterSnapshotShowVariableSettings } from '@/fsd/3-features/view-settings';
 
 import { RosterSnapshotsUnit } from '@/fsd/2-widgets/roster-snapshots-unit';
+
+import { getUnitIdsFromTeamNames } from '@/fsd/1-pages/plan-teams2/team-filter.utils';
 
 import { IRosterSnapshot, ISnapshotUnitDiff } from '../input-roster-snapshots/models';
 import { RosterSnapshotsService } from '../input-roster-snapshots/roster-snapshots-service';
@@ -21,6 +26,7 @@ import {
     getGuildRosterHistoryApi,
     postGuildRosterSnapshotApi,
 } from './guild-roster-snapshots.models';
+import { RaidTeamFilterDropdown } from './raid-team-filter-dropdown';
 import {
     DiffEntry,
     applyCapTrimming,
@@ -54,6 +60,9 @@ export const RosterSnapshotsTab = ({ members, memberStates, onLoadMembers }: Ros
     const [leftSnapshotIndex, setLeftSnapshotIndex] = useState<number | undefined>();
     const [rightSnapshotSelection, setRightSnapshotSelection] = useState<number | 'current' | undefined>();
     const [selectedUserId, setSelectedUserId] = useState<string | undefined>();
+    const [selectedRaidTeamNames, setSelectedRaidTeamNames] = useState<string[]>([]);
+
+    const { teams2 } = useContext(StoreContext);
 
     // Save dialog
     const [saveDialogOpen, setSaveDialogOpen] = useState(false);
@@ -215,6 +224,25 @@ export const RosterSnapshotsTab = ({ members, memberStates, onLoadMembers }: Ros
         snapshots,
     ]);
 
+    const raidTeams = useMemo(() => teams2.filter(t => t.raid), [teams2]);
+
+    const raidTeamFilterOptions = useMemo(
+        () => raidTeams.map(t => ({ name: t.name, isSelected: selectedRaidTeamNames.includes(t.name) })),
+        [raidTeams, selectedRaidTeamNames]
+    );
+
+    const toggleRaidTeam = (teamName: string) => {
+        setSelectedRaidTeamNames(current => {
+            const next = new Set(current);
+            if (next.has(teamName)) {
+                next.delete(teamName);
+            } else {
+                next.add(teamName);
+            }
+            return [...next];
+        });
+    };
+
     const diffEntries = useMemo((): DiffEntry[] => {
         if (selectedUserId === undefined || leftSnapshotIndex === undefined || rightSnapshotSelection === undefined) {
             return [];
@@ -287,7 +315,14 @@ export const RosterSnapshotsTab = ({ members, memberStates, onLoadMembers }: Ros
         return results;
     }, [selectedUserId, leftSnapshotIndex, rightSnapshotSelection, memberHistoryMap, memberStates]);
 
+    const filteredDiffEntries = useMemo((): DiffEntry[] => {
+        const unitIds = getUnitIdsFromTeamNames(raidTeams, selectedRaidTeamNames);
+        if (unitIds.size === 0) return diffEntries;
+        return diffEntries.filter(({ char, mow }) => (char && unitIds.has(char.id)) || (mow && unitIds.has(mow.id)));
+    }, [diffEntries, raidTeams, selectedRaidTeamNames]);
+
     const isNoHistoryMode = hasLoadedHistoryOnce && snapshots.length === 0;
+    const apiKeyErrorIds = members?.filter(id => memberStates.get(id)?.status === 'error') ?? [];
 
     // Current-roster fallback (no-history mode)
     const selectedMemberState = selectedUserId === undefined ? undefined : memberStates.get(selectedUserId);
@@ -321,6 +356,23 @@ export const RosterSnapshotsTab = ({ members, memberStates, onLoadMembers }: Ros
             {historyError && <p className="text-sm text-red-600 dark:text-red-400">{historyError}</p>}
 
             <DebugJson label="guild/roster/history" value={history ?? 'not loaded'} />
+
+            {apiKeyErrorIds.length > 0 && (
+                <section className="flex flex-col gap-2">
+                    <h2 className="text-sm font-semibold text-red-600 dark:text-red-400">
+                        API key errors ({apiKeyErrorIds.length})
+                    </h2>
+                    <ul className="flex flex-wrap gap-2">
+                        {apiKeyErrorIds.map(id => (
+                            <li
+                                key={id}
+                                className="rounded bg-red-100 px-2 py-0.5 font-mono text-xs text-red-700 dark:bg-red-900/50 dark:text-red-300">
+                                {isLikelyUserId(id) ? obfuscateUserId(id) : id}
+                            </li>
+                        ))}
+                    </ul>
+                </section>
+            )}
 
             {!hasLoadedHistoryOnce && (
                 <p className="text-sm text-gray-500 dark:text-gray-400">
@@ -387,6 +439,10 @@ export const RosterSnapshotsTab = ({ members, memberStates, onLoadMembers }: Ros
                         </>
                     )}
 
+                    {raidTeams.length > 0 && (
+                        <RaidTeamFilterDropdown teams={raidTeamFilterOptions} onToggleTeam={toggleRaidTeam} />
+                    )}
+
                     {membersInComparison.length > 0 && (
                         <div className="flex items-center gap-2">
                             <label htmlFor="history-member-select" className={labelClass}>
@@ -413,10 +469,12 @@ export const RosterSnapshotsTab = ({ members, memberStates, onLoadMembers }: Ros
             {isNoHistoryMode && <p className="text-sm text-gray-500 dark:text-gray-400">No roster history found.</p>}
 
             {/* Diff view */}
-            {diffEntries.length > 0 &&
+            {filteredDiffEntries.length > 0 &&
                 (() => {
-                    const changed = diffEntries.filter(event => event.hasChanged).toSorted((a, b) => b.power - a.power);
-                    const unchanged = diffEntries
+                    const changed = filteredDiffEntries
+                        .filter(event => event.hasChanged)
+                        .toSorted((a, b) => b.power - a.power);
+                    const unchanged = filteredDiffEntries
                         .filter(event => !event.hasChanged)
                         .toSorted((a, b) => b.power - a.power);
                     return (

--- a/src/fsd/1-pages/input-guild-roster-snapshots/rosters-tab.tsx
+++ b/src/fsd/1-pages/input-guild-roster-snapshots/rosters-tab.tsx
@@ -24,6 +24,7 @@ export const RostersTab = ({ members, memberStates }: RostersTabProps) => {
         );
     }
 
+    const errors = members.filter(id => memberStates.get(id)?.status === 'error');
     const notShared = members.filter(id => memberStates.get(id)?.status === 'not-shared');
     const nameOnly = members.filter(id => memberStates.get(id)?.status === 'name-only');
     const successes = members.filter(id => memberStates.get(id)?.status === 'success');
@@ -41,6 +42,23 @@ export const RostersTab = ({ members, memberStates }: RostersTabProps) => {
             )}
 
             {members.length === 0 && <p className="text-sm text-gray-500 dark:text-gray-400">No members found.</p>}
+
+            {errors.length > 0 && (
+                <section className="flex flex-col gap-2">
+                    <h2 className="text-sm font-semibold text-red-600 dark:text-red-400">
+                        API key errors ({errors.length})
+                    </h2>
+                    <ul className="flex flex-wrap gap-2">
+                        {errors.map(id => (
+                            <li
+                                key={id}
+                                className="rounded bg-red-100 px-2 py-0.5 font-mono text-xs text-red-700 dark:bg-red-900/50 dark:text-red-300">
+                                {isLikelyUserId(id) ? obfuscateUserId(id) : id}
+                            </li>
+                        ))}
+                    </ul>
+                </section>
+            )}
 
             {notShared.length > 0 && (
                 <section className="flex flex-col gap-2">

--- a/src/fsd/1-pages/input-roster-snapshots/roster-snapshots.tsx
+++ b/src/fsd/1-pages/input-roster-snapshots/roster-snapshots.tsx
@@ -26,6 +26,9 @@ import { RosterSnapshotDiffStyle, RosterSnapshotShowVariableSettings } from '@/f
 
 import { RosterSnapshotsUnit } from '@/fsd/2-widgets/roster-snapshots-unit';
 
+// eslint-disable-next-line import-x/no-internal-modules, boundaries/element-types
+import { getUnitIdsFromTeamNames } from '@/fsd/1-pages/plan-teams2/team-filter.utils';
+
 import { ManageSnapshotsDialog } from './manage-snapshots-dialog';
 import { IRosterSnapshot, IRosterSnapshotsState } from './models';
 import { RosterFilterDropdown } from './roster-filter-dropdown';
@@ -795,11 +798,9 @@ export const RosterSnapshots = () => {
     const rosterFilterSummaryLabel = selectedFilterCount === 0 ? 'All Units' : `${selectedFilterCount} selected`;
 
     const selectedUnitIds = useMemo(() => {
-        const selectedTeamUnitIds = teams2
-            .filter(team => selectedTeamNames.includes(team.name))
-            .flatMap(team => [...team.chars, ...(team.mows ?? [])]);
+        const teamUnitIds = getUnitIdsFromTeamNames(teams2, selectedTeamNames);
         const selectedLeUnitIds = selectedLeOptions.flatMap(option => option.unitIds);
-        const allSelectedUnitIds = [...selectedTeamUnitIds, ...selectedLeUnitIds];
+        const allSelectedUnitIds = [...teamUnitIds, ...selectedLeUnitIds];
 
         if (allSelectedUnitIds.length === 0) {
             return new Set<string>();

--- a/src/fsd/1-pages/learn-guild-performance/guild-performance.hook.ts
+++ b/src/fsd/1-pages/learn-guild-performance/guild-performance.hook.ts
@@ -1,0 +1,223 @@
+/* eslint-disable import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure */
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { makeApiCall } from '@/fsd/5-shared/api';
+import {
+    TacticusDamageType,
+    getTacticusGuildData,
+    safeParseGuildSeasonHistory,
+    safeParseGuildSeasonSummary,
+    safeParseSharedLeaderboards,
+    type GuildSeasonHistoryEntry,
+    type GuildSeasonHistoryResponse,
+    type SharedLeaderboardsResponse,
+    type TacticusGuildRaidResponse,
+} from '@/fsd/5-shared/lib/tacticus-api';
+import { useAuth } from '@/fsd/5-shared/model';
+
+import { LOADING, type GuildMemberName, type GuildTokenEntry, type LoadingOrData } from './guild-performance.types';
+import { buildAvgDamageMap, getAllGuildPlayers, mergeSeasonSummaries } from './guild-performance.utils';
+
+// Module-level cache so data persists across navigations
+let cachedCurrent: TacticusGuildRaidResponse | undefined;
+let cachedHistory: GuildSeasonHistoryResponse | undefined;
+let cachedSharedLeaderboards: SharedLeaderboardsResponse | undefined;
+let cachedGuildInfo: { tag: string; name: string } | undefined;
+let cachedNames: Map<string, string> | undefined;
+let cachedRawNames: GuildMemberName[] | undefined;
+let cachedTokens: GuildTokenEntry[] | undefined;
+/** Gates the one-shot auto-fetch (the cache vars above can legitimately stay undefined for members). */
+let cachedFetched = false;
+
+function errorText(error: unknown): string | undefined {
+    if (error === undefined) return undefined;
+    if (typeof error === 'string') return error;
+    if (error instanceof Error) return error.message;
+    return String(error);
+}
+
+export function useGuildPerformance() {
+    const { userInfo } = useAuth();
+    const hasGuildApiKey = !!userInfo?.tacticusGuildApiKey;
+    const hasGuildTag = !!userInfo?.guildTag;
+    const isMember = !hasGuildApiKey && hasGuildTag;
+    const hasAccess = hasGuildApiKey || hasGuildTag;
+    const ownUserId = userInfo?.tacticusUserId;
+    // For a keyless member, the player-aware tabs are pinned to their own (un-anonymized) rows.
+    const memberUserId = isMember && ownUserId ? ownUserId : undefined;
+
+    const [current, setCurrent] = useState<LoadingOrData<TacticusGuildRaidResponse>>(cachedCurrent ?? LOADING);
+    const [seasonHistory, setSeasonHistory] = useState<GuildSeasonHistoryResponse | undefined>(cachedHistory);
+    const [sharedLeaderboards, setSharedLeaderboards] = useState<SharedLeaderboardsResponse | undefined>(
+        cachedSharedLeaderboards
+    );
+    const [guildInfo, setGuildInfo] = useState<{ tag: string; name: string } | undefined>(cachedGuildInfo);
+    const [historyError, setHistoryError] = useState<string | undefined>();
+    const [names, setNames] = useState<Map<string, string>>(cachedNames ?? new Map());
+    const [rawNames, setRawNames] = useState<GuildMemberName[] | undefined>(cachedRawNames);
+    const [tokens, setTokens] = useState<GuildTokenEntry[] | typeof LOADING>(cachedTokens ?? LOADING);
+    const [tokenError, setTokenError] = useState<string | undefined>();
+    const [isRefreshing, setIsRefreshing] = useState(false);
+
+    const currentData = current === LOADING ? undefined : current;
+    const tokenData = tokens === LOADING ? undefined : tokens;
+
+    const availableSeasons = useMemo(() => {
+        const set = new Set<number>();
+        if (currentData?.season != undefined) set.add(currentData.season);
+        for (const season of seasonHistory?.seasonData ?? []) set.add(season.season);
+        return [...set].toSorted((a, b) => b - a);
+    }, [currentData, seasonHistory]);
+
+    const allPlayers = useMemo(
+        () => getAllGuildPlayers(currentData?.entries ?? [], seasonHistory?.seasonData ?? [], names),
+        [currentData, seasonHistory, names]
+    );
+
+    const avgDamageMap = useMemo(() => {
+        const allEntries = (currentData?.entries ?? []).filter(
+            entry => entry.damageType !== TacticusDamageType.Bomb && entry.remainingHp !== 0
+        );
+        return buildAvgDamageMap(allEntries);
+    }, [currentData]);
+
+    const refreshSharedLeaderboards = useCallback(async () => {
+        const response = await makeApiCall<unknown>('GET', 'guild/sharedLeaderboards');
+        const parsedSharedLb = response.data === undefined ? undefined : safeParseSharedLeaderboards(response.data);
+        cachedSharedLeaderboards = parsedSharedLb?.success ? parsedSharedLb.data : undefined;
+        setSharedLeaderboards(cachedSharedLeaderboards);
+    }, []);
+
+    const fetchData = useCallback(async () => {
+        setIsRefreshing(true);
+        try {
+            const [currentResponse, historyResponse, namesResponse, tokensResponse, sharedLbResponse, guildResponse] =
+                await Promise.all([
+                    makeApiCall<unknown>('GET', 'guild/raid?history=false'),
+                    makeApiCall<unknown>('GET', 'guild/raid?history=true'),
+                    makeApiCall<GuildMemberName[]>('GET', 'guild/members/names'),
+                    makeApiCall<GuildTokenEntry[]>('GET', 'guild/tokens'),
+                    makeApiCall<unknown>('GET', 'guild/sharedLeaderboards'),
+                    getTacticusGuildData(),
+                ]);
+
+            // --- names (shared) ---
+            const nameMap = new Map<string, string>();
+            for (const member of namesResponse.data ?? []) {
+                if (member.name) nameMap.set(member.userId, member.name);
+            }
+            // A keyless member sees their own (un-anonymized) rows; label them when not otherwise known.
+            if (isMember && ownUserId) nameMap.set(ownUserId, nameMap.get(ownUserId) ?? 'You');
+            cachedRawNames = namesResponse.data;
+            setRawNames(namesResponse.data);
+            cachedNames = nameMap;
+            setNames(nameMap);
+
+            // --- history (both user types return { sequenceNumber, seasonData }) ---
+            let seasonData: GuildSeasonHistoryEntry[] = [];
+            let sequenceNumber = 0;
+            let parseError: string | undefined;
+            if (historyResponse.data !== undefined) {
+                const parsed = safeParseGuildSeasonHistory(historyResponse.data);
+                if (parsed.success) {
+                    seasonData = parsed.data.seasonData;
+                    sequenceNumber = parsed.data.sequenceNumber;
+                } else {
+                    parseError = parsed.error.message;
+                }
+            }
+
+            if (hasGuildApiKey) {
+                // Leader: current season is the raw per-hit response, wrapped in { raidResponse: ... }.
+                const wrapper = currentResponse.data as { raidResponse?: TacticusGuildRaidResponse } | undefined;
+                const raw = wrapper?.raidResponse;
+                if (raw) {
+                    cachedCurrent = raw;
+                    setCurrent(raw);
+                }
+                const history = { sequenceNumber, seasonData };
+                cachedHistory = history;
+                setSeasonHistory(history);
+                setHistoryError(parseError);
+            } else {
+                // Member: current season is a single anonymized summary wrapped in { summary: ... }.
+                if (currentResponse.data !== undefined) {
+                    const wrapper = currentResponse.data as { summary?: unknown } | undefined;
+                    const summaryData = wrapper?.summary;
+                    if (summaryData !== undefined) {
+                        const parsed = safeParseGuildSeasonSummary(summaryData);
+                        if (parsed.success) {
+                            seasonData = mergeSeasonSummaries(seasonData, parsed.data);
+                        } else {
+                            parseError ??= parsed.error.message;
+                        }
+                    }
+                }
+                const history = { sequenceNumber, seasonData };
+                cachedHistory = history;
+                setSeasonHistory(history);
+                // Surface a backend access error (403 sharing-disabled / 404 not-a-member) when no data.
+                setHistoryError(
+                    seasonData.length === 0
+                        ? (errorText(currentResponse.error) ?? errorText(historyResponse.error) ?? parseError)
+                        : parseError
+                );
+            }
+
+            // --- tokens ---
+            if (tokensResponse.data) {
+                cachedTokens = tokensResponse.data;
+                setTokens(tokensResponse.data);
+            } else if (tokensResponse.error) {
+                const error = tokensResponse.error;
+                setTokenError(typeof error === 'string' ? error : ((error as Error).message ?? 'Unknown error'));
+                setTokens([]);
+            }
+
+            // --- shared leaderboards ---
+            const parsedSharedLb =
+                sharedLbResponse.data === undefined ? undefined : safeParseSharedLeaderboards(sharedLbResponse.data);
+            cachedSharedLeaderboards = parsedSharedLb?.success ? parsedSharedLb.data : undefined;
+            setSharedLeaderboards(cachedSharedLeaderboards);
+
+            // --- guild info ---
+            if (guildResponse.data?.guild) {
+                const { guildTag, name } = guildResponse.data.guild;
+                cachedGuildInfo = { tag: guildTag, name };
+                setGuildInfo({ tag: guildTag, name });
+            }
+
+            cachedFetched = true;
+        } finally {
+            setIsRefreshing(false);
+        }
+    }, [hasGuildApiKey, isMember, ownUserId]);
+
+    useEffect(() => {
+        if (!hasAccess) return;
+        if (cachedFetched) return;
+        void fetchData();
+    }, [hasAccess, fetchData]);
+
+    return {
+        hasGuildApiKey,
+        hasAccess,
+        isMember,
+        memberUserId,
+        currentData,
+        seasonHistory,
+        sharedLeaderboards,
+        guildInfo,
+        historyError,
+        names,
+        rawNames,
+        tokenData,
+        tokenError,
+        isRefreshing,
+        availableSeasons,
+        allPlayers,
+        avgDamageMap,
+        fetchData,
+        refreshSharedLeaderboards,
+    };
+}

--- a/src/fsd/1-pages/learn-guild-performance/guild-performance.hook.ts
+++ b/src/fsd/1-pages/learn-guild-performance/guild-performance.hook.ts
@@ -1,5 +1,5 @@
 /* eslint-disable import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure */
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { makeApiCall } from '@/fsd/5-shared/api';
 import {
@@ -46,6 +46,9 @@ export function useGuildPerformance() {
     // For a keyless member, the player-aware tabs are pinned to their own (un-anonymized) rows.
     const memberUserId = isMember && ownUserId ? ownUserId : undefined;
 
+    const authIdentity = `${userInfo?.tacticusGuildApiKey ?? ''}|${userInfo?.tacticusUserId ?? ''}|${userInfo?.guildTag ?? ''}`;
+    const previousIdentityReference = useRef<string | undefined>(undefined);
+
     const [current, setCurrent] = useState<LoadingOrData<TacticusGuildRaidResponse>>(cachedCurrent ?? LOADING);
     const [seasonHistory, setSeasonHistory] = useState<GuildSeasonHistoryResponse | undefined>(cachedHistory);
     const [sharedLeaderboards, setSharedLeaderboards] = useState<SharedLeaderboardsResponse | undefined>(
@@ -58,6 +61,29 @@ export function useGuildPerformance() {
     const [tokens, setTokens] = useState<GuildTokenEntry[] | typeof LOADING>(cachedTokens ?? LOADING);
     const [tokenError, setTokenError] = useState<string | undefined>();
     const [isRefreshing, setIsRefreshing] = useState(false);
+
+    useEffect(() => {
+        const previous = previousIdentityReference.current;
+        previousIdentityReference.current = authIdentity;
+        if (previous === undefined || previous === authIdentity) return;
+        cachedCurrent = undefined;
+        cachedHistory = undefined;
+        cachedSharedLeaderboards = undefined;
+        cachedGuildInfo = undefined;
+        cachedNames = undefined;
+        cachedRawNames = undefined;
+        cachedTokens = undefined;
+        cachedFetched = false;
+        setCurrent(LOADING);
+        setSeasonHistory(undefined);
+        setSharedLeaderboards(undefined);
+        setGuildInfo(undefined);
+        setHistoryError(undefined);
+        setNames(new Map());
+        setRawNames(undefined);
+        setTokens(LOADING);
+        setTokenError(undefined);
+    }, [authIdentity]);
 
     const currentData = current === LOADING ? undefined : current;
     const tokenData = tokens === LOADING ? undefined : tokens;
@@ -168,6 +194,7 @@ export function useGuildPerformance() {
             if (tokensResponse.data) {
                 cachedTokens = tokensResponse.data;
                 setTokens(tokensResponse.data);
+                setTokenError(undefined);
             } else if (tokensResponse.error) {
                 const error = tokensResponse.error;
                 setTokenError(typeof error === 'string' ? error : ((error as Error).message ?? 'Unknown error'));

--- a/src/fsd/1-pages/learn-guild-performance/guild-performance.tsx
+++ b/src/fsd/1-pages/learn-guild-performance/guild-performance.tsx
@@ -1,48 +1,16 @@
 /* eslint-disable import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure */
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useState } from 'react';
 
-import { makeApiCall } from '@/fsd/5-shared/api';
-import {
-    TacticusDamageType,
-    getTacticusGuildData,
-    safeParseGuildSeasonHistory,
-    safeParseGuildSeasonSummary,
-    safeParseSharedLeaderboards,
-    type GuildSeasonHistoryEntry,
-    type GuildSeasonHistoryResponse,
-    type SharedLeaderboardsResponse,
-    type TacticusGuildRaidResponse,
-} from '@/fsd/5-shared/lib/tacticus-api';
-import { useAuth } from '@/fsd/5-shared/model';
 import { DebugJson } from '@/fsd/5-shared/ui';
 
 import { NoKeyMessage, SeasonSelect, PlayerSelect } from './guild-performance.components';
-import { LOADING, type GuildMemberName, type GuildTokenEntry, type LoadingOrData } from './guild-performance.types';
-import { buildAvgDamageMap, getAllGuildPlayers, mergeSeasonSummaries } from './guild-performance.utils';
+import { useGuildPerformance } from './guild-performance.hook';
 import { DamageTab } from './tabs/damage-tab';
 import { HistoricalPerformanceTab } from './tabs/historical-performance-tab';
 import { LeaderboardTab } from './tabs/leaderboards-tab';
 import { LoopsTab } from './tabs/loops-tab';
 import { OverviewTab } from './tabs/overview-tab';
 import { PerformanceTab } from './tabs/performance-tab';
-
-// Module-level cache so data persists across navigations
-let cachedCurrent: TacticusGuildRaidResponse | undefined;
-let cachedHistory: GuildSeasonHistoryResponse | undefined;
-let cachedSharedLeaderboards: SharedLeaderboardsResponse | undefined;
-let cachedGuildInfo: { tag: string; name: string } | undefined;
-let cachedNames: Map<string, string> | undefined;
-let cachedRawNames: GuildMemberName[] | undefined;
-let cachedTokens: GuildTokenEntry[] | undefined;
-/** Gates the one-shot auto-fetch (the cache vars above can legitimately stay undefined for members). */
-let cachedFetched = false;
-
-function errorText(error: unknown): string | undefined {
-    if (error === undefined) return undefined;
-    if (typeof error === 'string') return error;
-    if (error instanceof Error) return error.message;
-    return String(error);
-}
 
 const TAB_IDS = ['overview', 'damage', 'leaderboards', 'loops', 'performance', 'historical-performance'] as const;
 type TabId = (typeof TAB_IDS)[number];
@@ -87,178 +55,35 @@ const TabBar = ({
 );
 
 export const GuildPerformance = () => {
-    const { userInfo } = useAuth();
-    // A keyed user (leader/co-leader) gets raw current-season data; a keyless member with a guild
-    // tag gets an anonymized aggregated summary instead. Either grants access to this page.
-    const hasGuildApiKey = !!userInfo?.tacticusGuildApiKey;
-    const hasGuildTag = !!userInfo?.guildTag;
-    const isMember = !hasGuildApiKey && hasGuildTag;
-    const hasAccess = hasGuildApiKey || hasGuildTag;
-    const ownUserId = userInfo?.tacticusUserId;
-    // For a keyless member, the player-aware tabs are pinned to their own (un-anonymized) rows.
-    const memberUserId = isMember && ownUserId ? ownUserId : undefined;
+    const {
+        hasGuildApiKey,
+        hasAccess,
+        isMember,
+        memberUserId,
+        currentData,
+        seasonHistory,
+        sharedLeaderboards,
+        guildInfo,
+        historyError,
+        names,
+        rawNames,
+        tokenData,
+        tokenError,
+        isRefreshing,
+        availableSeasons,
+        allPlayers,
+        avgDamageMap,
+        fetchData,
+        refreshSharedLeaderboards,
+    } = useGuildPerformance();
 
-    const [current, setCurrent] = useState<LoadingOrData<TacticusGuildRaidResponse>>(cachedCurrent ?? LOADING);
-    const [seasonHistory, setSeasonHistory] = useState<GuildSeasonHistoryResponse | undefined>(cachedHistory);
-    const [sharedLeaderboards, setSharedLeaderboards] = useState<SharedLeaderboardsResponse | undefined>(
-        cachedSharedLeaderboards
-    );
-    const [guildInfo, setGuildInfo] = useState<{ tag: string; name: string } | undefined>(cachedGuildInfo);
-    const [historyError, setHistoryError] = useState<string | undefined>();
-    const [names, setNames] = useState<Map<string, string>>(cachedNames ?? new Map());
-    const [rawNames, setRawNames] = useState<GuildMemberName[] | undefined>(cachedRawNames);
     // Members have no raw current-season data, so the Overview tab is empty for them — land on Damage.
     const [activeTab, setActiveTab] = useState<TabId>(isMember ? 'damage' : 'overview');
-    const [tokens, setTokens] = useState<GuildTokenEntry[] | typeof LOADING>(cachedTokens ?? LOADING);
-    const [tokenError, setTokenError] = useState<string | undefined>();
-    const [isRefreshing, setIsRefreshing] = useState(false);
-
-    const currentData = current === LOADING ? undefined : current;
-    const tokenData = tokens === LOADING ? undefined : tokens;
-
-    // --- sticky season + player selection (shared across tabs) ---
-    const availableSeasons = useMemo(() => {
-        const set = new Set<number>();
-        if (currentData?.season != undefined) set.add(currentData.season);
-        for (const season of seasonHistory?.seasonData ?? []) set.add(season.season);
-        return [...set].toSorted((a, b) => b - a);
-    }, [currentData, seasonHistory]);
-
     const [seasonOverride, setSeasonOverride] = useState<number | undefined>();
     const selectedSeason = seasonOverride ?? availableSeasons[0];
-
-    const allPlayers = useMemo(
-        () => getAllGuildPlayers(currentData?.entries ?? [], seasonHistory?.seasonData ?? [], names),
-        [currentData, seasonHistory, names]
-    );
     const [selectedUserId, setSelectedUserId] = useState<string | undefined>();
     // A keyless member is pinned to their own rows; a leader drives selection via the dropdown.
     const selectedPlayerId = isMember ? memberUserId : selectedUserId;
-
-    const avgDamageMap = useMemo(() => {
-        const allEntries = (currentData?.entries ?? []).filter(
-            entry => entry.damageType !== TacticusDamageType.Bomb && entry.remainingHp !== 0
-        );
-        return buildAvgDamageMap(allEntries);
-    }, [currentData]);
-
-    const refreshSharedLeaderboards = useCallback(async () => {
-        const response = await makeApiCall<unknown>('GET', 'guild/sharedLeaderboards');
-        const parsedSharedLb = response.data === undefined ? undefined : safeParseSharedLeaderboards(response.data);
-        cachedSharedLeaderboards = parsedSharedLb?.success ? parsedSharedLb.data : undefined;
-        setSharedLeaderboards(cachedSharedLeaderboards);
-    }, []);
-
-    const fetchData = useCallback(async () => {
-        setIsRefreshing(true);
-        try {
-            const [currentResponse, historyResponse, namesResponse, tokensResponse, sharedLbResponse, guildResponse] =
-                await Promise.all([
-                    makeApiCall<unknown>('GET', 'guild/raid?history=false'),
-                    makeApiCall<unknown>('GET', 'guild/raid?history=true'),
-                    makeApiCall<GuildMemberName[]>('GET', 'guild/members/names'),
-                    makeApiCall<GuildTokenEntry[]>('GET', 'guild/tokens'),
-                    makeApiCall<unknown>('GET', 'guild/sharedLeaderboards'),
-                    getTacticusGuildData(),
-                ]);
-
-            // --- names (shared) ---
-            const nameMap = new Map<string, string>();
-            for (const member of namesResponse.data ?? []) {
-                if (member.name) nameMap.set(member.userId, member.name);
-            }
-            // A keyless member sees their own (un-anonymized) rows; label them when not otherwise known.
-            if (isMember && ownUserId) nameMap.set(ownUserId, nameMap.get(ownUserId) ?? 'You');
-            cachedRawNames = namesResponse.data;
-            setRawNames(namesResponse.data);
-            cachedNames = nameMap;
-            setNames(nameMap);
-
-            // --- history (both user types return { sequenceNumber, seasonData }) ---
-            let seasonData: GuildSeasonHistoryEntry[] = [];
-            let sequenceNumber = 0;
-            let parseError: string | undefined;
-            if (historyResponse.data !== undefined) {
-                const parsed = safeParseGuildSeasonHistory(historyResponse.data);
-                if (parsed.success) {
-                    seasonData = parsed.data.seasonData;
-                    sequenceNumber = parsed.data.sequenceNumber;
-                } else {
-                    parseError = parsed.error.message;
-                }
-            }
-
-            if (hasGuildApiKey) {
-                // Leader: current season is the raw per-hit response, wrapped in { raidResponse: ... }.
-                const wrapper = currentResponse.data as { raidResponse?: TacticusGuildRaidResponse } | undefined;
-                const raw = wrapper?.raidResponse;
-                if (raw) {
-                    cachedCurrent = raw;
-                    setCurrent(raw);
-                }
-                const history = { sequenceNumber, seasonData };
-                cachedHistory = history;
-                setSeasonHistory(history);
-                setHistoryError(parseError);
-            } else {
-                // Member: current season is a single anonymized summary wrapped in { summary: ... }.
-                if (currentResponse.data !== undefined) {
-                    const wrapper = currentResponse.data as { summary?: unknown } | undefined;
-                    const summaryData = wrapper?.summary;
-                    if (summaryData !== undefined) {
-                        const parsed = safeParseGuildSeasonSummary(summaryData);
-                        if (parsed.success) {
-                            seasonData = mergeSeasonSummaries(seasonData, parsed.data);
-                        } else {
-                            parseError ??= parsed.error.message;
-                        }
-                    }
-                }
-                const history = { sequenceNumber, seasonData };
-                cachedHistory = history;
-                setSeasonHistory(history);
-                // Surface a backend access error (403 sharing-disabled / 404 not-a-member) when no data.
-                setHistoryError(
-                    seasonData.length === 0
-                        ? (errorText(currentResponse.error) ?? errorText(historyResponse.error) ?? parseError)
-                        : parseError
-                );
-            }
-
-            // --- tokens ---
-            if (tokensResponse.data) {
-                cachedTokens = tokensResponse.data;
-                setTokens(tokensResponse.data);
-            } else if (tokensResponse.error) {
-                const error = tokensResponse.error;
-                setTokenError(typeof error === 'string' ? error : ((error as Error).message ?? 'Unknown error'));
-                setTokens([]);
-            }
-
-            // --- shared leaderboards ---
-            const parsedSharedLb =
-                sharedLbResponse.data === undefined ? undefined : safeParseSharedLeaderboards(sharedLbResponse.data);
-            cachedSharedLeaderboards = parsedSharedLb?.success ? parsedSharedLb.data : undefined;
-            setSharedLeaderboards(cachedSharedLeaderboards);
-
-            // --- guild info ---
-            if (guildResponse.data?.guild) {
-                const { guildTag, name } = guildResponse.data.guild;
-                cachedGuildInfo = { tag: guildTag, name };
-                setGuildInfo({ tag: guildTag, name });
-            }
-
-            cachedFetched = true;
-        } finally {
-            setIsRefreshing(false);
-        }
-    }, [hasGuildApiKey, isMember, ownUserId]);
-
-    useEffect(() => {
-        if (!hasAccess) return;
-        if (cachedFetched) return;
-        void fetchData();
-    }, [hasAccess, fetchData]);
 
     if (!hasAccess) return <NoKeyMessage />;
 
@@ -273,7 +98,7 @@ export const GuildPerformance = () => {
                     }}
                     disabled={isRefreshing}
                     className="rounded border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700">
-                    {isRefreshing ? 'Refreshing\u2026' : 'Refresh'}
+                    {isRefreshing ? 'Refreshing…' : 'Refresh'}
                 </button>
             </div>
             {isMember && historyError !== undefined && (seasonHistory?.seasonData.length ?? 0) === 0 && (
@@ -281,11 +106,8 @@ export const GuildPerformance = () => {
                     {historyError}
                 </div>
             )}
-            <DebugJson label="guild/raid?history=false" value={currentData ?? 'loading\u2026'} />
-            <DebugJson
-                label="guild/raid?history=true (parsed)"
-                value={historyError ?? seasonHistory ?? 'loading\u2026'}
-            />
+            <DebugJson label="guild/raid?history=false" value={currentData ?? 'loading…'} />
+            <DebugJson label="guild/raid?history=true (parsed)" value={historyError ?? seasonHistory ?? 'loading…'} />
             <DebugJson label="guild/members/names" value={rawNames} />
             <DebugJson label="guild/tokens" value={tokenData ?? 'loading…'} />
             <DebugJson label="guild/sharedLeaderboards" value={sharedLeaderboards ?? 'loading…'} />

--- a/src/fsd/1-pages/learn-guild-performance/guild-performance.tsx
+++ b/src/fsd/1-pages/learn-guild-performance/guild-performance.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure */
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { DebugJson } from '@/fsd/5-shared/ui';
 
@@ -79,6 +79,9 @@ export const GuildPerformance = () => {
 
     // Members have no raw current-season data, so the Overview tab is empty for them — land on Damage.
     const [activeTab, setActiveTab] = useState<TabId>(isMember ? 'damage' : 'overview');
+    useEffect(() => {
+        setActiveTab(isMember ? 'damage' : 'overview');
+    }, [isMember]);
     const [seasonOverride, setSeasonOverride] = useState<number | undefined>();
     const selectedSeason = seasonOverride ?? availableSeasons[0];
     const [selectedUserId, setSelectedUserId] = useState<string | undefined>();

--- a/src/fsd/1-pages/learn-guild-performance/tabs/leaderboards-tab.tsx
+++ b/src/fsd/1-pages/learn-guild-performance/tabs/leaderboards-tab.tsx
@@ -1,14 +1,8 @@
 /* eslint-disable import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure */
 import { useEffect, useMemo, useState } from 'react';
 
-import { isLikelyUserId, obfuscateUserId } from '@/fsd/5-shared/lib';
 import {
-    TacticusDamageType,
-    TacticusEncounterType,
-    type GuildSeasonBossLeaderboard,
-    type GuildSeasonBossLeaderboardEntry,
     type GuildSeasonHistoryResponse,
-    type GuildSeasonSummary,
     type SharedLeaderboardsResponse,
     type TacticusGuildRaidEntry,
     type TacticusGuildRaidResponse,
@@ -17,7 +11,6 @@ import { Rarity, RarityMapper } from '@/fsd/5-shared/model';
 import { RarityIcon, UnitShardIcon } from '@/fsd/5-shared/ui/icons';
 
 import { CharactersService } from '@/fsd/4-entities/character/characters.service';
-import { MowsService } from '@/fsd/4-entities/mow';
 
 import { CompIcons } from '../guild-performance.components';
 import {
@@ -25,25 +18,26 @@ import {
     bossPrefixRoundIconMap,
     computeDefaultRaritiesFromRarities,
     getAvailableBossPrefixes,
-    getBossOrder,
     getBossPrefix,
-    resolvePlayerName,
     sortBossPrefixes,
     unitRoundIconMap,
 } from '../guild-performance.utils';
 
+import {
+    ALL_RARITIES,
+    buildGuildOptions,
+    buildLeaderboardGroups,
+    buildLeaderboardGroupsFromSummary,
+    mergeSharedEntries,
+    unitDisplayLabel,
+    type BossGroup,
+    type GuildOption,
+    type LeaderboardEntry,
+} from './leaderboards-tab.utils';
+
 // ---------------------------------------------------------------------------
 // Filter sub-components
 // ---------------------------------------------------------------------------
-
-const ALL_RARITIES: Rarity[] = [
-    Rarity.Common,
-    Rarity.Uncommon,
-    Rarity.Rare,
-    Rarity.Epic,
-    Rarity.Legendary,
-    Rarity.Mythic,
-];
 
 function RarityFilterGroup({ selected, onChange }: { selected: Rarity[]; onChange: (rarities: Rarity[]) => void }) {
     const toggle = (r: Rarity) => {
@@ -181,323 +175,6 @@ function NumberInput({ label, value, onChange }: { label: string; value: number;
             />
         </label>
     );
-}
-
-// ---------------------------------------------------------------------------
-// Leaderboard data model + logic
-// ---------------------------------------------------------------------------
-
-interface LeaderboardEntry {
-    /** Undefined when anonymized (another member in a keyless member's view). */
-    userId?: string;
-    displayName: string;
-    damage: number;
-    /** Hero unitIds followed by the machine-of-war unitId (if any). Empty when anonymized. */
-    comp: string[];
-}
-
-interface PrimeSlot {
-    unitId: string;
-    encounterIndex: number;
-    entries: LeaderboardEntry[];
-}
-
-interface BossGroup {
-    bossPrefix: string;
-    bossUnitId: string;
-    rarity: Rarity;
-    /** entry.set — used for sort order within same rarity */
-    set: number;
-    bossEntries: LeaderboardEntry[];
-    primeSlots: PrimeSlot[];
-}
-
-/** Top N hits at (unitId, rarity[, encounterIndex]), sorted by damage desc. A player may appear multiple times. */
-function buildTopN(
-    entries: TacticusGuildRaidEntry[],
-    unitId: string,
-    rarity: Rarity,
-    names: Map<string, string>,
-    maxCount: number,
-    encounterIndex?: number
-): LeaderboardEntry[] {
-    return entries
-        .filter(entry => {
-            if (entry.unitId !== unitId || entry.rarity !== rarity) return false;
-            if (encounterIndex !== undefined && entry.encounterIndex !== encounterIndex) return false;
-            if (entry.damageType === TacticusDamageType.Bomb) return false;
-            return true;
-        })
-        .toSorted((a, b) => b.damageDealt - a.damageDealt)
-        .slice(0, maxCount)
-        .map(entry => ({
-            userId: entry.userId,
-            displayName: resolvePlayerName(entry.userId, names),
-            damage: entry.damageDealt,
-            comp: [
-                ...entry.heroDetails.map(hero => hero.unitId),
-                ...(entry.machineOfWarDetails ? [entry.machineOfWarDetails.unitId] : []),
-            ],
-        }));
-}
-
-/** Maps aggregated leaderboard entries (historical seasons) into {@link LeaderboardEntry} rows. */
-function toLeaderboardEntries(
-    entries: GuildSeasonBossLeaderboardEntry[],
-    names: Map<string, string>
-): LeaderboardEntry[] {
-    return entries.map(entry => ({
-        userId: entry.playerId,
-        displayName: resolvePlayerName(entry.playerId, names),
-        damage: entry.damage,
-        comp: entry.comp,
-    }));
-}
-
-function buildLeaderboardGroups(
-    entries: TacticusGuildRaidEntry[],
-    selectedBossPrefixes: string[],
-    names: Map<string, string>,
-    bossTopN: number,
-    primeTopN: number
-): BossGroup[] {
-    type BossSlot = { unitId: string; set: number; rarity: Rarity; bossPrefix: string };
-    const bossSlots = new Map<string, BossSlot>();
-
-    for (const entry of entries) {
-        if (entry.encounterType !== TacticusEncounterType.Boss) continue;
-        if (entry.damageType === TacticusDamageType.Bomb) continue;
-        const bossPrefix = /^(GuildBoss\d+)/.exec(entry.unitId)?.[1] ?? entry.unitId;
-        if (selectedBossPrefixes.length > 0 && !selectedBossPrefixes.includes(bossPrefix)) continue;
-        // Key = bossPrefix:rarity so each boss family+rarity gets one leaderboard
-        const key = `${bossPrefix}:${entry.rarity}`;
-        if (!bossSlots.has(key))
-            bossSlots.set(key, { unitId: entry.unitId, set: entry.set, rarity: entry.rarity, bossPrefix });
-    }
-
-    // Prime slots: keyed by bossPrefix:rarity, then by prime unitId:encounterIndex
-    const primeSlotMap = new Map<string, Map<string, { unitId: string; encounterIndex: number }>>();
-    for (const entry of entries) {
-        if (entry.encounterType !== TacticusEncounterType.SideBoss) continue;
-        if (entry.damageType === TacticusDamageType.Bomb) continue;
-        const bossPrefix = /^(GuildBoss\d+)/.exec(entry.unitId)?.[1] ?? entry.unitId;
-        if (selectedBossPrefixes.length > 0 && !selectedBossPrefixes.includes(bossPrefix)) continue;
-        const groupKey = `${bossPrefix}:${entry.rarity}`;
-        let group = primeSlotMap.get(groupKey);
-        if (group === undefined) {
-            group = new Map();
-            primeSlotMap.set(groupKey, group);
-        }
-        const slotKey = `${entry.unitId}:${entry.encounterIndex}`;
-        if (!group.has(slotKey)) group.set(slotKey, { unitId: entry.unitId, encounterIndex: entry.encounterIndex });
-    }
-
-    const groups: BossGroup[] = [];
-    for (const [groupKey, slot] of bossSlots) {
-        const primeSlots = [...(primeSlotMap.get(groupKey)?.values() ?? [])]
-            .toSorted((a, b) => a.encounterIndex - b.encounterIndex)
-            .map(ps => ({
-                unitId: ps.unitId,
-                encounterIndex: ps.encounterIndex,
-                entries: buildTopN(entries, ps.unitId, slot.rarity, names, primeTopN, ps.encounterIndex),
-            }))
-            .filter(ps => ps.entries.length > 0);
-        groups.push({
-            bossPrefix: slot.bossPrefix,
-            bossUnitId: slot.unitId,
-            rarity: slot.rarity,
-            set: slot.set,
-            bossEntries: buildTopN(entries, slot.unitId, slot.rarity, names, bossTopN),
-            primeSlots,
-        });
-    }
-    // Sort each composition by unitId, but maintaining the machine of war at the end if present.
-    for (const group of groups) {
-        for (const entry of group.bossEntries) {
-            const heroUnits = entry.comp.filter(unitId => MowsService.resolveToStatic(unitId) === undefined).toSorted();
-            const mow = entry.comp.find(unitId => MowsService.resolveToStatic(unitId) !== undefined);
-            entry.comp = [...heroUnits, ...(mow ? [mow] : [])];
-        }
-    }
-
-    // Sort: rarity desc, then set desc
-    return groups.toSorted((a, b) => {
-        if (a.rarity !== b.rarity) return b.rarity - a.rarity;
-        return b.set - a.set;
-    });
-}
-
-/**
- * Reconstructs leaderboard groups from a historical season aggregate. Each leaderboard is already
- * the top-5 single hits for one enemy (boss or prime, top-2 rarities only); we re-group a boss with
- * its primes by GuildBoss{N} prefix + rarity. `bossTopN`/`primeTopN` can only trim the stored five.
- */
-function buildLeaderboardGroupsFromSummary(
-    summary: GuildSeasonSummary,
-    selectedRarities: Rarity[],
-    selectedBossPrefixes: string[],
-    names: Map<string, string>,
-    bossTopN: number,
-    primeTopN: number
-): BossGroup[] {
-    interface GroupAccumulator {
-        bossPrefix: string;
-        rarity: Rarity;
-        bossUnitId: string;
-        bossEntries: LeaderboardEntry[];
-        primeSlots: PrimeSlot[];
-    }
-    const groups = new Map<string, GroupAccumulator>();
-
-    for (const board of summary.leaderboards) {
-        const { enemyId, rarity: rarityName, encounterIndex } = board.enemyInfo;
-        const rarity = RarityMapper.stringToNumber[rarityName];
-        if (!selectedRarities.includes(rarity)) continue;
-        const bossPrefix = getBossPrefix(enemyId);
-        if (selectedBossPrefixes.length > 0 && !selectedBossPrefixes.includes(bossPrefix)) continue;
-
-        const key = `${bossPrefix}:${rarity}`;
-        let group = groups.get(key);
-        if (group === undefined) {
-            group = { bossPrefix, rarity, bossUnitId: '', bossEntries: [], primeSlots: [] };
-            groups.set(key, group);
-        }
-        const entries = toLeaderboardEntries(board.entries, names);
-        if (encounterIndex === 0) {
-            group.bossUnitId = enemyId;
-            group.bossEntries = entries.slice(0, bossTopN);
-        } else {
-            group.primeSlots.push({ unitId: enemyId, encounterIndex, entries: entries.slice(0, primeTopN) });
-        }
-    }
-
-    return [...groups.values()]
-        .map(group => ({
-            bossPrefix: group.bossPrefix,
-            bossUnitId: group.bossUnitId,
-            rarity: group.rarity,
-            // The aggregate has no `set`; the GuildBoss{N} rotation order stands in for it.
-            set: getBossOrder(group.bossUnitId),
-            bossEntries: group.bossEntries,
-            primeSlots: group.primeSlots
-                .toSorted((a, b) => a.encounterIndex - b.encounterIndex)
-                .filter(prime => prime.entries.length > 0),
-        }))
-        .toSorted((a, b) => {
-            if (a.rarity !== b.rarity) return b.rarity - a.rarity;
-            return b.set - a.set;
-        });
-}
-
-// ---------------------------------------------------------------------------
-// Guild-filter data model + helpers
-// ---------------------------------------------------------------------------
-
-interface GuildOption {
-    guildTag: string;
-    displayName: string;
-}
-
-/** Returns one entry per non-own guild present in the shared leaderboard data, alphabetically sorted.
- *  Guilds with duplicate display names get their tag appended for disambiguation. */
-function buildGuildOptions(leaderboards: GuildSeasonBossLeaderboard[]): GuildOption[] {
-    const seen = new Map<string, string>(); // tag → raw display name
-    for (const lb of leaderboards) {
-        for (const entry of lb.entries) {
-            if (entry.isOwnGuild || entry.guildTag === undefined || seen.has(entry.guildTag)) continue;
-            seen.set(entry.guildTag, entry.playerId ?? entry.guildTag);
-        }
-    }
-
-    const nameCounts = new Map<string, number>();
-    for (const displayName of seen.values()) {
-        nameCounts.set(displayName, (nameCounts.get(displayName) ?? 0) + 1);
-    }
-
-    return [...seen.entries()]
-        .map(([tag, displayName]) => ({
-            guildTag: tag,
-            displayName: (nameCounts.get(displayName) ?? 0) > 1 ? `${displayName} (${tag})` : displayName,
-        }))
-        .toSorted((a, b) => a.displayName.localeCompare(b.displayName));
-}
-
-/** Merges entries from the selected guilds (non-own) into the existing boss groups, re-sorting after. */
-function mergeSharedEntries(
-    groups: BossGroup[],
-    sharedLeaderboards: GuildSeasonBossLeaderboard[],
-    selectedGuildTags: Set<string>,
-    bossTopN: number,
-    primeTopN: number
-): BossGroup[] {
-    // key: `${enemyId}:${rarityNumber}:${encounterIndex}`
-    const sharedByKey = new Map<string, LeaderboardEntry[]>();
-    for (const lb of sharedLeaderboards) {
-        const rarityNumber = RarityMapper.stringToNumber[lb.enemyInfo.rarity];
-        const key = `${lb.enemyInfo.enemyId}:${rarityNumber}:${lb.enemyInfo.encounterIndex}`;
-        for (const entry of lb.entries) {
-            if (entry.isOwnGuild || entry.guildTag === undefined || !selectedGuildTags.has(entry.guildTag)) continue;
-            const mapped: LeaderboardEntry = {
-                displayName: isLikelyUserId(entry.playerId ?? '')
-                    ? obfuscateUserId(entry.playerId ?? '')
-                    : (entry.playerId ?? entry.guildTag),
-                damage: entry.damage,
-                comp: entry.comp,
-            };
-            const bucket = sharedByKey.get(key);
-            if (bucket) bucket.push(mapped);
-            else sharedByKey.set(key, [mapped]);
-        }
-    }
-
-    if (sharedByKey.size === 0) return groups;
-
-    return groups.map(group => {
-        const bossKey = `${group.bossUnitId}:${group.rarity}:0`;
-        const sharedBossEntries = sharedByKey.get(bossKey) ?? [];
-        const bossEntries = [...group.bossEntries, ...sharedBossEntries]
-            .toSorted((a, b) => b.damage - a.damage)
-            .slice(0, bossTopN);
-
-        const primeSlots = group.primeSlots.map(prime => {
-            const primeKey = `${prime.unitId}:${group.rarity}:${prime.encounterIndex}`;
-            const sharedPrimeEntries = sharedByKey.get(primeKey) ?? [];
-            const entries = [...prime.entries, ...sharedPrimeEntries]
-                .toSorted((a, b) => b.damage - a.damage)
-                .slice(0, primeTopN);
-            return { ...prime, entries };
-        });
-
-        return { ...group, bossEntries, primeSlots };
-    });
-}
-
-// ---------------------------------------------------------------------------
-/**
- * Given a GuildBoss unit ID, returns the best display name:
- * - For main bosses: uses the boss family name from bossPrefixDisplayNames
- * - For primes/minions: extracts the last two CamelCase words (the snowprint ID),
- *   looks up the character, and returns their shortName if found, otherwise the
- *   last-two-words string, otherwise the raw unitId.
- */
-function unitDisplayLabel(unitId: string): string {
-    const bossPrefix = /^(GuildBoss\d+)/.exec(unitId)?.[1];
-
-    // Prime/minion: strip the leading GuildBoss{N}(MiniBoss|Minion){N} part
-    const primeMatch = /(?:MiniBoss|Minion)\d+(.+)/.exec(unitId);
-    if (primeMatch) {
-        const tail = primeMatch[1]; // e.g. "EldarAutarch", "TyranWarriorLeviathan", "ThousInfernalMaster"
-        const snowprintId = tail.charAt(0).toLowerCase() + tail.slice(1);
-        const character = CharactersService.getUnit(snowprintId);
-        if (character) return character.shortName;
-        // Fallback: split CamelCase into readable words
-        return tail.split(/(?=[A-Z])/).join(' ');
-    }
-
-    // Main boss: use boss family name
-    if (bossPrefix !== undefined) return bossPrefixDisplayNames[bossPrefix] ?? unitId;
-
-    return unitId;
 }
 
 function MedalBadge({ rank }: { rank: number }) {

--- a/src/fsd/1-pages/learn-guild-performance/tabs/leaderboards-tab.utils.ts
+++ b/src/fsd/1-pages/learn-guild-performance/tabs/leaderboards-tab.utils.ts
@@ -1,0 +1,324 @@
+/* eslint-disable import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure */
+import { isLikelyUserId, obfuscateUserId } from '@/fsd/5-shared/lib';
+import {
+    TacticusDamageType,
+    TacticusEncounterType,
+    type GuildSeasonBossLeaderboard,
+    type GuildSeasonBossLeaderboardEntry,
+    type GuildSeasonSummary,
+    type TacticusGuildRaidEntry,
+} from '@/fsd/5-shared/lib/tacticus-api';
+import { Rarity, RarityMapper } from '@/fsd/5-shared/model';
+
+import { CharactersService } from '@/fsd/4-entities/character/characters.service';
+import { MowsService } from '@/fsd/4-entities/mow';
+
+import { bossPrefixDisplayNames, getBossOrder, getBossPrefix, resolvePlayerName } from '../guild-performance.utils';
+
+export const ALL_RARITIES: Rarity[] = [
+    Rarity.Common,
+    Rarity.Uncommon,
+    Rarity.Rare,
+    Rarity.Epic,
+    Rarity.Legendary,
+    Rarity.Mythic,
+];
+
+export interface LeaderboardEntry {
+    /** Undefined when anonymized (another member in a keyless member's view). */
+    userId?: string;
+    displayName: string;
+    damage: number;
+    /** Hero unitIds followed by the machine-of-war unitId (if any). Empty when anonymized. */
+    comp: string[];
+}
+
+export interface PrimeSlot {
+    unitId: string;
+    encounterIndex: number;
+    entries: LeaderboardEntry[];
+}
+
+export interface BossGroup {
+    bossPrefix: string;
+    bossUnitId: string;
+    rarity: Rarity;
+    /** entry.set — used for sort order within same rarity */
+    set: number;
+    bossEntries: LeaderboardEntry[];
+    primeSlots: PrimeSlot[];
+}
+
+export interface GuildOption {
+    guildTag: string;
+    displayName: string;
+}
+
+/** Top N hits at (unitId, rarity[, encounterIndex]), sorted by damage desc. A player may appear multiple times. */
+export function buildTopN(
+    entries: TacticusGuildRaidEntry[],
+    unitId: string,
+    rarity: Rarity,
+    names: Map<string, string>,
+    maxCount: number,
+    encounterIndex?: number
+): LeaderboardEntry[] {
+    return entries
+        .filter(entry => {
+            if (entry.unitId !== unitId || entry.rarity !== rarity) return false;
+            if (encounterIndex !== undefined && entry.encounterIndex !== encounterIndex) return false;
+            if (entry.damageType === TacticusDamageType.Bomb) return false;
+            return true;
+        })
+        .toSorted((a, b) => b.damageDealt - a.damageDealt)
+        .slice(0, maxCount)
+        .map(entry => ({
+            userId: entry.userId,
+            displayName: resolvePlayerName(entry.userId, names),
+            damage: entry.damageDealt,
+            comp: [
+                ...entry.heroDetails.map(hero => hero.unitId),
+                ...(entry.machineOfWarDetails ? [entry.machineOfWarDetails.unitId] : []),
+            ],
+        }));
+}
+
+/** Maps aggregated leaderboard entries (historical seasons) into {@link LeaderboardEntry} rows. */
+export function toLeaderboardEntries(
+    entries: GuildSeasonBossLeaderboardEntry[],
+    names: Map<string, string>
+): LeaderboardEntry[] {
+    return entries.map(entry => ({
+        userId: entry.playerId,
+        displayName: resolvePlayerName(entry.playerId, names),
+        damage: entry.damage,
+        comp: entry.comp,
+    }));
+}
+
+export function buildLeaderboardGroups(
+    entries: TacticusGuildRaidEntry[],
+    selectedBossPrefixes: string[],
+    names: Map<string, string>,
+    bossTopN: number,
+    primeTopN: number
+): BossGroup[] {
+    type BossSlot = { unitId: string; set: number; rarity: Rarity; bossPrefix: string };
+    const bossSlots = new Map<string, BossSlot>();
+
+    for (const entry of entries) {
+        if (entry.encounterType !== TacticusEncounterType.Boss) continue;
+        if (entry.damageType === TacticusDamageType.Bomb) continue;
+        const bossPrefix = /^(GuildBoss\d+)/.exec(entry.unitId)?.[1] ?? entry.unitId;
+        if (selectedBossPrefixes.length > 0 && !selectedBossPrefixes.includes(bossPrefix)) continue;
+        const key = `${bossPrefix}:${entry.rarity}`;
+        if (!bossSlots.has(key))
+            bossSlots.set(key, { unitId: entry.unitId, set: entry.set, rarity: entry.rarity, bossPrefix });
+    }
+
+    const primeSlotMap = new Map<string, Map<string, { unitId: string; encounterIndex: number }>>();
+    for (const entry of entries) {
+        if (entry.encounterType !== TacticusEncounterType.SideBoss) continue;
+        if (entry.damageType === TacticusDamageType.Bomb) continue;
+        const bossPrefix = /^(GuildBoss\d+)/.exec(entry.unitId)?.[1] ?? entry.unitId;
+        if (selectedBossPrefixes.length > 0 && !selectedBossPrefixes.includes(bossPrefix)) continue;
+        const groupKey = `${bossPrefix}:${entry.rarity}`;
+        let group = primeSlotMap.get(groupKey);
+        if (group === undefined) {
+            group = new Map();
+            primeSlotMap.set(groupKey, group);
+        }
+        const slotKey = `${entry.unitId}:${entry.encounterIndex}`;
+        if (!group.has(slotKey)) group.set(slotKey, { unitId: entry.unitId, encounterIndex: entry.encounterIndex });
+    }
+
+    const groups: BossGroup[] = [];
+    for (const [groupKey, slot] of bossSlots) {
+        const primeSlots = [...(primeSlotMap.get(groupKey)?.values() ?? [])]
+            .toSorted((a, b) => a.encounterIndex - b.encounterIndex)
+            .map(ps => ({
+                unitId: ps.unitId,
+                encounterIndex: ps.encounterIndex,
+                entries: buildTopN(entries, ps.unitId, slot.rarity, names, primeTopN, ps.encounterIndex),
+            }))
+            .filter(ps => ps.entries.length > 0);
+        groups.push({
+            bossPrefix: slot.bossPrefix,
+            bossUnitId: slot.unitId,
+            rarity: slot.rarity,
+            set: slot.set,
+            bossEntries: buildTopN(entries, slot.unitId, slot.rarity, names, bossTopN),
+            primeSlots,
+        });
+    }
+    for (const group of groups) {
+        for (const entry of group.bossEntries) {
+            const heroUnits = entry.comp.filter(unitId => MowsService.resolveToStatic(unitId) === undefined).toSorted();
+            const mow = entry.comp.find(unitId => MowsService.resolveToStatic(unitId) !== undefined);
+            entry.comp = [...heroUnits, ...(mow ? [mow] : [])];
+        }
+    }
+
+    return groups.toSorted((a, b) => {
+        if (a.rarity !== b.rarity) return b.rarity - a.rarity;
+        return b.set - a.set;
+    });
+}
+
+/**
+ * Reconstructs leaderboard groups from a historical season aggregate. Each leaderboard is already
+ * the top-5 single hits for one enemy (boss or prime, top-2 rarities only); we re-group a boss with
+ * its primes by GuildBoss{N} prefix + rarity. `bossTopN`/`primeTopN` can only trim the stored five.
+ */
+export function buildLeaderboardGroupsFromSummary(
+    summary: GuildSeasonSummary,
+    selectedRarities: Rarity[],
+    selectedBossPrefixes: string[],
+    names: Map<string, string>,
+    bossTopN: number,
+    primeTopN: number
+): BossGroup[] {
+    interface GroupAccumulator {
+        bossPrefix: string;
+        rarity: Rarity;
+        bossUnitId: string;
+        bossEntries: LeaderboardEntry[];
+        primeSlots: PrimeSlot[];
+    }
+    const groups = new Map<string, GroupAccumulator>();
+
+    for (const board of summary.leaderboards) {
+        const { enemyId, rarity: rarityName, encounterIndex } = board.enemyInfo;
+        const rarity = RarityMapper.stringToNumber[rarityName];
+        if (!selectedRarities.includes(rarity)) continue;
+        const bossPrefix = getBossPrefix(enemyId);
+        if (selectedBossPrefixes.length > 0 && !selectedBossPrefixes.includes(bossPrefix)) continue;
+
+        const key = `${bossPrefix}:${rarity}`;
+        let group = groups.get(key);
+        if (group === undefined) {
+            group = { bossPrefix, rarity, bossUnitId: '', bossEntries: [], primeSlots: [] };
+            groups.set(key, group);
+        }
+        const entries = toLeaderboardEntries(board.entries, names);
+        if (encounterIndex === 0) {
+            group.bossUnitId = enemyId;
+            group.bossEntries = entries.slice(0, bossTopN);
+        } else {
+            group.primeSlots.push({ unitId: enemyId, encounterIndex, entries: entries.slice(0, primeTopN) });
+        }
+    }
+
+    return [...groups.values()]
+        .map(group => ({
+            bossPrefix: group.bossPrefix,
+            bossUnitId: group.bossUnitId,
+            rarity: group.rarity,
+            set: getBossOrder(group.bossUnitId),
+            bossEntries: group.bossEntries,
+            primeSlots: group.primeSlots
+                .toSorted((a, b) => a.encounterIndex - b.encounterIndex)
+                .filter(prime => prime.entries.length > 0),
+        }))
+        .toSorted((a, b) => {
+            if (a.rarity !== b.rarity) return b.rarity - a.rarity;
+            return b.set - a.set;
+        });
+}
+
+/** Returns one entry per non-own guild present in the shared leaderboard data, alphabetically sorted.
+ *  Guilds with duplicate display names get their tag appended for disambiguation. */
+export function buildGuildOptions(leaderboards: GuildSeasonBossLeaderboard[]): GuildOption[] {
+    const seen = new Map<string, string>(); // tag → raw display name
+    for (const lb of leaderboards) {
+        for (const entry of lb.entries) {
+            if (entry.isOwnGuild || entry.guildTag === undefined || seen.has(entry.guildTag)) continue;
+            seen.set(entry.guildTag, entry.playerId ?? entry.guildTag);
+        }
+    }
+
+    const nameCounts = new Map<string, number>();
+    for (const displayName of seen.values()) {
+        nameCounts.set(displayName, (nameCounts.get(displayName) ?? 0) + 1);
+    }
+
+    return [...seen.entries()]
+        .map(([tag, displayName]) => ({
+            guildTag: tag,
+            displayName: (nameCounts.get(displayName) ?? 0) > 1 ? `${displayName} (${tag})` : displayName,
+        }))
+        .toSorted((a, b) => a.displayName.localeCompare(b.displayName));
+}
+
+/** Merges entries from the selected guilds (non-own) into the existing boss groups, re-sorting after. */
+export function mergeSharedEntries(
+    groups: BossGroup[],
+    sharedLeaderboards: GuildSeasonBossLeaderboard[],
+    selectedGuildTags: Set<string>,
+    bossTopN: number,
+    primeTopN: number
+): BossGroup[] {
+    const sharedByKey = new Map<string, LeaderboardEntry[]>();
+    for (const lb of sharedLeaderboards) {
+        const rarityNumber = RarityMapper.stringToNumber[lb.enemyInfo.rarity];
+        const key = `${lb.enemyInfo.enemyId}:${rarityNumber}:${lb.enemyInfo.encounterIndex}`;
+        for (const entry of lb.entries) {
+            if (entry.isOwnGuild || entry.guildTag === undefined || !selectedGuildTags.has(entry.guildTag)) continue;
+            const mapped: LeaderboardEntry = {
+                displayName: isLikelyUserId(entry.playerId ?? '')
+                    ? obfuscateUserId(entry.playerId ?? '')
+                    : (entry.playerId ?? entry.guildTag),
+                damage: entry.damage,
+                comp: entry.comp,
+            };
+            const bucket = sharedByKey.get(key);
+            if (bucket) bucket.push(mapped);
+            else sharedByKey.set(key, [mapped]);
+        }
+    }
+
+    if (sharedByKey.size === 0) return groups;
+
+    return groups.map(group => {
+        const bossKey = `${group.bossUnitId}:${group.rarity}:0`;
+        const sharedBossEntries = sharedByKey.get(bossKey) ?? [];
+        const bossEntries = [...group.bossEntries, ...sharedBossEntries]
+            .toSorted((a, b) => b.damage - a.damage)
+            .slice(0, bossTopN);
+
+        const primeSlots = group.primeSlots.map(prime => {
+            const primeKey = `${prime.unitId}:${group.rarity}:${prime.encounterIndex}`;
+            const sharedPrimeEntries = sharedByKey.get(primeKey) ?? [];
+            const entries = [...prime.entries, ...sharedPrimeEntries]
+                .toSorted((a, b) => b.damage - a.damage)
+                .slice(0, primeTopN);
+            return { ...prime, entries };
+        });
+
+        return { ...group, bossEntries, primeSlots };
+    });
+}
+
+/**
+ * Given a GuildBoss unit ID, returns the best display name:
+ * - For main bosses: uses the boss family name from bossPrefixDisplayNames
+ * - For primes/minions: extracts the last two CamelCase words (the snowprint ID),
+ *   looks up the character, and returns their shortName if found, otherwise the
+ *   last-two-words string, otherwise the raw unitId.
+ */
+export function unitDisplayLabel(unitId: string): string {
+    const bossPrefix = /^(GuildBoss\d+)/.exec(unitId)?.[1];
+
+    const primeMatch = /(?:MiniBoss|Minion)\d+(.+)/.exec(unitId);
+    if (primeMatch) {
+        const tail = primeMatch[1];
+        const snowprintId = tail.charAt(0).toLowerCase() + tail.slice(1);
+        const character = CharactersService.getUnit(snowprintId);
+        if (character) return character.shortName;
+        return tail.split(/(?=[A-Z])/).join(' ');
+    }
+
+    if (bossPrefix !== undefined) return bossPrefixDisplayNames[bossPrefix] ?? unitId;
+
+    return unitId;
+}

--- a/src/fsd/1-pages/plan-teams2/team-filter.utils.ts
+++ b/src/fsd/1-pages/plan-teams2/team-filter.utils.ts
@@ -1,0 +1,8 @@
+import { ITeam2 } from './models';
+
+/** Returns the set of snowprintIds for all chars and mows belonging to the named teams. */
+export function getUnitIdsFromTeamNames(teams: ITeam2[], teamNames: string[]): Set<string> {
+    if (teamNames.length === 0) return new Set();
+    const nameSet = new Set(teamNames);
+    return new Set(teams.filter(t => nameSet.has(t.name)).flatMap(t => [...t.chars, ...(t.mows ?? [])]));
+}

--- a/src/fsd/3-features/tacticus-integration/tacticus-integration.dialog.tsx
+++ b/src/fsd/3-features/tacticus-integration/tacticus-integration.dialog.tsx
@@ -27,7 +27,6 @@ interface Props extends DialogProps {
 }
 
 function buildErrorMessage(error: string | Error | undefined): string {
-    console.trace('error: ', error);
     const baseMessage = 'Failed to update settings';
     const detail = typeof error === 'string' ? error : error?.message;
     return detail ? `${baseMessage}: ${detail}` : baseMessage;

--- a/src/reducers/store.provider2.tsx
+++ b/src/reducers/store.provider2.tsx
@@ -639,7 +639,6 @@ export const StoreProvider = ({ children }: React.PropsWithChildren) => {
                     combinedGuildTags: combinedGuildTags ?? undefined,
                     guildTag,
                 });
-                console.log('[users/me] setUserInfo combinedGuildTags →', combinedGuildTags ?? undefined);
                 const localModifiedDateTicks = modifiedDateTicksReference.current;
 
                 const hasDataConflict = localModifiedDateTicks !== serverModifiedDateTicks;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added raid team filtering to restrict roster snapshots to selected teams
  * Visualized API key errors in roster view with obfuscated member identification
  * Created raid team dropdown filter component

* **Refactor**
  * Moved Save button to main toolbar with automatic change detection and disable state
  * Extracted leaderboard building logic into dedicated utility module
  * Refactored guild performance data fetching using a custom hook for improved state management

* **Chores**
  * Removed debug console statements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->