### PR TITLE
Fix set goal zindex

### DIFF
--- a/src/fsd/5-shared/ui/modal/modal.tsx
+++ b/src/fsd/5-shared/ui/modal/modal.tsx
@@ -6,7 +6,7 @@ import { Dialog } from './dialog';
 
 const modalOverlayStyles = tv({
     base: [
-        'fixed top-0 left-0 isolate z-50 h-(--visual-viewport-height) w-full',
+        'fixed top-0 left-0 isolate z-[200] h-(--visual-viewport-height) w-full',
         'flex items-end justify-end bg-black/50 text-center sm:items-center sm:justify-center',
         '[--visual-viewport-vertical-padding:16px] sm:[--visual-viewport-vertical-padding:32px]',
     ],

--- a/src/fsd/5-shared/ui/portal-dialog/portal-dialog.tsx
+++ b/src/fsd/5-shared/ui/portal-dialog/portal-dialog.tsx
@@ -59,7 +59,7 @@ const PortalDialogRoot = ({
 
     return createPortal(
         <div
-            className="fixed inset-0 z-40 flex items-start justify-center overflow-auto bg-black/50 py-8"
+            className="fixed inset-0 z-[200] flex items-start justify-center overflow-auto bg-black/50 py-8"
             onPointerDown={event_ => {
                 pointerDownOnBackdrop.current = event_.target === event_.currentTarget;
             }}

--- a/src/fsd/5-shared/ui/selects/select-multi.tsx
+++ b/src/fsd/5-shared/ui/selects/select-multi.tsx
@@ -4,7 +4,15 @@ import { type ReactNode } from 'react';
 
 import { cn } from '@/fsd/5-shared/lib';
 
-import { checkIconClass, labelClass, optionClassName, panel, triggerDisabled, triggerMulti } from './select-styles';
+import {
+    checkIconClass,
+    labelClass,
+    optionClassName,
+    panel,
+    panelAnchor,
+    triggerDisabled,
+    triggerMulti,
+} from './select-styles';
 
 export interface SelectMultiProps<T> {
     options: T[];
@@ -72,7 +80,7 @@ export const SelectMulti = <T,>({
                         </div>
                     </ListboxButton>
 
-                    <ListboxOptions transition anchor="bottom start" className={panel}>
+                    <ListboxOptions transition anchor={panelAnchor} className={panel}>
                         {options.map((option, index) => (
                             <ListboxOption key={index} value={option} className={optionClassName}>
                                 {({ selected }) => (

--- a/src/fsd/5-shared/ui/selects/select-styles.ts
+++ b/src/fsd/5-shared/ui/selects/select-styles.ts
@@ -18,13 +18,28 @@ export function triggerDisabled(base: string, disabled?: boolean): string {
 
 // ─── dropdown panel ──────────────────────────────────────────────────────────
 
-// Panel with anchor positioning (used by Select/SelectMulti Listbox)
+// Panel with anchor positioning (used by Select/SelectMulti Listbox).
+// Portals to the body floating layer, so its z-index is global — it must sit
+// above the dialog overlay (z-200) and the mobile bottom nav (z-100).
+// Gap (offset from trigger) and padding (minimum space from the viewport edge)
+// are passed via the ListboxOptions `anchor` prop, not here — floating-ui then
+// accounts for them in its collision math so a downward-opening dropdown never
+// ends flush against the bottom (under the fixed mobile nav / iOS home-indicator),
+// which made the last option hard to tap. No `mt-*` margin: an untracked margin
+// would push the panel past what floating-ui measured.
 export const panel = [
-    'z-50 mt-2 max-h-[min(60vh,24rem)] w-[var(--button-width)]',
+    'z-[1000] max-h-[min(60vh,24rem)] w-[var(--button-width)]',
     'overflow-y-auto overscroll-contain rounded-lg border border-(--border)',
     'bg-(--overlay) py-1 shadow-xl',
     'transition duration-100 ease-in data-leave:opacity-0',
 ].join(' ');
+
+// Anchor config for the floating (portaled) Listbox panel. `gap` is the offset
+// from the trigger; `padding` is the minimum space kept from every viewport
+// edge, so a downward-opening dropdown stops short of the bottom instead of
+// sitting under the fixed mobile nav / iOS home-indicator (last option was hard
+// to tap). Shared so Select and SelectMulti stay in sync.
+export const panelAnchor = { to: 'bottom start', gap: 8, padding: 24 } as const;
 
 // Panel with absolute positioning (used by ComboBox/ComboBoxMulti)
 export const panelAbsolute = [

--- a/src/fsd/5-shared/ui/selects/select.tsx
+++ b/src/fsd/5-shared/ui/selects/select.tsx
@@ -10,6 +10,7 @@ import {
     labelClass,
     optionClassName,
     panel,
+    panelAnchor,
     triggerDisabled,
     triggerSingle,
 } from './select-styles';
@@ -63,7 +64,7 @@ export const Select = <T,>({
                         </span>
                     </ListboxButton>
 
-                    <ListboxOptions transition anchor="bottom start" className={panel}>
+                    <ListboxOptions transition anchor={panelAnchor} className={panel}>
                         {options.map((option, index) => (
                             <ListboxOption key={index} value={option} className={optionClassName}>
                                 {({ selected }) => (


### PR DESCRIPTION
Now it goes over the bottom menu also the dropdowns do not touch the bottom

<img width="670" height="259" alt="image" src="https://github.com/user-attachments/assets/96821d43-f3c4-42b6-a9ca-5304aba4ca26" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved modal, dialog, and dropdown stacking so overlay elements appear above other page content more reliably.
  * Updated select menus to open in a better positioned floating panel, reducing clipping and spacing issues near the viewport edge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->