### PR TITLE
Add daily raids farm order preference to goals estimation logic

### DIFF
--- a/src/fsd/1-pages/home/goals-section.tsx
+++ b/src/fsd/1-pages/home/goals-section.tsx
@@ -20,6 +20,7 @@ import { MowsService } from '@/fsd/4-entities/mow';
 import { GoalsService } from '@/fsd/3-features/goals/goals.service';
 import { UpgradesService } from '@/fsd/3-features/goals/upgrades.service';
 
+/** Builds the short progress description line shown under a goal (e.g. rank transition, target stars, "Unlock"). */
 function describeGoal(goal: IPersonalGoal, currentRank?: Rank): string {
     switch (goal.type) {
         case PersonalGoalType.UpgradeRank: {
@@ -41,6 +42,7 @@ function describeGoal(goal: IPersonalGoal, currentRank?: Rank): string {
     }
 }
 
+/** Maps a goal type to its short badge label (Rank, Ascend, Unlock, Abilities). */
 function goalTypeLabel(type: PersonalGoalType): string {
     switch (type) {
         case PersonalGoalType.UpgradeRank: {
@@ -62,6 +64,11 @@ function goalTypeLabel(type: PersonalGoalType): string {
     }
 }
 
+/**
+ * Homepage card summarizing the user's top goals with per-goal estimates (energy, tokens, ETA)
+ * and completed/blocked status. Blocked status is computed with the same goal-priority awareness
+ * as the dedicated goals page.
+ */
 export function GoalsSection() {
     const navigate = useNavigate();
     const { goals, characters, mows, campaignsProgress, inventory, dailyRaids, dailyRaidsPreferences, gameModeTokens } =

--- a/src/fsd/1-pages/home/goals-section.tsx
+++ b/src/fsd/1-pages/home/goals-section.tsx
@@ -5,7 +5,7 @@ import { isMobile } from 'react-device-detect';
 import { useNavigate } from 'react-router-dom';
 
 import { PersonalGoalType } from 'src/models/enums';
-import { IPersonalGoal } from 'src/models/interfaces';
+import { IDailyRaidsFarmOrder, IPersonalGoal } from 'src/models/interfaces';
 import { menuItemById } from 'src/models/menu-items';
 import { StoreContext } from 'src/reducers/store.provider';
 
@@ -115,6 +115,8 @@ export function GoalsSection() {
         ]
     );
 
+    const isGoalPriority = dailyRaidsPreferences?.farmPreferences?.order === IDailyRaidsFarmOrder.goalPriority;
+
     const goalsEstimates = useMemo(
         () =>
             GoalsService.buildGoalEstimates(
@@ -123,7 +125,8 @@ export function GoalsSection() {
                 upgradeMaterialGoals,
                 upgradeRankOrMowGoals,
                 upgradeAbilities,
-                resolvedCharacters
+                resolvedCharacters,
+                isGoalPriority
             ),
         [
             estimatedUpgradesTotal,
@@ -132,6 +135,7 @@ export function GoalsSection() {
             upgradeRankOrMowGoals,
             upgradeAbilities,
             resolvedCharacters,
+            isGoalPriority,
         ]
     );
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Goal estimates now update correctly when the farm-order preference changes.
  * Improved how goal calculations reflect priority-based farming preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->