### PR TITLE
Fix an error where shard farming was getting filtered

### DIFF
--- a/src/fsd/4-entities/campaign/campaigns.service.ts
+++ b/src/fsd/4-entities/campaign/campaigns.service.ts
@@ -261,7 +261,13 @@ export class CampaignsService {
             return false;
         }
 
-        if (upgradesRarity.length > 0 && materialRarity != undefined && !upgradesRarity.includes(materialRarity)) {
+        if (
+            upgradesRarity.length > 0 &&
+            materialRarity != undefined &&
+            materialRarity !== 'Shard' &&
+            materialRarity !== 'Mythic Shard' &&
+            !upgradesRarity.includes(materialRarity)
+        ) {
             return false;
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved location filtering so rarity-based restrictions are only applied for eligible materials.
  * Shard rarity items now bypass the extra rarity constraint, preventing overly restrictive results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->