### PR TITLE
Add toggles for the daily shops in today raids

### DIFF
--- a/src/fsd/3-features/view-settings/model.ts
+++ b/src/fsd/3-features/view-settings/model.ts
@@ -38,6 +38,9 @@ export interface IViewPreferences
     showHseWarning: boolean;
     apiIntegrationSyncOptions: string[];
     tokenomicsTableView: boolean;
+    showGuildShop?: boolean;
+    showWarShop?: boolean;
+    showRogueTrader?: boolean;
     leaderboardBossTopN: number;
     leaderboardPrimeTopN: number;
 }

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -262,6 +262,9 @@ export const defaultData: IPersonalData2 = {
         apiIntegrationSyncOptions: ['roster', 'inventory', 'campaignProgress', 'raidedLocations'],
         leaderboardBossTopN: 5,
         leaderboardPrimeTopN: 3,
+        showGuildShop: true,
+        showWarShop: true,
+        showRogueTrader: true,
     },
     dailyRaidsPreferences: {
         dailyEnergy: 288,

--- a/src/routes/tables/daily-raids.tsx
+++ b/src/routes/tables/daily-raids.tsx
@@ -9,6 +9,7 @@ import { RaidsHeader } from 'src/routes/tables/raids-header';
 import { RogueTraderSection } from 'src/routes/tables/rogue-trader-section';
 import { TodayRaids } from 'src/routes/tables/today-raids';
 import { WarShopSection } from 'src/routes/tables/war-shop-section';
+import DailyRaidsSettings from 'src/shared-components/daily-raids-settings';
 
 import { useAuth } from '@/fsd/5-shared/model';
 
@@ -57,11 +58,13 @@ export const DailyRaids = () => {
         inventory,
         onslaughtPreferences,
         playerMetadata,
+        viewPreferences,
     } = useContext(StoreContext);
 
     const resolvedMows = useMemo(() => MowsService.resolveAllFromStorage(storeMows), [storeMows]);
 
     const [hasChanges, setHasChanges] = useState<boolean>(false);
+    const [raidSettingsOpen, setRaidSettingsOpen] = useState(false);
     const upgrades = useMemo(
         () => addShardsToUpgrades(inventory.upgrades, storeCharacters, resolvedMows),
         [inventory.upgrades, storeCharacters, resolvedMows]
@@ -203,10 +206,13 @@ export const DailyRaids = () => {
                 refreshDisabled={!hasChanges}
                 refreshHandle={refresh}
                 resetDisabled={!dailyRaids.raidedLocations?.length}
-                resetHandler={resetDay}>
+                resetHandler={resetDay}
+                onOpenSettings={() => setRaidSettingsOpen(true)}>
                 <ActiveGoalsDialog units={units} goals={allGoals} onGoalsSelectChange={handleGoalsSelectionChange} />
                 <LocationsFilter filter={dailyRaids.filters} filtersChange={saveFilterChanges} />
             </RaidsHeader>
+
+            <DailyRaidsSettings open={raidSettingsOpen} close={() => setRaidSettingsOpen(false)} />
 
             <Suspense fallback={undefined}>
                 <RaidsPlan
@@ -226,31 +232,38 @@ export const DailyRaids = () => {
                         infiniteEstimatedRanks.upgradesRaids[0],
                         estimatedRanks.upgradesRaids[0]
                     )}
+                    onOpenSettings={() => setRaidSettingsOpen(true)}
                     guildShopSection={
-                        <GuildShopSection
-                            inProgressMaterials={estimatedRanks.inProgressMaterials}
-                            blockedMaterials={estimatedRanks.blockedMaterials}
-                            userPL={playerMetadata.powerLevel ?? 1}
-                        />
+                        (viewPreferences.showGuildShop ?? true) ? (
+                            <GuildShopSection
+                                inProgressMaterials={estimatedRanks.inProgressMaterials}
+                                blockedMaterials={estimatedRanks.blockedMaterials}
+                                userPL={playerMetadata.powerLevel ?? 1}
+                            />
+                        ) : undefined
                     }
                     warShopSection={
-                        <WarShopSection
-                            inProgressMaterials={estimatedRanks.inProgressMaterials}
-                            blockedMaterials={estimatedRanks.blockedMaterials}
-                            componentsByAlliance={mowCounts.componentsByAlliance}
-                            forgeBadgeCounts={mowCounts.forgeBadgeCounts}
-                            componentNeededBy={mowCounts.componentNeededBy}
-                            forgeBadgeNeededBy={mowCounts.forgeBadgeNeededBy}
-                            userPL={playerMetadata.powerLevel ?? 1}
-                        />
+                        (viewPreferences.showWarShop ?? true) ? (
+                            <WarShopSection
+                                inProgressMaterials={estimatedRanks.inProgressMaterials}
+                                blockedMaterials={estimatedRanks.blockedMaterials}
+                                componentsByAlliance={mowCounts.componentsByAlliance}
+                                forgeBadgeCounts={mowCounts.forgeBadgeCounts}
+                                componentNeededBy={mowCounts.componentNeededBy}
+                                forgeBadgeNeededBy={mowCounts.forgeBadgeNeededBy}
+                                userPL={playerMetadata.powerLevel ?? 1}
+                            />
+                        ) : undefined
                     }
                     rogueTraderSection={
-                        <RogueTraderSection
-                            inProgressMaterials={estimatedRanks.inProgressMaterials}
-                            blockedMaterials={estimatedRanks.blockedMaterials}
-                            forgeBadgeCounts={mowCounts.forgeBadgeCounts}
-                            forgeBadgeNeededBy={mowCounts.forgeBadgeNeededBy}
-                        />
+                        (viewPreferences.showRogueTrader ?? true) ? (
+                            <RogueTraderSection
+                                inProgressMaterials={estimatedRanks.inProgressMaterials}
+                                blockedMaterials={estimatedRanks.blockedMaterials}
+                                forgeBadgeCounts={mowCounts.forgeBadgeCounts}
+                                forgeBadgeNeededBy={mowCounts.forgeBadgeNeededBy}
+                            />
+                        ) : undefined
                     }
                 />
             )}

--- a/src/routes/tables/raids-header.tsx
+++ b/src/routes/tables/raids-header.tsx
@@ -1,15 +1,13 @@
 import { Link2, RefreshCw, RotateCcw, Settings } from 'lucide-react';
-import React, { useState } from 'react';
+import { type FC, type PropsWithChildren } from 'react';
 import { isMobile } from 'react-device-detect';
-
-import DailyRaidsSettings from 'src/shared-components/daily-raids-settings';
 
 import { Button, PageToolbar, PageToolbarDivider } from '@/fsd/5-shared/ui';
 import { MiscIcon } from '@/fsd/5-shared/ui/icons';
 import { LinkButton } from '@/fsd/5-shared/ui/link';
 import { SyncButton } from '@/fsd/5-shared/ui/sync-button';
 
-interface Props extends React.PropsWithChildren {
+interface Props extends PropsWithChildren {
     actualDailyEnergy: string;
     resetHandler: () => void;
     refreshHandle: () => void;
@@ -17,9 +15,10 @@ interface Props extends React.PropsWithChildren {
     resetDisabled: boolean;
     refreshDisabled: boolean;
     hasSync: boolean;
+    onOpenSettings: () => void;
 }
 
-export const RaidsHeader: React.FC<Props> = ({
+export const RaidsHeader: FC<Props> = ({
     actualDailyEnergy,
     children,
     refreshDisabled,
@@ -28,58 +27,48 @@ export const RaidsHeader: React.FC<Props> = ({
     refreshHandle,
     hasSync,
     onAfterSync,
+    onOpenSettings,
 }) => {
-    const [openSettings, setOpenSettings] = useState<boolean>(false);
-
     return (
-        <>
-            <PageToolbar>
-                {/* Navigation */}
-                <LinkButton size="small" href={isMobile ? '/mobile/plan/goals' : '/plan/goals'}>
-                    <Link2 data-slot="icon" />
-                    Go to Goals
-                </LinkButton>
+        <PageToolbar>
+            {/* Navigation */}
+            <LinkButton size="small" href={isMobile ? '/mobile/plan/goals' : '/plan/goals'}>
+                <Link2 data-slot="icon" />
+                Go to Goals
+            </LinkButton>
 
-                <PageToolbarDivider />
+            <PageToolbarDivider />
 
-                {/* Primary config */}
-                <Button intent="secondary" appearance="outline" size="small" onPress={() => setOpenSettings(true)}>
-                    <Settings data-slot="icon" />
-                    Raids Settings
-                </Button>
-                {children}
-                <span className="flex items-center gap-1 text-sm text-(--soft-fg)">
-                    <MiscIcon icon={'energy'} height={15} width={15} />
-                    {actualDailyEnergy}
-                </span>
+            {/* Primary config */}
+            <Button intent="secondary" appearance="outline" size="small" onPress={onOpenSettings}>
+                <Settings data-slot="icon" />
+                Raids Settings
+            </Button>
+            {children}
+            <span className="flex items-center gap-1 text-sm text-(--soft-fg)">
+                <MiscIcon icon={'energy'} height={15} width={15} />
+                {actualDailyEnergy}
+            </span>
 
-                <PageToolbarDivider />
+            <PageToolbarDivider />
 
-                {/* State actions */}
-                {hasSync && (
-                    <SyncButton intent="secondary" showText={true} appearance="outline" onAfterSync={onAfterSync} />
-                )}
-                <Button
-                    intent="secondary"
-                    appearance="outline"
-                    size="small"
-                    isDisabled={refreshDisabled}
-                    onPress={refreshHandle}>
-                    <RefreshCw data-slot="icon" />
-                    {!isMobile && 'Refresh'}
-                </Button>
-                <Button
-                    appearance="outline"
-                    size="small"
-                    intent="danger"
-                    isDisabled={resetDisabled}
-                    onPress={resetHandler}>
-                    <RotateCcw data-slot="icon" />
-                    Reset day
-                </Button>
-            </PageToolbar>
-
-            <DailyRaidsSettings open={openSettings} close={() => setOpenSettings(false)} />
-        </>
+            {/* State actions */}
+            {hasSync && (
+                <SyncButton intent="secondary" showText={true} appearance="outline" onAfterSync={onAfterSync} />
+            )}
+            <Button
+                intent="secondary"
+                appearance="outline"
+                size="small"
+                isDisabled={refreshDisabled}
+                onPress={refreshHandle}>
+                <RefreshCw data-slot="icon" />
+                {!isMobile && 'Refresh'}
+            </Button>
+            <Button appearance="outline" size="small" intent="danger" isDisabled={resetDisabled} onPress={resetHandler}>
+                <RotateCcw data-slot="icon" />
+                Reset day
+            </Button>
+        </PageToolbar>
     );
 };

--- a/src/routes/tables/today-raids.tsx
+++ b/src/routes/tables/today-raids.tsx
@@ -16,11 +16,19 @@ interface Props {
     guildShopSection?: ReactNode;
     warShopSection?: ReactNode;
     rogueTraderSection?: ReactNode;
+    onOpenSettings?: () => void;
 }
 
 const isShardRaid = (raid: IUpgradeRaid) => raid.rarity === 'Shard' || raid.rarity === 'Mythic Shard';
 
-export const TodayRaids: FC<Props> = ({ raids, bonusRaids, guildShopSection, warShopSection, rogueTraderSection }) => {
+export const TodayRaids: FC<Props> = ({
+    raids,
+    bonusRaids,
+    guildShopSection,
+    warShopSection,
+    rogueTraderSection,
+    onOpenSettings,
+}) => {
     const locs = raids.flatMap(raid => raid.raidLocations);
     const energySpent = sum(locs.map(loc => loc.raidsAlreadyPerformed * loc.energyCost));
     const raidsCount = sum(locs.map(loc => loc.raidsAlreadyPerformed));
@@ -75,6 +83,16 @@ export const TodayRaids: FC<Props> = ({ raids, bonusRaids, guildShopSection, war
                             ))}
                         </div>
                     </Suspense>
+                    <p className="w-full text-center text-xs text-(--soft-fg)">
+                        Manage visibility of the daily shops in{' '}
+                        {onOpenSettings ? (
+                            <button className="underline hover:text-(--fg)" onClick={onOpenSettings}>
+                                Raid Settings
+                            </button>
+                        ) : (
+                            'Raid Settings'
+                        )}
+                    </p>
                     {guildShopSection}
                     {warShopSection}
                     {rogueTraderSection}

--- a/src/shared-components/daily-raids-settings.tsx
+++ b/src/shared-components/daily-raids-settings.tsx
@@ -1,5 +1,5 @@
 import { Info } from 'lucide-react';
-import React, { useCallback, useContext } from 'react';
+import React, { useCallback, useContext, useState } from 'react';
 
 import { DailyRaidsStrategy } from 'src/models/enums';
 import { DailyRaidsCustomLocations } from 'src/shared-components/daily-raids-custom-locations';
@@ -124,8 +124,13 @@ interface Props {
 
 const DailyRaidsSettings: React.FC<Props> = ({ close, open }) => {
     const dispatch = useContext(DispatchContext);
-    const { dailyRaidsPreferences } = useContext(StoreContext);
+    const { dailyRaidsPreferences, viewPreferences } = useContext(StoreContext);
     const [dailyRaidsPreferencesForm, setDailyRaidsPreferencesForm] = React.useState(dailyRaidsPreferences);
+    const [shopVisibility, setShopVisibility] = useState({
+        showGuildShop: viewPreferences.showGuildShop ?? true,
+        showWarShop: viewPreferences.showWarShop ?? true,
+        showRogueTrader: viewPreferences.showRogueTrader ?? true,
+    });
     const [dailyEnergy, setDailyEnergy] = React.useState(() => {
         const index = energyMarks.findIndex(x => x.value === dailyRaidsPreferences.dailyEnergy);
         return index === -1 ? 2 : index;
@@ -153,6 +158,9 @@ const DailyRaidsSettings: React.FC<Props> = ({ close, open }) => {
 
     const saveChanges = () => {
         dispatch.dailyRaidsPreferences({ type: 'Set', value: dailyRaidsPreferencesForm });
+        dispatch.viewPreferences({ type: 'Update', setting: 'showGuildShop', value: shopVisibility.showGuildShop });
+        dispatch.viewPreferences({ type: 'Update', setting: 'showWarShop', value: shopVisibility.showWarShop });
+        dispatch.viewPreferences({ type: 'Update', setting: 'showRogueTrader', value: shopVisibility.showRogueTrader });
         close();
     };
 
@@ -293,6 +301,32 @@ const DailyRaidsSettings: React.FC<Props> = ({ close, open }) => {
                         }}
                     />
                 )}
+
+                {/* Shop visibility */}
+                <fieldset>
+                    <legend className="mb-2 text-sm font-semibold text-(--fg)">Shop visibility:</legend>
+                    <div className="flex flex-col gap-2 ps-2">
+                        <Switch
+                            isSelected={shopVisibility.showGuildShop}
+                            onChange={checked =>
+                                setShopVisibility(current => ({ ...current, showGuildShop: checked }))
+                            }>
+                            Guild Shop
+                        </Switch>
+                        <Switch
+                            isSelected={shopVisibility.showWarShop}
+                            onChange={checked => setShopVisibility(current => ({ ...current, showWarShop: checked }))}>
+                            War Shop
+                        </Switch>
+                        <Switch
+                            isSelected={shopVisibility.showRogueTrader}
+                            onChange={checked =>
+                                setShopVisibility(current => ({ ...current, showRogueTrader: checked }))
+                            }>
+                            Rogue Trader
+                        </Switch>
+                    </div>
+                </fieldset>
             </PortalDialog.Body>
 
             <PortalDialog.Footer>

--- a/src/shared-components/daily-raids-settings.tsx
+++ b/src/shared-components/daily-raids-settings.tsx
@@ -143,6 +143,16 @@ const DailyRaidsSettings: React.FC<Props> = ({ close, open }) => {
         setDailyRaidsPreferencesForm(dailyRaidsPreferences);
     }, [dailyRaidsPreferences]);
 
+    React.useEffect(() => {
+        if (open) {
+            setShopVisibility({
+                showGuildShop: viewPreferences.showGuildShop ?? true,
+                showWarShop: viewPreferences.showWarShop ?? true,
+                showRogueTrader: viewPreferences.showRogueTrader ?? true,
+            });
+        }
+    }, [open, viewPreferences]);
+
     const updatePreferences = useCallback((value: IDailyRaidsFarmOrder) => {
         setDailyRaidsPreferencesForm(current => ({
             ...current,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a daily raids settings dialog with controls for shop visibility.
  * Introduced options to show or hide Guild Shop, War Shop, and Rogue Trader sections.
  * Added an in-page way to open raid settings from the raids view.

* **Bug Fixes**
  * Shop section visibility now follows saved preferences, with sensible defaults when no setting is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->