### PR TITLE
Add subtitles and fill missing breadcrumb descriptions across all routes

### DIFF
--- a/src/fsd/0-app/routing/desktop-routes.tsx
+++ b/src/fsd/0-app/routing/desktop-routes.tsx
@@ -88,7 +88,12 @@ export const globalPlanRoutes: RouteObject[] = [
     lreLazyRoute,
     {
         path: 'plan/leMasterTable',
-        handle: { section: 'Plan', title: 'LE Master Table' },
+        handle: {
+            section: 'Plan',
+            title: 'LE Master Table',
+            description:
+                'Cross-event overview of all Legendary Release Events with point thresholds and character picks.',
+        },
         async lazy() {
             const { MasterTable } = await import('@/fsd/1-pages/plan-lre/master-table');
             return { Component: MasterTable };

--- a/src/fsd/1-pages/guild-war-layout/guild-war-zones.route.tsx
+++ b/src/fsd/1-pages/guild-war-layout/guild-war-zones.route.tsx
@@ -4,7 +4,8 @@ export const guildWarZonesLazyRoute: RouteObject = {
     path: 'plan/guildWar/zones',
     handle: {
         section: 'Plan',
-        title: 'Guild War Zones',
+        title: 'Guild War',
+        subtitle: 'Zones',
         description: "Map out your guild's full zone layout for the ongoing war.",
     },
     async lazy() {

--- a/src/fsd/1-pages/input-equipment/equipment.route.tsx
+++ b/src/fsd/1-pages/input-equipment/equipment.route.tsx
@@ -2,7 +2,11 @@ import { RouteObject } from 'react-router-dom';
 
 export const equipmentLazyRoute: RouteObject = {
     path: 'input/equipment',
-    handle: { section: 'My Game', title: 'Equipment' },
+    handle: {
+        section: 'My Game',
+        title: 'Equipment',
+        description: 'Track which equipment pieces your characters have equipped and their current forge levels.',
+    },
     async lazy() {
         const { Equipment } = await import('./equipment');
         return { Component: Equipment };

--- a/src/fsd/1-pages/input-guild-roster-snapshots/guild-roster-snapshots.route.tsx
+++ b/src/fsd/1-pages/input-guild-roster-snapshots/guild-roster-snapshots.route.tsx
@@ -2,6 +2,11 @@ import { RouteObject } from 'react-router-dom';
 
 export const guildRosterSnapshotsLazyRoute: RouteObject = {
     path: 'input/guild-roster-snapshots',
+    handle: {
+        section: 'My Game',
+        title: 'Guild Roster Snapshots',
+        description: 'Guild leaders: pull live roster snapshots for all members via the Tacticus API.',
+    },
     async lazy() {
         const { GuildRosterSnapshots } = await import('./guild-roster-snapshots');
         return { Component: GuildRosterSnapshots };

--- a/src/fsd/1-pages/input-onslaught/onslaught.route.tsx
+++ b/src/fsd/1-pages/input-onslaught/onslaught.route.tsx
@@ -6,7 +6,7 @@ export const onslaughtLazyRoute: RouteObject = {
         section: 'My Game',
         title: 'Onslaught',
         description:
-            'Set your current sector and tier for each alliance. These values are used to estimate shards earned per onslaught token when computing ascension goal timelines.',
+            'Log your current sector and tier per alliance to estimate shard income across ascension goal timelines.',
     },
     async lazy() {
         const { Onslaught } = await import('./onslaught');

--- a/src/fsd/1-pages/input-resources/resources.route.tsx
+++ b/src/fsd/1-pages/input-resources/resources.route.tsx
@@ -5,7 +5,7 @@ export const resourcesLazyRoute: RouteObject = {
     handle: {
         section: 'My Game',
         title: 'Resources',
-        description: 'Log your daily gold, gems, and other currency income to inform planning.',
+        description: 'Overview of your gold, gems, and other currency income sources.',
     },
     async lazy() {
         const { Resources } = await import('./resources');

--- a/src/fsd/1-pages/input-xp-income/xp-income.route.tsx
+++ b/src/fsd/1-pages/input-xp-income/xp-income.route.tsx
@@ -5,7 +5,7 @@ export const xpIncomeLazyRoute: RouteObject = {
     handle: {
         section: 'My Game',
         title: 'XP Income',
-        description: 'Pick your codex rarity, then tell us how many you earn per day.',
+        description: 'Log your daily codex income to project character XP gain and level-up timelines.',
     },
     async lazy() {
         const { XpIncome } = await import('./xp-income');

--- a/src/fsd/1-pages/learn-guild-performance/guild-performance.route.tsx
+++ b/src/fsd/1-pages/learn-guild-performance/guild-performance.route.tsx
@@ -2,6 +2,11 @@ import { RouteObject } from 'react-router-dom';
 
 export const guildPerformanceLazyRoute: RouteObject = {
     path: 'learn/guildPerformance',
+    handle: {
+        section: 'Library',
+        title: 'Guild Performance',
+        description: 'Analyse guild raid performance — damage, leaderboards, loops, and token usage per season.',
+    },
     async lazy() {
         const { GuildPerformance } = await import('./guild-performance');
         return { Component: GuildPerformance };

--- a/src/fsd/1-pages/plan-ces/ces.route.tsx
+++ b/src/fsd/1-pages/plan-ces/ces.route.tsx
@@ -4,8 +4,8 @@ export const cesRoute: RouteObject = {
     path: 'plan/ces',
     handle: {
         section: 'Plan',
-        title: 'CES',
-        description: 'Track your progress and rewards across Champion Extermination Squad events.',
+        title: 'Campaign Events',
+        description: 'Plan your character selections and track rewards across Campaign Events.',
     },
     async lazy() {
         const { CEs } = await import('./ces');

--- a/src/fsd/1-pages/plan-lre/lre-hook.ts
+++ b/src/fsd/1-pages/plan-lre/lre-hook.ts
@@ -6,6 +6,7 @@ import { LegendaryEventDefaultPage } from '@/models/interfaces';
 import { StoreContext } from '@/reducers/store.provider';
 
 import { useQueryState } from '@/fsd/5-shared/lib';
+import { usePageMetaOverride } from '@/fsd/5-shared/ui';
 import { useTitle } from '@/fsd/5-shared/ui/contexts';
 
 import { CharactersService } from '@/fsd/4-entities/character';
@@ -26,6 +27,19 @@ export const useLre = () => {
                 ? (LegendaryEventEnum[initQueryParameter as keyof typeof LegendaryEventEnum] as LegendaryEventEnum)
                 : LegendaryEventEnum.Mephiston,
         value => LegendaryEventEnum[value]
+    );
+
+    const lreChar = CharactersService.getLreCharacter(legendaryEventId);
+    usePageMetaOverride(
+        lreChar
+            ? {
+                  section: 'Plan',
+                  title: 'LRE',
+                  subtitle: lreChar.name,
+                  description:
+                      'Build teams for each track of the current Legendary Release Event and track your score, chest, and shard progress.',
+              }
+            : undefined
     );
 
     const isEventActive = useMemo(() => {
@@ -78,14 +92,13 @@ export const useLre = () => {
     const changeTab = (_: React.SyntheticEvent, value: LreSection) => setSection(value);
 
     useEffect(() => {
-        const lreChar = CharactersService.getLreCharacter(legendaryEventId);
         if (lreChar) {
-            const relatedLre = LegendaryEventService.getEventByCharacterSnowprintId(lreChar!.snowprintId);
+            const relatedLre = LegendaryEventService.getEventByCharacterSnowprintId(lreChar.snowprintId);
             const nextDate = relatedLre?.nextEventDate ?? 'TBA';
             setHeaderTitle(
                 !relatedLre || relatedLre.finished
                     ? `${lreChar.name} (Finished)`
-                    : `${lreChar.name} ${relatedLre!.eventStage}/3 (${nextDate})`
+                    : `${lreChar.name} ${relatedLre.eventStage}/3 (${nextDate})`
             );
         }
     }, [characters, legendaryEventId]);

--- a/src/fsd/1-pages/plan-lre/lre-route.tsx
+++ b/src/fsd/1-pages/plan-lre/lre-route.tsx
@@ -5,7 +5,8 @@ export const lreLazyRoute: RouteObject = {
     handle: {
         section: 'Plan',
         title: 'LRE',
-        description: 'Plan your Long Range Escalation node picks and track expected rewards.',
+        description:
+            'Build teams for each track of the current Legendary Release Event and track your score, chest, and shard progress.',
     },
     async lazy() {
         const { Lre } = await import('./lre');

--- a/src/fsd/1-pages/plan-war-defense-2/war-defense2.route.tsx
+++ b/src/fsd/1-pages/plan-war-defense-2/war-defense2.route.tsx
@@ -4,7 +4,8 @@ export const warDefense2Route: RouteObject = {
     path: 'plan/wardefense2',
     handle: {
         section: 'Plan',
-        title: 'War Defense',
+        title: 'Guild War',
+        subtitle: 'Defense',
         description: 'Assign characters to your guild war defense zones.',
     },
     async lazy() {

--- a/src/fsd/1-pages/plan-war-offense2/war-offense2.route.tsx
+++ b/src/fsd/1-pages/plan-war-offense2/war-offense2.route.tsx
@@ -4,7 +4,8 @@ export const warOffense2Route: RouteObject = {
     path: 'plan/waroffense2',
     handle: {
         section: 'Plan',
-        title: 'War Offense',
+        title: 'Guild War',
+        subtitle: 'Offense',
         description: 'Plan your attack teams and target assignments for the current guild war.',
     },
     async lazy() {

--- a/src/fsd/2-widgets/app-bar/app-bar.tsx
+++ b/src/fsd/2-widgets/app-bar/app-bar.tsx
@@ -175,7 +175,18 @@ export const TopAppBar: React.FC<Props> = ({ headerTitle, seenAppVersion, onClos
                         {meta.section && (
                             <span className="text-[13px] tracking-[.04em] text-(--soft-fg)">{meta.section}&nbsp;/</span>
                         )}
-                        <h1 className="m-0 text-lg font-bold tracking-[-0.01em] text-(--fg)">{meta.title}</h1>
+                        {meta.subtitle ? (
+                            <>
+                                <span className="text-[13px] tracking-[.04em] text-(--soft-fg)">
+                                    {meta.title}&nbsp;/
+                                </span>
+                                <h1 className="m-0 text-lg font-bold tracking-[-0.01em] text-(--fg)">
+                                    {meta.subtitle}
+                                </h1>
+                            </>
+                        ) : (
+                            <h1 className="m-0 text-lg font-bold tracking-[-0.01em] text-(--fg)">{meta.title}</h1>
+                        )}
                         {meta.description && (
                             <LazyTooltip title={meta.description}>
                                 <button className="inline-flex h-5 w-5 cursor-pointer items-center justify-center rounded-md border border-transparent bg-transparent text-(--soft-fg) transition hover:text-(--fg)">

--- a/src/fsd/5-shared/ui/page-meta/page-meta.types.ts
+++ b/src/fsd/5-shared/ui/page-meta/page-meta.types.ts
@@ -1,5 +1,6 @@
 export interface PageMeta {
     section?: string;
     title: string;
+    subtitle?: string;
     description?: string;
 }

--- a/src/fsd/5-shared/ui/page-meta/use-page-meta-override.ts
+++ b/src/fsd/5-shared/ui/page-meta/use-page-meta-override.ts
@@ -11,9 +11,10 @@ export function usePageMetaOverride(meta?: PageMeta) {
     const { set } = useContext(PageMetaContext);
     const section = meta?.section;
     const title = meta?.title;
+    const subtitle = meta?.subtitle;
     const description = meta?.description;
     useEffect(() => {
-        set(title === undefined ? undefined : { section, title, description });
+        set(title === undefined ? undefined : { section, title, subtitle, description });
         return () => set(undefined);
-    }, [set, section, title, description]);
+    }, [set, section, title, subtitle, description]);
 }


### PR DESCRIPTION
<img width="543" height="137" alt="image" src="https://github.com/user-attachments/assets/3d17f00a-bbad-421f-93df-fc601a4ee02c" />
<img width="284" height="82" alt="image" src="https://github.com/user-attachments/assets/ea7e65ef-7f76-4efd-86c8-ed1acc2ddd06" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Navigation now displays page subtitles alongside titles for enhanced organization and clarity across the app.
  * Added comprehensive descriptions to multiple route pages, including Guild Performance, Guild Roster Snapshots, and others.

* **Updates**
  * Reorganized page labels for improved navigation structure (e.g., "War Defense" split into "Guild War" + "Defense").
  * Refreshed route metadata descriptions across various sections for better user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->