### PR TITLE
Add a new goal type to pre-farm bottlenecking materials

### DIFF
--- a/src/fsd/1-pages/goals/goal-card/goal-card.tsx
+++ b/src/fsd/1-pages/goals/goal-card/goal-card.tsx
@@ -15,7 +15,7 @@ import { IMow2 } from '@/fsd/4-entities/mow';
 import { UpgradeImage, UpgradesService } from '@/fsd/4-entities/upgrade';
 
 import { IGoalEstimate } from '@/fsd/3-features/goals';
-import { TypedGoalSelect } from '@/fsd/3-features/goals/goals.models';
+import { TypedGoalSelect, isUnitlessMaterialGoal } from '@/fsd/3-features/goals/goals.models';
 
 import { GoalCardActions } from './actions';
 import { GoalCardAscend } from './ascend';
@@ -125,10 +125,9 @@ export const GoalCard: React.FC<Props> = ({
                 backgroundImage: `linear-gradient(${bgColor}, ${bgColor})`,
             };
 
-    const material =
-        goal.type === PersonalGoalType.UpgradeMaterial || goal.type === PersonalGoalType.PreFarmMaterialForGoals
-            ? UpgradesService.getUpgradeMaterial(goal.upgradeMaterialId)
-            : undefined;
+    const material = isUnitlessMaterialGoal(goal)
+        ? UpgradesService.getUpgradeMaterial(goal.upgradeMaterialId)
+        : undefined;
 
     return (
         <div
@@ -138,8 +137,7 @@ export const GoalCard: React.FC<Props> = ({
             <div className="grid grid-cols-[auto_1fr_auto] items-center gap-x-3 border-b border-(--card-border) px-4 py-3">
                 <div className="flex items-center gap-1">
                     <span className="text-[1.35rem] leading-none font-semibold text-(--soft-fg)">#{goal.priority}</span>
-                    {(goal.type === PersonalGoalType.UpgradeMaterial ||
-                        goal.type === PersonalGoalType.PreFarmMaterialForGoals) && (
+                    {isUnitlessMaterialGoal(goal) && (
                         <UpgradeImage
                             material={goal.upgradeMaterialId}
                             iconPath={material?.icon ?? ''}
@@ -147,20 +145,14 @@ export const GoalCard: React.FC<Props> = ({
                             size={40}
                         />
                     )}
-                    {goal.type !== PersonalGoalType.UpgradeMaterial &&
-                        goal.type !== PersonalGoalType.PreFarmMaterialForGoals && (
-                            <UnitShardIcon icon={goal.unitRoundIcon} height={40} />
-                        )}
+                    {!isUnitlessMaterialGoal(goal) && <UnitShardIcon icon={goal.unitRoundIcon} height={40} />}
                 </div>
                 <div className="flex min-w-0 flex-col">
                     <span className="text-[1.05rem] leading-snug font-semibold text-(--fg)">
-                        {(goal.type === PersonalGoalType.UpgradeMaterial ||
-                            goal.type === PersonalGoalType.PreFarmMaterialForGoals) && (
+                        {isUnitlessMaterialGoal(goal) && (
                             <span>{UpgradesService.getUpgradeMaterial(goal.upgradeMaterialId)?.material}</span>
                         )}
-                        {goal.type !== PersonalGoalType.UpgradeMaterial &&
-                            goal.type !== PersonalGoalType.PreFarmMaterialForGoals &&
-                            (goal.unitName ?? goal.unitId)}
+                        {!isUnitlessMaterialGoal(goal) && (goal.unitName ?? goal.unitId)}
                     </span>
                     {calendarDate && <span className="text-xs text-(--soft-fg)">{calendarDate}</span>}
                 </div>

--- a/src/fsd/1-pages/goals/goal-card/goal-card.tsx
+++ b/src/fsd/1-pages/goals/goal-card/goal-card.tsx
@@ -21,6 +21,7 @@ import { GoalCardActions } from './actions';
 import { GoalCardAscend } from './ascend';
 import { GoalCardCharacterAbilities } from './character-abilities';
 import { GoalCardMowAbilities } from './mow-abilities';
+import { GoalCardPreFarmMaterial } from './pre-farm-material';
 import { GoalCardUnlock } from './unlock';
 import { GoalCardUpgradeMaterial } from './upgrade-material';
 import { GoalCardUpgradeRank } from './upgrade-rank';
@@ -29,7 +30,8 @@ import { GoalCardUpgradeRank } from './upgrade-rank';
 const showRaidsButton = (goal: TypedGoalSelect): boolean =>
     goal.type === PersonalGoalType.UpgradeRank ||
     goal.type === PersonalGoalType.MowAbilities ||
-    goal.type === PersonalGoalType.UpgradeMaterial;
+    goal.type === PersonalGoalType.UpgradeMaterial ||
+    goal.type === PersonalGoalType.PreFarmMaterialForGoals;
 
 interface Props {
     goal: TypedGoalSelect;
@@ -98,6 +100,9 @@ export const GoalCard: React.FC<Props> = ({
             case PersonalGoalType.UpgradeMaterial: {
                 return <GoalCardUpgradeMaterial goalEstimate={goalEstimate} calendarDate={calendarDate} />;
             }
+            case PersonalGoalType.PreFarmMaterialForGoals: {
+                return <GoalCardPreFarmMaterial goalEstimate={goalEstimate} calendarDate={calendarDate} />;
+            }
         }
     };
 
@@ -121,7 +126,7 @@ export const GoalCard: React.FC<Props> = ({
             };
 
     const material =
-        goal.type === PersonalGoalType.UpgradeMaterial
+        goal.type === PersonalGoalType.UpgradeMaterial || goal.type === PersonalGoalType.PreFarmMaterialForGoals
             ? UpgradesService.getUpgradeMaterial(goal.upgradeMaterialId)
             : undefined;
 
@@ -133,7 +138,8 @@ export const GoalCard: React.FC<Props> = ({
             <div className="grid grid-cols-[auto_1fr_auto] items-center gap-x-3 border-b border-(--card-border) px-4 py-3">
                 <div className="flex items-center gap-1">
                     <span className="text-[1.35rem] leading-none font-semibold text-(--soft-fg)">#{goal.priority}</span>
-                    {goal.type === PersonalGoalType.UpgradeMaterial && (
+                    {(goal.type === PersonalGoalType.UpgradeMaterial ||
+                        goal.type === PersonalGoalType.PreFarmMaterialForGoals) && (
                         <UpgradeImage
                             material={goal.upgradeMaterialId}
                             iconPath={material?.icon ?? ''}
@@ -141,16 +147,20 @@ export const GoalCard: React.FC<Props> = ({
                             size={40}
                         />
                     )}
-                    {goal.type !== PersonalGoalType.UpgradeMaterial && (
-                        <UnitShardIcon icon={goal.unitRoundIcon} height={40} />
-                    )}
+                    {goal.type !== PersonalGoalType.UpgradeMaterial &&
+                        goal.type !== PersonalGoalType.PreFarmMaterialForGoals && (
+                            <UnitShardIcon icon={goal.unitRoundIcon} height={40} />
+                        )}
                 </div>
                 <div className="flex min-w-0 flex-col">
                     <span className="text-[1.05rem] leading-snug font-semibold text-(--fg)">
-                        {goal.type === PersonalGoalType.UpgradeMaterial && (
+                        {(goal.type === PersonalGoalType.UpgradeMaterial ||
+                            goal.type === PersonalGoalType.PreFarmMaterialForGoals) && (
                             <span>{UpgradesService.getUpgradeMaterial(goal.upgradeMaterialId)?.material}</span>
                         )}
-                        {goal.type !== PersonalGoalType.UpgradeMaterial && (goal.unitName ?? goal.unitId)}
+                        {goal.type !== PersonalGoalType.UpgradeMaterial &&
+                            goal.type !== PersonalGoalType.PreFarmMaterialForGoals &&
+                            (goal.unitName ?? goal.unitId)}
                     </span>
                     {calendarDate && <span className="text-xs text-(--soft-fg)">{calendarDate}</span>}
                 </div>
@@ -203,7 +213,8 @@ export const GoalCard: React.FC<Props> = ({
                             {showRaidsButton(goal) && (
                                 <GoToRaidsButton
                                     unitId={
-                                        goal.type === PersonalGoalType.UpgradeMaterial
+                                        goal.type === PersonalGoalType.UpgradeMaterial ||
+                                        goal.type === PersonalGoalType.PreFarmMaterialForGoals
                                             ? goal.upgradeMaterialId
                                             : goal.unitId
                                     }

--- a/src/fsd/1-pages/goals/goal-card/pre-farm-material.tsx
+++ b/src/fsd/1-pages/goals/goal-card/pre-farm-material.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import { IGoalEstimate } from '@/fsd/3-features/goals';
+
+import { GoalEstimateRow } from './estimate-row';
+
+interface Props {
+    goalEstimate: IGoalEstimate;
+    calendarDate?: string;
+}
+
+export const GoalCardPreFarmMaterial: React.FC<Props> = ({ goalEstimate, calendarDate }) => {
+    const info = goalEstimate.materialQuantityInfo;
+
+    const quantityLabel = info ? `${info.held}/${info.thisGoalQuantity}` : undefined;
+
+    return (
+        <div className="flex flex-col gap-2">
+            {quantityLabel !== undefined && (
+                <div className="text-sm font-medium text-(--fg) tabular-nums">{quantityLabel}</div>
+            )}
+            {goalEstimate.included && (
+                <div className="flex-box wrap gap-2">
+                    <GoalEstimateRow
+                        daysLeft={goalEstimate.daysLeft ?? 0}
+                        calendarDate={calendarDate}
+                        energyTotal={goalEstimate.energyTotal}
+                    />
+                </div>
+            )}
+        </div>
+    );
+};

--- a/src/fsd/1-pages/home/goals-section.tsx
+++ b/src/fsd/1-pages/home/goals-section.tsx
@@ -96,7 +96,7 @@ export function GoalsSection() {
         [gameModeTokens]
     );
 
-    const { shardsGoals, upgradeMaterialGoals, upgradeRankOrMowGoals, upgradeAbilities } = useMemo(
+    const { shardsGoals, upgradeMaterialGoals, upgradeRankOrMowGoals, upgradeAbilities, preFarmGoals } = useMemo(
         () => GoalsService.prepareGoals(goals, units, false, onslaughtPreferences),
         [goals, units, onslaughtPreferences]
     );
@@ -144,7 +144,8 @@ export function GoalsSection() {
                 upgradeRankOrMowGoals,
                 upgradeAbilities,
                 resolvedCharacters,
-                isGoalPriority
+                isGoalPriority,
+                preFarmGoals
             ),
         [
             estimatedUpgradesTotal,
@@ -154,6 +155,7 @@ export function GoalsSection() {
             upgradeAbilities,
             resolvedCharacters,
             isGoalPriority,
+            preFarmGoals,
         ]
     );
 

--- a/src/fsd/1-pages/plan-armageddon/armageddon.tsx
+++ b/src/fsd/1-pages/plan-armageddon/armageddon.tsx
@@ -126,10 +126,8 @@ export const Armageddon = () => {
     }, [resolvedMows]);
 
     // ── goals estimation pipeline (for missing-resources coverage) ────────────
-    const { shardsGoals, upgradeRankOrMowGoals, upgradeMaterialGoals, upgradeAbilities, ascendGoals } = useMemo(
-        () => GoalsService.prepareGoals(goals, units, false),
-        [goals, units]
-    );
+    const { shardsGoals, upgradeRankOrMowGoals, upgradeMaterialGoals, upgradeAbilities, ascendGoals, preFarmGoals } =
+        useMemo(() => GoalsService.prepareGoals(goals, units, false), [goals, units]);
 
     const onslaughtTokensToday = useMemo(
         () => GoalUpgradesService.computeOnslaughtTokensToday(gameModeTokens),
@@ -176,7 +174,8 @@ export const Armageddon = () => {
                 upgradeRankOrMowGoals,
                 upgradeAbilities,
                 characters,
-                isGoalPriority
+                isGoalPriority,
+                preFarmGoals
             ),
         [
             estimatedUpgradesTotal,
@@ -186,6 +185,7 @@ export const Armageddon = () => {
             upgradeAbilities,
             characters,
             isGoalPriority,
+            preFarmGoals,
         ]
     );
 

--- a/src/fsd/1-pages/plan-ces/ces.tsx
+++ b/src/fsd/1-pages/plan-ces/ces.tsx
@@ -18,7 +18,7 @@ import { MowsService } from '@/fsd/4-entities/mow/mows.service';
 import { UpgradesService as FsdUpgradesService, UpgradeImage } from '@/fsd/4-entities/upgrade';
 
 import { ActiveGoalsDialog } from '@/fsd/3-features/goals/active-goals-dialog';
-import { CharacterRaidGoalSelect, TypedGoalSelect } from '@/fsd/3-features/goals/goals.models';
+import { CharacterRaidGoalSelect, TypedGoalSelect, isUnitlessMaterialGoal } from '@/fsd/3-features/goals/goals.models';
 import { GoalsService } from '@/fsd/3-features/goals/goals.service';
 import { UpgradesService } from '@/fsd/3-features/goals/upgrades.service';
 
@@ -60,7 +60,7 @@ function getNameAndIconForMaterialGoal(goal: IUpgradeMaterialGoal): { name: stri
 }
 
 function getNameAndIcon(goal: TypedGoalSelect): { name: string; icon: string } {
-    if (goal.type === PersonalGoalType.UpgradeMaterial || goal.type === PersonalGoalType.PreFarmMaterialForGoals) {
+    if (isUnitlessMaterialGoal(goal)) {
         if (goal.type === PersonalGoalType.UpgradeMaterial) return getNameAndIconForMaterialGoal(goal);
         const material = FsdUpgradesService.getUpgradeMaterial(goal.upgradeMaterialId);
         return { name: material?.label ?? goal.upgradeMaterialId, icon: material?.icon ?? '' };

--- a/src/fsd/1-pages/plan-ces/ces.tsx
+++ b/src/fsd/1-pages/plan-ces/ces.tsx
@@ -60,7 +60,11 @@ function getNameAndIconForMaterialGoal(goal: IUpgradeMaterialGoal): { name: stri
 }
 
 function getNameAndIcon(goal: TypedGoalSelect): { name: string; icon: string } {
-    if (goal.type === PersonalGoalType.UpgradeMaterial) return getNameAndIconForMaterialGoal(goal);
+    if (goal.type === PersonalGoalType.UpgradeMaterial || goal.type === PersonalGoalType.PreFarmMaterialForGoals) {
+        if (goal.type === PersonalGoalType.UpgradeMaterial) return getNameAndIconForMaterialGoal(goal);
+        const material = FsdUpgradesService.getUpgradeMaterial(goal.upgradeMaterialId);
+        return { name: material?.label ?? goal.upgradeMaterialId, icon: material?.icon ?? '' };
+    }
     return getNameAndIconForCharGoal(goal);
 }
 
@@ -84,7 +88,7 @@ export const CEs = () => {
 
     const [showAllBattles, setShowAllBattles] = useState(false);
 
-    const { allGoals, shardsGoals, upgradeMaterialGoals, upgradeRankOrMowGoals } = useMemo(
+    const { allGoals, shardsGoals, upgradeMaterialGoals, upgradeRankOrMowGoals, preFarmGoals } = useMemo(
         () => GoalsService.prepareGoals(goals, units, false),
         [goals, units]
     );
@@ -98,6 +102,7 @@ export const CEs = () => {
         () => upgradeRankOrMowGoals.filter(x => x.include),
         [upgradeRankOrMowGoals]
     );
+    const includedPreFarmGoals = useMemo(() => preFarmGoals.filter(x => x.include), [preFarmGoals]);
 
     const handleGoalsSelectionChange = useCallback(
         (selection: TypedGoalSelect[]) => {
@@ -127,7 +132,12 @@ export const CEs = () => {
             },
             chars,
             mows,
-            ...[includedUpgradeMaterialGoals, includedUpgradeRankOrMowGoals, includedShardsGoals].flat()
+            ...[
+                includedPreFarmGoals,
+                includedUpgradeMaterialGoals,
+                includedUpgradeRankOrMowGoals,
+                includedShardsGoals,
+            ].flat()
         );
     }, [
         dailyRaidsPreferences,
@@ -137,6 +147,7 @@ export const CEs = () => {
         onslaughtTokensToday,
         chars,
         mows,
+        includedPreFarmGoals,
         includedUpgradeMaterialGoals,
         includedUpgradeRankOrMowGoals,
         includedShardsGoals,

--- a/src/fsd/1-pages/ui-kit/ui-kit.page.tsx
+++ b/src/fsd/1-pages/ui-kit/ui-kit.page.tsx
@@ -199,10 +199,8 @@ const GoalCardShowcase = () => {
     const resolvedMows = useMemo(() => MowsService.resolveAllFromStorage(mows), [mows]);
     const units = useMemo(() => [...resolvedChars, ...resolvedMows], [resolvedChars, resolvedMows]);
 
-    const { shardsGoals, upgradeRankOrMowGoals, upgradeMaterialGoals, upgradeAbilities, ascendGoals } = useMemo(
-        () => GoalsService.prepareGoals(goals, units, false),
-        [goals, units]
-    );
+    const { shardsGoals, upgradeRankOrMowGoals, upgradeMaterialGoals, upgradeAbilities, ascendGoals, preFarmGoals } =
+        useMemo(() => GoalsService.prepareGoals(goals, units, false), [goals, units]);
 
     const onslaughtTokensToday = useMemo(
         () => UpgradesService.computeOnslaughtTokensToday(gameModeTokens),
@@ -246,7 +244,9 @@ const GoalCardShowcase = () => {
                 upgradeMaterialGoals,
                 upgradeRankOrMowGoals,
                 upgradeAbilities,
-                resolvedChars
+                resolvedChars,
+                undefined,
+                preFarmGoals
             ),
         [
             estimatedUpgradesTotal,
@@ -255,6 +255,7 @@ const GoalCardShowcase = () => {
             upgradeRankOrMowGoals,
             upgradeAbilities,
             resolvedChars,
+            preFarmGoals,
         ]
     );
 
@@ -1242,7 +1243,8 @@ const GoalsSectionGrid = ({ rows, variant, goalsEstimates, densityClass, rowHeig
                     data.type === PersonalGoalType.MowAbilities ||
                     data.type === PersonalGoalType.UpgradeMaterial;
                 const raidsUnitId =
-                    data.type === PersonalGoalType.UpgradeMaterial
+                    data.type === PersonalGoalType.UpgradeMaterial ||
+                    data.type === PersonalGoalType.PreFarmMaterialForGoals
                         ? (data.upgradeMaterialId ?? data.goalId)
                         : data.unitId;
                 const isActive = data.include !== false;
@@ -1292,7 +1294,10 @@ const GoalsSectionGrid = ({ rows, variant, goalsEstimates, densityClass, rowHeig
             valueGetter: params => {
                 const data = params.data;
                 if (!data) return '';
-                return data.type === PersonalGoalType.UpgradeMaterial ? data.upgradeMaterialId : data.unitName;
+                return data.type === PersonalGoalType.UpgradeMaterial ||
+                    data.type === PersonalGoalType.PreFarmMaterialForGoals
+                    ? data.upgradeMaterialId
+                    : data.unitName;
             },
             cellRenderer: (params: ICellRendererParams<TypedGoalSelect>) => {
                 const { data } = params;
@@ -1300,7 +1305,10 @@ const GoalsSectionGrid = ({ rows, variant, goalsEstimates, densityClass, rowHeig
                 let portrait: React.ReactNode;
                 let name: string;
                 let subline: string;
-                if (data.type === PersonalGoalType.UpgradeMaterial) {
+                if (
+                    data.type === PersonalGoalType.UpgradeMaterial ||
+                    data.type === PersonalGoalType.PreFarmMaterialForGoals
+                ) {
                     const mat = UpgradeEntityService.getUpgradeMaterial(data.upgradeMaterialId);
                     portrait = mat ? (
                         <UpgradeImage
@@ -1312,7 +1320,7 @@ const GoalsSectionGrid = ({ rows, variant, goalsEstimates, densityClass, rowHeig
                         />
                     ) : undefined;
                     name = mat?.label ?? '';
-                    subline = 'Material';
+                    subline = data.type === PersonalGoalType.PreFarmMaterialForGoals ? 'Pre-farm' : 'Material';
                 } else {
                     portrait = (
                         <UnitShardIcon icon={data.unitRoundIcon} height={30} width={30} tooltip={data.unitName} />
@@ -1703,7 +1711,12 @@ const GoalsSectionGrid = ({ rows, variant, goalsEstimates, densityClass, rowHeig
             cellRenderer: (params: ICellRendererParams<TypedGoalSelect>) => {
                 const { data } = params;
                 const est = goalsEstimates.find(x => x.goalId === data?.goalId);
-                if (!data || !est?.orbsEstimate || data.type === PersonalGoalType.UpgradeMaterial) {
+                if (
+                    !data ||
+                    !est?.orbsEstimate ||
+                    data.type === PersonalGoalType.UpgradeMaterial ||
+                    data.type === PersonalGoalType.PreFarmMaterialForGoals
+                ) {
                     return (
                         <div className="flex h-full items-center text-sm leading-normal text-(--soft-fg) opacity-50">
                             —
@@ -1923,8 +1936,15 @@ const GoalsTableShowcase = () => {
     const resolvedMows = useMemo(() => MowsService.resolveAllFromStorage(mows), [mows]);
     const units = useMemo(() => [...resolvedChars, ...resolvedMows], [resolvedChars, resolvedMows]);
 
-    const { allGoals, shardsGoals, upgradeRankOrMowGoals, upgradeMaterialGoals, upgradeAbilities, ascendGoals } =
-        useMemo(() => GoalsService.prepareGoals(goals, units, false), [goals, units]);
+    const {
+        allGoals,
+        shardsGoals,
+        upgradeRankOrMowGoals,
+        upgradeMaterialGoals,
+        upgradeAbilities,
+        ascendGoals,
+        preFarmGoals,
+    } = useMemo(() => GoalsService.prepareGoals(goals, units, false), [goals, units]);
 
     const onslaughtTokensToday = useMemo(
         () => UpgradesService.computeOnslaughtTokensToday(gameModeTokens),
@@ -1968,7 +1988,9 @@ const GoalsTableShowcase = () => {
                 upgradeMaterialGoals,
                 upgradeRankOrMowGoals,
                 upgradeAbilities,
-                resolvedChars
+                resolvedChars,
+                undefined,
+                preFarmGoals
             ),
         [
             estimatedUpgradesTotal,
@@ -1977,6 +1999,7 @@ const GoalsTableShowcase = () => {
             upgradeRankOrMowGoals,
             upgradeAbilities,
             resolvedChars,
+            preFarmGoals,
         ]
     );
 

--- a/src/fsd/3-features/goals/active-goals-dialog.tsx
+++ b/src/fsd/3-features/goals/active-goals-dialog.tsx
@@ -54,11 +54,19 @@ export const ActiveGoalsDialog: React.FC<Props> = ({ goals, units, onGoalsSelect
         const goalToEdit = goals.find(x => x.goalId === goalId);
         if (!goalToEdit) return;
 
-        const unitId = goalToEdit.type === PersonalGoalType.UpgradeMaterial ? undefined : goalToEdit.unitId;
+        const unitId =
+            goalToEdit.type === PersonalGoalType.UpgradeMaterial ||
+            goalToEdit.type === PersonalGoalType.PreFarmMaterialForGoals
+                ? undefined
+                : goalToEdit.unitId;
         const characterToEdit =
             unitId === undefined ? undefined : units.find(x => x.id === unitId || x.snowprintId === unitId);
 
-        if (goalToEdit.type === PersonalGoalType.UpgradeMaterial || characterToEdit) {
+        if (
+            goalToEdit.type === PersonalGoalType.UpgradeMaterial ||
+            goalToEdit.type === PersonalGoalType.PreFarmMaterialForGoals ||
+            characterToEdit
+        ) {
             setEditGoal(goalToEdit);
             setEditUnit(characterToEdit);
         }
@@ -76,6 +84,7 @@ export const ActiveGoalsDialog: React.FC<Props> = ({ goals, units, onGoalsSelect
         return currentSelected !== initialSelected;
     }, [currentGoalsSelect, goals]);
 
+    const preFarmGoals = currentGoalsSelect.filter(x => x.type === PersonalGoalType.PreFarmMaterialForGoals);
     const upgradeMaterialGoals = currentGoalsSelect.filter(x => x.type === PersonalGoalType.UpgradeMaterial);
     const upgradeRankGoals = currentGoalsSelect.filter(x => x.type === PersonalGoalType.UpgradeRank);
     const upgradeMowGoals = currentGoalsSelect.filter(x => x.type === PersonalGoalType.MowAbilities);
@@ -155,6 +164,7 @@ export const ActiveGoalsDialog: React.FC<Props> = ({ goals, units, onGoalsSelect
                         {ascendGoals.length > 0 && renderGoalsGroup('Ascend/Promote', ascendGoals)}
                         {unlockGoals.length > 0 && renderGoalsGroup('Unlock', unlockGoals)}
                         {upgradeMaterialGoals.length > 0 && renderGoalsGroup('Upgrade Material', upgradeMaterialGoals)}
+                        {preFarmGoals.length > 0 && renderGoalsGroup('Pre-farm Material', preFarmGoals)}
                     </div>
                 </PortalDialog.Body>
 
@@ -175,11 +185,14 @@ export const ActiveGoalsDialog: React.FC<Props> = ({ goals, units, onGoalsSelect
             </PortalDialog>
 
             {editGoal !== undefined &&
-                (editUnit !== undefined || editGoal.type === PersonalGoalType.UpgradeMaterial) && (
+                (editUnit !== undefined ||
+                    editGoal.type === PersonalGoalType.UpgradeMaterial ||
+                    editGoal.type === PersonalGoalType.PreFarmMaterialForGoals) && (
                     <EditGoalDialog
                         isOpen={true}
                         goal={editGoal}
                         unit={editUnit}
+                        allGoals={goals}
                         onClose={() => {
                             setEditGoal(undefined);
                         }}

--- a/src/fsd/3-features/goals/active-goals-dialog.tsx
+++ b/src/fsd/3-features/goals/active-goals-dialog.tsx
@@ -9,7 +9,7 @@ import { EditGoalDialog } from 'src/shared-components/goals/edit-goal-dialog';
 import { Button, PortalDialog } from '@/fsd/5-shared/ui';
 
 import { IUnit } from '@/fsd/3-features/characters/characters.models';
-import { TypedGoalSelect } from '@/fsd/3-features/goals/goals.models';
+import { TypedGoalSelect, isUnitlessMaterialGoal } from '@/fsd/3-features/goals/goals.models';
 import { RaidsGoal } from '@/fsd/3-features/goals/raids-goal';
 
 interface Props {
@@ -54,19 +54,11 @@ export const ActiveGoalsDialog: React.FC<Props> = ({ goals, units, onGoalsSelect
         const goalToEdit = goals.find(x => x.goalId === goalId);
         if (!goalToEdit) return;
 
-        const unitId =
-            goalToEdit.type === PersonalGoalType.UpgradeMaterial ||
-            goalToEdit.type === PersonalGoalType.PreFarmMaterialForGoals
-                ? undefined
-                : goalToEdit.unitId;
+        const unitId = isUnitlessMaterialGoal(goalToEdit) ? undefined : goalToEdit.unitId;
         const characterToEdit =
             unitId === undefined ? undefined : units.find(x => x.id === unitId || x.snowprintId === unitId);
 
-        if (
-            goalToEdit.type === PersonalGoalType.UpgradeMaterial ||
-            goalToEdit.type === PersonalGoalType.PreFarmMaterialForGoals ||
-            characterToEdit
-        ) {
+        if (isUnitlessMaterialGoal(goalToEdit) || characterToEdit) {
             setEditGoal(goalToEdit);
             setEditUnit(characterToEdit);
         }

--- a/src/fsd/3-features/goals/goals.models.ts
+++ b/src/fsd/3-features/goals/goals.models.ts
@@ -19,7 +19,7 @@ import {
     ICharacterUpgradeMow,
     ICharacterUpgradeRankGoal,
 } from '@/fsd/4-entities/goal';
-import { IUpgradeMaterialGoal } from '@/fsd/4-entities/goal/model';
+import { IPreFarmMaterialForGoalsGoal, IUpgradeMaterialGoal } from '@/fsd/4-entities/goal/model';
 import { IBaseUpgrade } from '@/fsd/4-entities/upgrade';
 
 import {
@@ -44,7 +44,7 @@ export type CharacterRaidGoalSelect =
     | ICharacterUpgradeMow
     | ICharacterUpgradeAbilities;
 
-export type TypedGoalSelect = CharacterRaidGoalSelect | IUpgradeMaterialGoal;
+export type TypedGoalSelect = CharacterRaidGoalSelect | IUpgradeMaterialGoal | IPreFarmMaterialForGoalsGoal;
 
 /**
  * Personal goal payload for upgrading a character's abilities.

--- a/src/fsd/3-features/goals/goals.models.ts
+++ b/src/fsd/3-features/goals/goals.models.ts
@@ -46,6 +46,13 @@ export type CharacterRaidGoalSelect =
 
 export type TypedGoalSelect = CharacterRaidGoalSelect | IUpgradeMaterialGoal | IPreFarmMaterialForGoalsGoal;
 
+/** Returns true for goals that have no associated unit (material-farming and pre-farm goals). */
+export function isUnitlessMaterialGoal(
+    goal: TypedGoalSelect
+): goal is IUpgradeMaterialGoal | IPreFarmMaterialForGoalsGoal {
+    return goal.type === PersonalGoalType.UpgradeMaterial || goal.type === PersonalGoalType.PreFarmMaterialForGoals;
+}
+
 /**
  * Personal goal payload for upgrading a character's abilities.
  *

--- a/src/fsd/3-features/goals/goals.service.ts
+++ b/src/fsd/3-features/goals/goals.service.ts
@@ -10,7 +10,7 @@ import { Alliance, Rank, Rarity, RarityStars, XP_BOOK_VALUE, XP_BOOK_ORDER } fro
 
 import { CharactersService } from '@/fsd/4-entities/character';
 import { ICharacter2 } from '@/fsd/4-entities/character/model';
-import { IUpgradeMaterialGoal } from '@/fsd/4-entities/goal/model';
+import { IPreFarmMaterialForGoalsGoal, IUpgradeMaterialGoal } from '@/fsd/4-entities/goal/model';
 import { IMow2, IMowLevelMaterials, MowsService } from '@/fsd/4-entities/mow';
 import { OrbAscensionCalculator } from '@/fsd/4-entities/unit/unit-ascension.service';
 import { isCharacter, isMow } from '@/fsd/4-entities/unit/units.functions';
@@ -109,11 +109,12 @@ export class GoalsService {
         upgradeRankOrMowGoals: Array<ICharacterUpgradeRankGoal | ICharacterUpgradeMow>,
         upgradeAbilities: Array<ICharacterUpgradeAbilities>,
         characters: ICharacter2[],
-        isGoalPriority: boolean = false
+        isGoalPriority: boolean = false,
+        preFarmGoals: IPreFarmMaterialForGoalsGoal[] = []
     ): IGoalEstimate[] {
         const result: IGoalEstimate[] = [];
 
-        for (const goal of [shardsGoals, upgradeMaterialGoals, upgradeRankOrMowGoals].flat()) {
+        for (const goal of [shardsGoals, upgradeMaterialGoals, upgradeRankOrMowGoals, preFarmGoals].flat()) {
             const estimate: IGoalEstimate = {
                 goalId: goal.goalId,
                 energyTotal: 0,
@@ -224,7 +225,7 @@ export class GoalsService {
             if (blockedEntries.length === 0) {
                 estimate.blocked = false;
             } else if (isGoalPriority) {
-                const allGoals = [...shardsGoals, ...upgradeMaterialGoals, ...upgradeRankOrMowGoals];
+                const allGoals = [...shardsGoals, ...upgradeMaterialGoals, ...upgradeRankOrMowGoals, ...preFarmGoals];
                 const goalPriorityMap = new Map(allGoals.map(g => [g.goalId, g.priority]));
 
                 estimate.blocked = blockedEntries.some(blockedEntry => {
@@ -305,6 +306,7 @@ export class GoalsService {
         shardsGoals: Array<ICharacterUnlockGoal | ICharacterAscendGoal>;
         upgradeRankOrMowGoals: Array<ICharacterUpgradeRankGoal | ICharacterUpgradeMow>;
         upgradeMaterialGoals: IUpgradeMaterialGoal[];
+        preFarmGoals: IPreFarmMaterialForGoalsGoal[];
         upgradeAbilities: Array<ICharacterUpgradeAbilities>;
         ascendGoals: Array<ICharacterAscendGoal>;
     } {
@@ -318,7 +320,10 @@ export class GoalsService {
                         x.snowprintId === (resolvedChar?.snowprintId ?? '') ||
                         x.snowprintId === (resolvedMow?.snowprintId ?? '')
                 );
-                if (g.type === PersonalGoalType.UpgradeMaterial) {
+                if (
+                    g.type === PersonalGoalType.UpgradeMaterial ||
+                    g.type === PersonalGoalType.PreFarmMaterialForGoals
+                ) {
                     return this.convertToTypedGoal(g);
                 } else if (
                     ![
@@ -347,7 +352,13 @@ export class GoalsService {
             [PersonalGoalType.UpgradeRank, PersonalGoalType.MowAbilities].includes(x.type)
         ) as Array<ICharacterUpgradeRankGoal>;
 
-        const upgradeMaterialGoals = selectedGoals.filter(x => x.type === PersonalGoalType.UpgradeMaterial);
+        const upgradeMaterialGoals = selectedGoals.filter(
+            x => x.type === PersonalGoalType.UpgradeMaterial
+        ) as IUpgradeMaterialGoal[];
+
+        const preFarmGoals = selectedGoals.filter(
+            x => x.type === PersonalGoalType.PreFarmMaterialForGoals
+        ) as IPreFarmMaterialForGoalsGoal[];
 
         const upgradeAbilities = selectedGoals.filter(x =>
             [PersonalGoalType.CharacterAbilities].includes(x.type)
@@ -362,6 +373,7 @@ export class GoalsService {
             shardsGoals,
             upgradeRankOrMowGoals,
             upgradeMaterialGoals,
+            preFarmGoals,
             upgradeAbilities,
             ascendGoals,
         };
@@ -383,6 +395,19 @@ export class GoalsService {
                 quantity: g.upgradeMaterialQuantity,
                 notes: g.notes,
             } as IUpgradeMaterialGoal;
+        }
+
+        if (g.type === PersonalGoalType.PreFarmMaterialForGoals) {
+            if (!g.upgradeMaterialId) return;
+            return {
+                type: PersonalGoalType.PreFarmMaterialForGoals,
+                priority: g.priority,
+                goalId: g.id,
+                include: g.dailyRaids,
+                upgradeMaterialId: g.upgradeMaterialId,
+                goalIds: g.preFarmGoalIds ?? [],
+                notes: g.notes ?? '',
+            } as IPreFarmMaterialForGoalsGoal;
         }
 
         if (!unit) {
@@ -636,6 +661,13 @@ export class GoalsService {
                     ...base,
                     upgradeMaterialId: goal.upgradeMaterialId,
                     upgradeMaterialQuantity: goal.quantity,
+                };
+            }
+            case PersonalGoalType.PreFarmMaterialForGoals: {
+                return {
+                    ...base,
+                    upgradeMaterialId: goal.upgradeMaterialId,
+                    preFarmGoalIds: goal.goalIds,
                 };
             }
             default: {

--- a/src/fsd/3-features/goals/raids-goal.tsx
+++ b/src/fsd/3-features/goals/raids-goal.tsx
@@ -22,11 +22,14 @@ interface Props {
 
 export const RaidsGoal: React.FC<Props> = ({ goal, onSelectChange, onGoalEdit }) => {
     const material =
-        goal.type === PersonalGoalType.UpgradeMaterial
+        goal.type === PersonalGoalType.UpgradeMaterial || goal.type === PersonalGoalType.PreFarmMaterialForGoals
             ? UpgradesService.getUpgradeMaterial(goal.upgradeMaterialId ?? '')
             : undefined;
 
-    const tooltopText = goal.type === PersonalGoalType.UpgradeMaterial ? material?.label : goal.unitName;
+    const tooltopText =
+        goal.type === PersonalGoalType.UpgradeMaterial || goal.type === PersonalGoalType.PreFarmMaterialForGoals
+            ? material?.label
+            : goal.unitName;
 
     const getGoalInfo = (goal: TypedGoalSelect) => {
         switch (goal.type) {
@@ -117,6 +120,13 @@ export const RaidsGoal: React.FC<Props> = ({ goal, onSelectChange, onGoalEdit })
                     </AccessibleTooltip>
                 );
             }
+            case PersonalGoalType.PreFarmMaterialForGoals: {
+                return (
+                    <AccessibleTooltip title={'Pre-farm material goal'}>
+                        <span>{material?.label ?? ''}</span>
+                    </AccessibleTooltip>
+                );
+            }
         }
     };
 
@@ -130,17 +140,19 @@ export const RaidsGoal: React.FC<Props> = ({ goal, onSelectChange, onGoalEdit })
                     </IconButton>
                     <AccessibleTooltip title={tooltopText}>
                         <div>
-                            {goal.type === PersonalGoalType.UpgradeMaterial && (
+                            {(goal.type === PersonalGoalType.UpgradeMaterial ||
+                                goal.type === PersonalGoalType.PreFarmMaterialForGoals) && (
                                 <UpgradeImage
-                                    material={material!.snowprintId}
-                                    iconPath={material!.icon!}
+                                    material={material?.snowprintId ?? ''}
+                                    iconPath={material?.icon ?? ''}
                                     rarity={RarityMapper.stringToRarityString(material?.rarity ?? '')}
                                     size={40}
                                 />
                             )}
-                            {goal.type !== PersonalGoalType.UpgradeMaterial && (
-                                <UnitShardIcon icon={goal.unitRoundIcon} name={goal.unitName} />
-                            )}
+                            {goal.type !== PersonalGoalType.UpgradeMaterial &&
+                                goal.type !== PersonalGoalType.PreFarmMaterialForGoals && (
+                                    <UnitShardIcon icon={goal.unitRoundIcon} name={goal.unitName} />
+                                )}
                         </div>
                     </AccessibleTooltip>
                     {getGoalInfo(goal)}

--- a/src/fsd/3-features/goals/raids-goal.tsx
+++ b/src/fsd/3-features/goals/raids-goal.tsx
@@ -12,7 +12,7 @@ import { RankIcon, RarityIcon, StarsIcon, UnitShardIcon } from '@/fsd/5-shared/u
 
 import { UpgradeImage, UpgradesService } from '@/fsd/4-entities/upgrade';
 
-import { TypedGoalSelect } from '@/fsd/3-features/goals/goals.models';
+import { TypedGoalSelect, isUnitlessMaterialGoal } from '@/fsd/3-features/goals/goals.models';
 
 interface Props {
     goal: TypedGoalSelect;
@@ -21,15 +21,11 @@ interface Props {
 }
 
 export const RaidsGoal: React.FC<Props> = ({ goal, onSelectChange, onGoalEdit }) => {
-    const material =
-        goal.type === PersonalGoalType.UpgradeMaterial || goal.type === PersonalGoalType.PreFarmMaterialForGoals
-            ? UpgradesService.getUpgradeMaterial(goal.upgradeMaterialId ?? '')
-            : undefined;
+    const material = isUnitlessMaterialGoal(goal)
+        ? UpgradesService.getUpgradeMaterial(goal.upgradeMaterialId ?? '')
+        : undefined;
 
-    const tooltopText =
-        goal.type === PersonalGoalType.UpgradeMaterial || goal.type === PersonalGoalType.PreFarmMaterialForGoals
-            ? material?.label
-            : goal.unitName;
+    const tooltopText = isUnitlessMaterialGoal(goal) ? material?.label : goal.unitName;
 
     const getGoalInfo = (goal: TypedGoalSelect) => {
         switch (goal.type) {
@@ -140,8 +136,7 @@ export const RaidsGoal: React.FC<Props> = ({ goal, onSelectChange, onGoalEdit })
                     </IconButton>
                     <AccessibleTooltip title={tooltopText}>
                         <div>
-                            {(goal.type === PersonalGoalType.UpgradeMaterial ||
-                                goal.type === PersonalGoalType.PreFarmMaterialForGoals) && (
+                            {isUnitlessMaterialGoal(goal) && (
                                 <UpgradeImage
                                     material={material?.snowprintId ?? ''}
                                     iconPath={material?.icon ?? ''}
@@ -149,10 +144,9 @@ export const RaidsGoal: React.FC<Props> = ({ goal, onSelectChange, onGoalEdit })
                                     size={40}
                                 />
                             )}
-                            {goal.type !== PersonalGoalType.UpgradeMaterial &&
-                                goal.type !== PersonalGoalType.PreFarmMaterialForGoals && (
-                                    <UnitShardIcon icon={goal.unitRoundIcon} name={goal.unitName} />
-                                )}
+                            {!isUnitlessMaterialGoal(goal) && (
+                                <UnitShardIcon icon={goal.unitRoundIcon} name={goal.unitName} />
+                            )}
                         </div>
                     </AccessibleTooltip>
                     {getGoalInfo(goal)}

--- a/src/fsd/3-features/goals/upgrades.service.ts
+++ b/src/fsd/3-features/goals/upgrades.service.ts
@@ -18,7 +18,7 @@ import { CampaignsService, CampaignType, Campaign, ICampaignBattleComposed } fro
 import { campaignEventsLocations, campaignsByGroup } from '@/fsd/4-entities/campaign/campaigns.constants';
 import { CharactersService, CharacterUpgradesService, IUnitUpgradeRank } from '@/fsd/4-entities/character';
 import { ICharacter2, IUnitShards } from '@/fsd/4-entities/character/model';
-import { IUpgradeMaterialGoal } from '@/fsd/4-entities/goal/model';
+import { IPreFarmMaterialForGoalsGoal, IUpgradeMaterialGoal } from '@/fsd/4-entities/goal/model';
 import { IMow2, mows2Data, MowsService } from '@/fsd/4-entities/mow';
 import { NpcService } from '@/fsd/4-entities/npc/@x/unit';
 import {
@@ -41,6 +41,7 @@ import {
     IUnitUpgrade,
     IUpgradeRaid,
     IUpgradesRaidsDay,
+    TypedGoalSelect,
 } from '@/fsd/3-features/goals/goals.models';
 
 import { getOnslaughtRewardMidpoint } from '@/fsd/1-pages/input-onslaught/onslaught-rewards';
@@ -125,6 +126,7 @@ export class UpgradesService {
             | ICharacterAscendGoal
             | ICharacterUnlockGoal
             | IUpgradeMaterialGoal
+            | IPreFarmMaterialForGoalsGoal
         >,
         Map<string, number>
     >();
@@ -142,6 +144,7 @@ export class UpgradesService {
             | ICharacterAscendGoal
             | ICharacterUnlockGoal
             | IUpgradeMaterialGoal
+            | IPreFarmMaterialForGoalsGoal
         >
     ): Map<string, number> {
         const cached = this.goalPriorityByIdCache.get(goals);
@@ -178,6 +181,7 @@ export class UpgradesService {
             | ICharacterAscendGoal
             | ICharacterUnlockGoal
             | IUpgradeMaterialGoal
+            | IPreFarmMaterialForGoalsGoal
         >,
         cache: Map<string, { neededByHigherPriorityGoals: number; stillNeededForGoal: number; totalRemaining: number }>
     ): void {
@@ -305,19 +309,23 @@ export class UpgradesService {
             | ICharacterAscendGoal
             | ICharacterUnlockGoal
             | IUpgradeMaterialGoal
+            | IPreFarmMaterialForGoalsGoal
         >
     ): IEstimatedUpgrades {
         performance.mark('getUpgradesEstimatedDays-start');
         const inventoryUpgrades = this.canonicalizeInventoryUpgrades(settings.upgrades, chars, mows);
 
-        const unitsUpgrades = this.getUpgrades(inventoryUpgrades, chars, mows, goals);
+        const isGoalPriorityMode = settings.preferences.farmPreferences?.order === IDailyRaidsFarmOrder.goalPriority;
+        const goalsForUpgrades = goals;
+
+        const unitsUpgrades = this.getUpgrades(inventoryUpgrades, chars, mows, goalsForUpgrades);
 
         const combinedBaseMaterials = this.combineBaseMaterials(unitsUpgrades);
 
         this.populateLocationsData(combinedBaseMaterials, settings);
 
         this.removeLocationsForOnslaughtOnlyGoals(
-            goals,
+            goalsForUpgrades,
             Object.values(combinedBaseMaterials).flatMap(x => x.locations)
         );
 
@@ -332,13 +340,13 @@ export class UpgradesService {
             }
         >();
 
-        this.precomputeHigherPriorityNeeds(combinedBaseMaterials, goals, remainingNeededCache);
+        this.precomputeHigherPriorityNeeds(combinedBaseMaterials, goalsForUpgrades, remainingNeededCache);
 
         const { upgradesRaids, remainingMats } = this.generateDailyRaidsList(
             settings,
             chars,
             mows,
-            goals,
+            goalsForUpgrades,
             combinedBaseMaterials,
             inventoryUpgrades,
             remainingNeededCache
@@ -368,9 +376,9 @@ export class UpgradesService {
             };
         });
 
-        const isGoalPriority = settings.preferences.farmPreferences?.order === IDailyRaidsFarmOrder.goalPriority;
+        const isGoalPriority = isGoalPriorityMode;
         const goalPriorityEstimates = isGoalPriority
-            ? this.getGoalPriorityEstimates(combinedBaseMaterials, inventoryUpgrades, goals, chars, mows)
+            ? this.getGoalPriorityEstimates(combinedBaseMaterials, inventoryUpgrades, goalsForUpgrades, chars, mows)
             : undefined;
 
         const finishedMaterials = isGoalPriority
@@ -450,6 +458,7 @@ export class UpgradesService {
             | ICharacterAscendGoal
             | ICharacterUnlockGoal
             | IUpgradeMaterialGoal
+            | IPreFarmMaterialForGoalsGoal
         >
     ): boolean {
         if (!mat.id.startsWith('shards_') && !mat.id.startsWith('mythicShards_')) {
@@ -458,12 +467,15 @@ export class UpgradesService {
             // We have shard goals but no place to farm them, check for onslaught.
             const rawGoal = goals.find(goal => mat.relatedGoals.find(relatedGoal => goal.goalId === relatedGoal));
             if (rawGoal === undefined) return false;
-            if (rawGoal.type === PersonalGoalType.UpgradeMaterial) {
+            if (
+                rawGoal.type === PersonalGoalType.UpgradeMaterial ||
+                rawGoal.type === PersonalGoalType.PreFarmMaterialForGoals
+            ) {
                 return mat.locations.some(loc => loc.isSuggested);
             }
             const goal = rawGoal as Exclude<
                 ICharacterUpgradeRankGoal | ICharacterUpgradeMow | ICharacterAscendGoal | ICharacterUnlockGoal,
-                IUpgradeMaterialGoal
+                IUpgradeMaterialGoal | IPreFarmMaterialForGoalsGoal
             >;
             if (goal === undefined || goal.type === PersonalGoalType.Unlock) {
                 // we either don't have a goal, or we have an unlock goal that we can't farm, so the goal is blocked.
@@ -569,6 +581,7 @@ export class UpgradesService {
             | ICharacterAscendGoal
             | ICharacterUnlockGoal
             | IUpgradeMaterialGoal
+            | IPreFarmMaterialForGoalsGoal
         >,
         locs: ICampaignBattleComposed[]
     ): void {
@@ -630,6 +643,7 @@ export class UpgradesService {
             | ICharacterAscendGoal
             | ICharacterUnlockGoal
             | IUpgradeMaterialGoal
+            | IPreFarmMaterialForGoalsGoal
         >,
         combinedBaseMaterials: Record<string, ICombinedUpgrade>,
         inventoryUpgrades: Record<string, number>,
@@ -757,6 +771,7 @@ export class UpgradesService {
             | ICharacterAscendGoal
             | ICharacterUnlockGoal
             | IUpgradeMaterialGoal
+            | IPreFarmMaterialForGoalsGoal
         >,
         combinedBaseMaterials: Record<string, ICombinedUpgrade>,
         inventory: Record<string, number>,
@@ -857,6 +872,7 @@ export class UpgradesService {
             | ICharacterAscendGoal
             | ICharacterUnlockGoal
             | IUpgradeMaterialGoal
+            | IPreFarmMaterialForGoalsGoal
         >,
         remainingMats: Record<string, ICombinedUpgrade>
     ): Map<string, GoalPriorityLocationsState> | undefined {
@@ -911,6 +927,7 @@ export class UpgradesService {
             | ICharacterAscendGoal
             | ICharacterUnlockGoal
             | IUpgradeMaterialGoal
+            | IPreFarmMaterialForGoalsGoal
         >,
         remainingNeededCache: Map<
             string,
@@ -1026,7 +1043,10 @@ export class UpgradesService {
                 for (const loc of sortedCandidateLocs) {
                     if (energy < minEnergy) break;
                     const raidKey = `${loc.rewards.potential[0].id}::${goal.goalId}`;
-                    const unitId = goal.type === PersonalGoalType.UpgradeMaterial ? '' : goal.unitId;
+                    const isUnitless =
+                        goal.type === PersonalGoalType.UpgradeMaterial ||
+                        goal.type === PersonalGoalType.PreFarmMaterialForGoals;
+                    const unitId = isUnitless ? '' : goal.unitId;
                     energy = this.raidLocation(
                         day,
                         energy,
@@ -1072,6 +1092,7 @@ export class UpgradesService {
             | ICharacterAscendGoal
             | ICharacterUnlockGoal
             | IUpgradeMaterialGoal
+            | IPreFarmMaterialForGoalsGoal
         >,
         goalId: string | undefined,
         options: { raidKey?: string; goal?: { goalId: string; unitId: string } } | undefined,
@@ -1211,6 +1232,7 @@ export class UpgradesService {
             | ICharacterAscendGoal
             | ICharacterUnlockGoal
             | IUpgradeMaterialGoal
+            | IPreFarmMaterialForGoalsGoal
         >,
         goalId: string | undefined,
         options: { raidKey?: string; goal?: { goalId: string; unitId: string } } | undefined,
@@ -1300,6 +1322,7 @@ export class UpgradesService {
             | ICharacterAscendGoal
             | ICharacterUnlockGoal
             | IUpgradeMaterialGoal
+            | IPreFarmMaterialForGoalsGoal
         >,
         goalId: string | undefined,
         cache?: Map<string, { neededByHigherPriorityGoals: number; stillNeededForGoal: number; totalRemaining: number }>
@@ -1372,6 +1395,7 @@ export class UpgradesService {
             | ICharacterAscendGoal
             | ICharacterUnlockGoal
             | IUpgradeMaterialGoal
+            | IPreFarmMaterialForGoalsGoal
         >,
         cache?: Map<string, { neededByHigherPriorityGoals: number; stillNeededForGoal: number; totalRemaining: number }>
     ): string | undefined {
@@ -1421,6 +1445,7 @@ export class UpgradesService {
             | ICharacterAscendGoal
             | ICharacterUnlockGoal
             | IUpgradeMaterialGoal
+            | IPreFarmMaterialForGoalsGoal
         >,
         highestPriorityGoalId?: string,
         cache: Map<
@@ -1459,6 +1484,7 @@ export class UpgradesService {
             | ICharacterAscendGoal
             | ICharacterUnlockGoal
             | IUpgradeMaterialGoal
+            | IPreFarmMaterialForGoalsGoal
         >,
         combinedBaseMaterials: Record<string, ICombinedUpgrade>,
         inventory: Record<string, number>,
@@ -1547,6 +1573,7 @@ export class UpgradesService {
             | ICharacterAscendGoal
             | ICharacterUnlockGoal
             | IUpgradeMaterialGoal
+            | IPreFarmMaterialForGoalsGoal
         >,
         combinedBaseMaterials: Record<string, ICombinedUpgrade>,
         inventory: Record<string, number>,
@@ -2247,6 +2274,76 @@ export class UpgradesService {
     }
 
     /**
+    /** Returns how many of `materialId` a single rank-up or MoW goal requires, ignoring inventory. */
+    public static computeRawMaterialCountForGoal(
+        materialId: string,
+        goal: ICharacterUpgradeRankGoal | ICharacterUpgradeMow
+    ): number {
+        const upgradeRanks =
+            goal.type === PersonalGoalType.UpgradeRank
+                ? CharacterUpgradesService.getCharacterUpgradeRank(goal)
+                : this.getMowUpgradeRank(goal);
+        const rawMaterials = this.getBaseUpgradesTotal({}, upgradeRanks, undefined, {});
+        const count = rawMaterials[materialId] ?? 0;
+        if (count === 0) return 0;
+
+        if (goal.upgradesRarity && goal.upgradesRarity.length > 0) {
+            const upgradeData = FsdUpgradesService.baseUpgradesData[materialId];
+            if (
+                upgradeData &&
+                upgradeData.rarity !== 'Shard' &&
+                upgradeData.rarity !== 'Mythic Shard' &&
+                !goal.upgradesRarity.includes(upgradeData.rarity as Rarity)
+            )
+                return 0;
+        }
+
+        return count;
+    }
+
+    /**
+     * Sums the raw (inventory-independent) count of a specific material across all active rank-up/MoW
+     * goals referenced by a pre-farm goal. Used to compute how much to farm for that pre-farm goal.
+     */
+    public static computeRawDemandForPreFarmGoal(
+        preFarmGoal: IPreFarmMaterialForGoalsGoal,
+        allGoals: ReadonlyArray<TypedGoalSelect>
+    ): number {
+        const upgradeData = FsdUpgradesService.baseUpgradesData[preFarmGoal.upgradeMaterialId];
+        let total = 0;
+        for (const goalId of preFarmGoal.goalIds) {
+            const goal = allGoals.find(g => g.goalId === goalId);
+            if (!goal || !goal.include) continue;
+            let upgradeRanks: IUnitUpgradeRank[] | undefined;
+            if (goal.type === PersonalGoalType.UpgradeRank) {
+                upgradeRanks = CharacterUpgradesService.getCharacterUpgradeRank(goal);
+            } else if (goal.type === PersonalGoalType.MowAbilities) {
+                upgradeRanks = this.getMowUpgradeRank(goal);
+            } else {
+                continue;
+            }
+            // Use empty inventory so we get the raw (pre-inventory) demand.
+            const rawMaterials = this.getBaseUpgradesTotal({}, upgradeRanks, undefined, {});
+            const count = rawMaterials[preFarmGoal.upgradeMaterialId] ?? 0;
+            if (count === 0) continue;
+
+            if (
+                'upgradesRarity' in goal &&
+                goal.upgradesRarity &&
+                goal.upgradesRarity.length > 0 &&
+                upgradeData &&
+                upgradeData.rarity !== 'Shard' &&
+                upgradeData.rarity !== 'Mythic Shard' &&
+                !goal.upgradesRarity.includes(upgradeData.rarity as Rarity)
+            )
+                continue;
+
+            total += count;
+        }
+        return total;
+    }
+
+    /**
      * Computes and returns a list of unit upgrades, one per goal, based on the provided inventory and goal definitions.
      *
      * This method processes each goal, determines the required upgrade ranks, filters upgrades by rarity if specified,
@@ -2269,11 +2366,48 @@ export class UpgradesService {
             | ICharacterAscendGoal
             | ICharacterUnlockGoal
             | IUpgradeMaterialGoal
+            | IPreFarmMaterialForGoalsGoal
         >
     ): IUnitUpgrade[] {
         const result: IUnitUpgrade[] = [];
         const clonedUpgrades = { ...inventoryUpgrades };
+
+        // Pre-pass: for each active pre-farm goal, record which material it covers for each active referenced goal.
+        // This prevents the referenced rank-up/MoW goals from double-counting those materials.
+        const materialCoveredByPreFarm = new Map<string, Set<string>>(); // referencedGoalId → Set<materialId>
         for (const goal of goals) {
+            if (goal.type !== PersonalGoalType.PreFarmMaterialForGoals || !goal.include) continue;
+            for (const referencedGoalId of goal.goalIds) {
+                const referencedGoal = goals.find(g => g.goalId === referencedGoalId);
+                if (!referencedGoal?.include) continue;
+                const covered = materialCoveredByPreFarm.get(referencedGoalId) ?? new Set<string>();
+                covered.add(goal.upgradeMaterialId);
+                materialCoveredByPreFarm.set(referencedGoalId, covered);
+            }
+        }
+
+        for (const goal of goals) {
+            // Pre-farm goals: compute raw demand from all active referenced goals, inject farmed amount
+            // back into clonedUpgrades so subsequent goals see it as available inventory.
+            if (goal.type === PersonalGoalType.PreFarmMaterialForGoals) {
+                if (!goal.include) continue;
+                const rawDemand = this.computeRawDemandForPreFarmGoal(goal, goals);
+                const materialLabel = FsdUpgradesService.getUpgradeMaterial(goal.upgradeMaterialId)?.label ?? '';
+                result.push({
+                    goalId: goal.goalId,
+                    unitId: '',
+                    label: materialLabel,
+                    upgradeMaterials: {},
+                    upgradeRanks: [],
+                    upgradeShards: undefined,
+                    baseUpgradesTotal: { [goal.upgradeMaterialId]: rawDemand },
+                    relatedUpgrades: [],
+                });
+                // Inject the total demand into clonedUpgrades: subsequent goals see the pre-farmed amount.
+                clonedUpgrades[goal.upgradeMaterialId] = (clonedUpgrades[goal.upgradeMaterialId] ?? 0) + rawDemand;
+                continue;
+            }
+
             const upgradeMaterials = (() => {
                 if (goal.type !== PersonalGoalType.UpgradeMaterial) return {};
                 return { [goal.upgradeMaterialId]: goal.quantity };
@@ -2310,6 +2444,14 @@ export class UpgradesService {
                 clonedUpgrades
             );
 
+            // Remove materials already managed by an active pre-farm goal for this goal.
+            const coveredMaterials = materialCoveredByPreFarm.get(goal.goalId);
+            if (coveredMaterials) {
+                for (const materialId of coveredMaterials) {
+                    delete baseUpgradesTotal[materialId];
+                }
+            }
+
             if ('upgradesRarity' in goal && goal.upgradesRarity && goal.upgradesRarity.length > 0) {
                 // remove upgrades that do not match to selected rarities
                 for (const upgradeId in baseUpgradesTotal) {
@@ -2338,13 +2480,13 @@ export class UpgradesService {
                 return result;
             });
 
+            const isUnitlessGoal = goal.type === PersonalGoalType.UpgradeMaterial;
             result.push({
                 goalId: goal.goalId,
-                unitId: goal.type === PersonalGoalType.UpgradeMaterial ? '' : goal.unitId,
-                label:
-                    goal.type === PersonalGoalType.UpgradeMaterial
-                        ? (FsdUpgradesService.getUpgradeMaterial(goal.upgradeMaterialId)?.label ?? '')
-                        : goal.unitName,
+                unitId: isUnitlessGoal ? '' : goal.unitId,
+                label: isUnitlessGoal
+                    ? (FsdUpgradesService.getUpgradeMaterial(goal.upgradeMaterialId)?.label ?? '')
+                    : goal.unitName,
                 upgradeMaterials,
                 upgradeRanks,
                 upgradeShards,
@@ -2429,6 +2571,7 @@ export class UpgradesService {
             | ICharacterAscendGoal
             | ICharacterUnlockGoal
             | IUpgradeMaterialGoal
+            | IPreFarmMaterialForGoalsGoal
         >,
         chars: ICharacter2[],
         mows: IMow2[]
@@ -2453,7 +2596,11 @@ export class UpgradesService {
                     requiredCount,
                     countByGoalId: { [goal.goalId]: requiredCount },
                     relatedGoals: [goal.goalId],
-                    relatedCharacters: goal.type === PersonalGoalType.UpgradeMaterial ? [] : [goal.unitId],
+                    relatedCharacters:
+                        goal.type === PersonalGoalType.UpgradeMaterial ||
+                        goal.type === PersonalGoalType.PreFarmMaterialForGoals
+                            ? []
+                            : [goal.unitId],
                 };
 
                 const estimate = this.getUpgradeEstimate(perGoalUpgrade, requiredCount, acquiredCount);

--- a/src/fsd/3-features/goals/upgrades.service.ts
+++ b/src/fsd/3-features/goals/upgrades.service.ts
@@ -2309,36 +2309,12 @@ export class UpgradesService {
         preFarmGoal: IPreFarmMaterialForGoalsGoal,
         allGoals: ReadonlyArray<TypedGoalSelect>
     ): number {
-        const upgradeData = FsdUpgradesService.baseUpgradesData[preFarmGoal.upgradeMaterialId];
         let total = 0;
         for (const goalId of preFarmGoal.goalIds) {
             const goal = allGoals.find(g => g.goalId === goalId);
             if (!goal || !goal.include) continue;
-            let upgradeRanks: IUnitUpgradeRank[] | undefined;
-            if (goal.type === PersonalGoalType.UpgradeRank) {
-                upgradeRanks = CharacterUpgradesService.getCharacterUpgradeRank(goal);
-            } else if (goal.type === PersonalGoalType.MowAbilities) {
-                upgradeRanks = this.getMowUpgradeRank(goal);
-            } else {
-                continue;
-            }
-            // Use empty inventory so we get the raw (pre-inventory) demand.
-            const rawMaterials = this.getBaseUpgradesTotal({}, upgradeRanks, undefined, {});
-            const count = rawMaterials[preFarmGoal.upgradeMaterialId] ?? 0;
-            if (count === 0) continue;
-
-            if (
-                'upgradesRarity' in goal &&
-                goal.upgradesRarity &&
-                goal.upgradesRarity.length > 0 &&
-                upgradeData &&
-                upgradeData.rarity !== 'Shard' &&
-                upgradeData.rarity !== 'Mythic Shard' &&
-                !goal.upgradesRarity.includes(upgradeData.rarity as Rarity)
-            )
-                continue;
-
-            total += count;
+            if (goal.type !== PersonalGoalType.UpgradeRank && goal.type !== PersonalGoalType.MowAbilities) continue;
+            total += this.computeRawMaterialCountForGoal(preFarmGoal.upgradeMaterialId, goal);
         }
         return total;
     }

--- a/src/fsd/4-entities/goal/enums.ts
+++ b/src/fsd/4-entities/goal/enums.ts
@@ -5,6 +5,7 @@ export enum PersonalGoalType {
     MowAbilities = 4,
     CharacterAbilities = 5,
     UpgradeMaterial = 6,
+    PreFarmMaterialForGoals = 7,
 }
 
 export enum CampaignsLocationsUsage {

--- a/src/fsd/4-entities/goal/index.ts
+++ b/src/fsd/4-entities/goal/index.ts
@@ -5,4 +5,5 @@ export type {
     ICharacterUnlockGoal,
     ICharacterAscendGoal,
     ICharacterRaidGoalSelectBase,
+    IPreFarmMaterialForGoalsGoal,
 } from './model';

--- a/src/fsd/4-entities/goal/model.ts
+++ b/src/fsd/4-entities/goal/model.ts
@@ -37,6 +37,12 @@ export interface IUpgradeMaterialGoal extends IGenericGoal {
     quantity: number;
 }
 
+export interface IPreFarmMaterialForGoalsGoal extends IGenericGoal {
+    type: PersonalGoalType.PreFarmMaterialForGoals;
+    upgradeMaterialId: string;
+    goalIds: string[];
+}
+
 export interface ICharacterUpgradeMow extends ICharacterRaidGoalSelectBase {
     type: PersonalGoalType.MowAbilities;
 

--- a/src/models/interfaces.ts
+++ b/src/models/interfaces.ts
@@ -408,6 +408,9 @@ export interface IPersonalGoal {
     // farm specifc upgrade material
     upgradeMaterialId?: string;
     upgradeMaterialQuantity?: number;
+
+    // pre-farm material for goals
+    preFarmGoalIds?: string[];
 }
 
 export interface IEstimatedRanksSettings {

--- a/src/reducers/goals.reducer.ts
+++ b/src/reducers/goals.reducer.ts
@@ -67,7 +67,14 @@ export const goalsReducer = (state: IPersonalGoal[], action: GoalsAction) => {
             }));
         }
         case 'Delete': {
-            return state.filter(x => x.id !== action.goalId).map((x, index) => ({ ...x, priority: index + 1 }));
+            const deletedId = action.goalId;
+            return state
+                .filter(x => x.id !== deletedId)
+                .map((x, index) => ({
+                    ...x,
+                    priority: index + 1,
+                    ...(x.preFarmGoalIds ? { preFarmGoalIds: x.preFarmGoalIds.filter(id => id !== deletedId) } : {}),
+                }));
         }
         case 'DeleteAll': {
             return [];

--- a/src/routes/goals/goals-table.tsx
+++ b/src/routes/goals/goals-table.tsx
@@ -451,7 +451,10 @@ export const GoalsTable: React.FC<Props> = ({
                 cellRenderer: (params: ICellRendererParams<TypedGoalSelect>) => {
                     const { data } = params;
                     if (data) {
-                        if (data.type === PersonalGoalType.UpgradeMaterial) {
+                        if (
+                            data.type === PersonalGoalType.UpgradeMaterial ||
+                            data.type === PersonalGoalType.PreFarmMaterialForGoals
+                        ) {
                             const mat = UpgradesService.getUpgradeMaterial(data.upgradeMaterialId);
                             if (mat !== undefined) {
                                 return (

--- a/src/routes/goals/goals.tsx
+++ b/src/routes/goals/goals.tsx
@@ -122,15 +122,22 @@ export const Goals = () => {
     const resolvedMows = useMemo(() => MowsService.resolveAllFromStorage(mows), [mows]);
     const units = useMemo(() => [...characters, ...resolvedMows], [characters, resolvedMows]);
 
-    const { allGoals, shardsGoals, upgradeRankOrMowGoals, upgradeMaterialGoals, ascendGoals, upgradeAbilities } =
-        useMemo(
-            () => GoalsService.prepareGoals(goals, units, false, onslaughtPreferences),
-            [goals, units, onslaughtPreferences]
-        );
+    const {
+        allGoals,
+        shardsGoals,
+        upgradeRankOrMowGoals,
+        upgradeMaterialGoals,
+        preFarmGoals,
+        ascendGoals,
+        upgradeAbilities,
+    } = useMemo(
+        () => GoalsService.prepareGoals(goals, units, false, onslaughtPreferences),
+        [goals, units, onslaughtPreferences]
+    );
 
     // Add these sorts to ensure the UI matches the global priority order
     const sortedShards = shardsGoals.toSorted((a, b) => a.priority - b.priority);
-    const sortedUpgrades = [upgradeMaterialGoals, upgradeRankOrMowGoals]
+    const sortedUpgrades = [preFarmGoals, upgradeMaterialGoals, upgradeRankOrMowGoals]
         .flat()
         .toSorted((a, b) => a.priority - b.priority);
     const sortedAbilities = upgradeAbilities.toSorted((a, b) => a.priority - b.priority);
@@ -154,7 +161,7 @@ export const Goals = () => {
         },
         characters,
         resolvedMows,
-        ...[upgradeMaterialGoals, upgradeRankOrMowGoals, shardsGoals].flat().filter(x => x.include)
+        ...[preFarmGoals, upgradeMaterialGoals, upgradeRankOrMowGoals, shardsGoals].flat().filter(x => x.include)
     );
 
     const energyAlreadySpent = useMemo(() => {
@@ -232,12 +239,18 @@ export const Goals = () => {
         if (item === 'edit') {
             const goal = allGoals.find(x => x.goalId === goalId);
             const relatedUnit =
-                goal?.type === PersonalGoalType.UpgradeMaterial
+                goal?.type === PersonalGoalType.UpgradeMaterial ||
+                goal?.type === PersonalGoalType.PreFarmMaterialForGoals
                     ? undefined
                     : [...characters, ...resolvedMows].find(
                           x => x.snowprintId === goal?.unitId || x.id === goal?.unitId
                       );
-            if (goal && (goal.type === PersonalGoalType.UpgradeMaterial || relatedUnit !== undefined)) {
+            if (
+                goal &&
+                (goal.type === PersonalGoalType.UpgradeMaterial ||
+                    goal.type === PersonalGoalType.PreFarmMaterialForGoals ||
+                    relatedUnit !== undefined)
+            ) {
                 setEditUnit(relatedUnit);
                 setEditGoal(goal);
             }
@@ -274,7 +287,8 @@ export const Goals = () => {
                 upgradeRankOrMowGoals,
                 upgradeAbilities,
                 characters,
-                isGoalPriority
+                isGoalPriority,
+                preFarmGoals
             ),
         [
             estimatedUpgradesTotal,
@@ -284,6 +298,7 @@ export const Goals = () => {
             upgradeAbilities,
             characters,
             isGoalPriority,
+            preFarmGoals,
         ]
     );
 
@@ -330,6 +345,20 @@ export const Goals = () => {
                 ...merged,
                 ...aggregated,
                 goalId: first.goalId,
+            };
+        }
+
+        // For pre-farm goals, compute raw demand from active referenced goals.
+        if (goal?.type === PersonalGoalType.PreFarmMaterialForGoals) {
+            const matId = goal.upgradeMaterialId;
+            const held = inventory.upgrades[matId] ?? 0;
+            const rawDemand = UpgradesService.computeRawDemandForPreFarmGoal(goal, allGoals);
+            first.materialQuantityInfo = {
+                held,
+                totalNeeded: rawDemand,
+                thisGoalQuantity: rawDemand,
+                isGoalPriority,
+                coveredByInventory: isGoalPriority ? Math.min(held, rawDemand) : undefined,
             };
         }
 
@@ -789,11 +818,14 @@ export const Goals = () => {
                 </Accordion>
             )}
             {editGoal !== undefined &&
-                (editUnit !== undefined || editGoal.type === PersonalGoalType.UpgradeMaterial) && (
+                (editUnit !== undefined ||
+                    editGoal.type === PersonalGoalType.UpgradeMaterial ||
+                    editGoal.type === PersonalGoalType.PreFarmMaterialForGoals) && (
                     <EditGoalDialog
                         isOpen={true}
                         goal={editGoal}
                         unit={editUnit}
+                        allGoals={allGoals}
                         onClose={() => {
                             setEditGoal(undefined);
                         }}

--- a/src/routes/tables/daily-raids.tsx
+++ b/src/routes/tables/daily-raids.tsx
@@ -70,7 +70,7 @@ export const DailyRaids = () => {
         [inventory.upgrades, storeCharacters, resolvedMows]
     );
     const units = useMemo(() => [...storeCharacters, ...resolvedMows], [storeCharacters, resolvedMows]);
-    const { allGoals, shardsGoals, upgradeMaterialGoals, upgradeRankOrMowGoals } = useMemo(() => {
+    const { allGoals, shardsGoals, upgradeMaterialGoals, upgradeRankOrMowGoals, preFarmGoals } = useMemo(() => {
         return GoalsService.prepareGoals(goals, units, true, onslaughtPreferences);
     }, [goals, units, onslaughtPreferences]);
 
@@ -138,6 +138,7 @@ export const DailyRaids = () => {
             },
             resolvedCharacters,
             resolvedMows,
+            ...preFarmGoals,
             ...upgradeMaterialGoals,
             ...upgradeRankOrMowGoals,
             ...shardsGoals
@@ -155,6 +156,7 @@ export const DailyRaids = () => {
         campaignsProgress,
         gameModeTokens,
         upgradeMaterialGoals,
+        preFarmGoals,
         onslaughtPreferences,
     ]);
 
@@ -172,6 +174,7 @@ export const DailyRaids = () => {
             },
             resolvedCharacters,
             resolvedMows,
+            ...preFarmGoals,
             ...upgradeMaterialGoals,
             ...upgradeRankOrMowGoals,
             ...shardsGoals
@@ -190,6 +193,7 @@ export const DailyRaids = () => {
         gameModeTokens,
         onslaughtPreferences,
         upgradeMaterialGoals,
+        preFarmGoals,
     ]);
 
     const mowCounts = useMemo(

--- a/src/shared-components/goals/edit-goal-dialog.tsx
+++ b/src/shared-components/goals/edit-goal-dialog.tsx
@@ -29,15 +29,21 @@ import { CharactersAbilitiesService } from '@/fsd/3-features/characters/characte
 import { ICharacterAscendGoal, TypedGoalSelect } from '@/fsd/3-features/goals/goals.models';
 
 import { IgnoreRankRarity } from './ignore-rank-rarity';
+import { PreFarmGoalSelector } from './pre-farm-goal-selector';
+
+const GOAL_EDIT_TITLE: Partial<Record<PersonalGoalType, string>> = {
+    [PersonalGoalType.PreFarmMaterialForGoals]: 'Pre-Farm Goal',
+};
 
 interface Props {
     isOpen: boolean;
     goal: TypedGoalSelect;
     unit: IUnit | undefined;
+    allGoals?: TypedGoalSelect[];
     onClose?: (goal?: TypedGoalSelect) => void;
 }
 
-export const EditGoalDialog: React.FC<Props> = ({ isOpen, onClose, goal, unit }) => {
+export const EditGoalDialog: React.FC<Props> = ({ isOpen, onClose, goal, unit, allGoals }) => {
     const { goals, campaignsProgress, inventory, onslaughtPreferences } = useContext(StoreContext);
     const dispatch = useContext(DispatchContext);
 
@@ -52,6 +58,11 @@ export const EditGoalDialog: React.FC<Props> = ({ isOpen, onClose, goal, unit })
             if (updatedGoal.type === PersonalGoalType.UpgradeMaterial) {
                 const material = UpgradesService.getUpgradeMaterial(updatedGoal.upgradeMaterialId);
                 enqueueSnackbar(`Goal for ${material?.material ?? 'unknown material'} was updated`, {
+                    variant: 'success',
+                });
+            } else if (updatedGoal.type === PersonalGoalType.PreFarmMaterialForGoals) {
+                const material = UpgradesService.getUpgradeMaterial(updatedGoal.upgradeMaterialId);
+                enqueueSnackbar(`Pre-farm goal for ${material?.material ?? 'material'} was updated`, {
                     variant: 'success',
                 });
             } else {
@@ -116,7 +127,7 @@ export const EditGoalDialog: React.FC<Props> = ({ isOpen, onClose, goal, unit })
         .map(x => x.id);
 
     const material =
-        form.type === PersonalGoalType.UpgradeMaterial
+        form.type === PersonalGoalType.UpgradeMaterial || form.type === PersonalGoalType.PreFarmMaterialForGoals
             ? UpgradesService.getUpgradeMaterial(form.upgradeMaterialId)
             : undefined;
 
@@ -124,14 +135,18 @@ export const EditGoalDialog: React.FC<Props> = ({ isOpen, onClose, goal, unit })
         <PortalDialog open={openDialog} onClose={() => handleClose()} aria-label="Edit goal">
             <PortalDialog.Header>
                 <div className="flex items-center gap-2">
-                    <span>Edit {PersonalGoalType[goal.type]} Goal</span>
-                    {goal.type === PersonalGoalType.UpgradeMaterial ? (
-                        <UpgradeImage
-                            material={material?.snowprintId ?? ''}
-                            iconPath={material?.icon ?? ''}
-                            size={40}
-                            rarity={RarityMapper.stringToRarityString(material?.rarity ?? '')}
-                        />
+                    <span>Edit {GOAL_EDIT_TITLE[goal.type] ?? PersonalGoalType[goal.type]} Goal</span>
+                    {goal.type === PersonalGoalType.UpgradeMaterial ||
+                    goal.type === PersonalGoalType.PreFarmMaterialForGoals ? (
+                        <div className="flex items-center gap-2">
+                            <UpgradeImage
+                                material={material?.snowprintId ?? ''}
+                                iconPath={material?.icon ?? ''}
+                                size={40}
+                                rarity={RarityMapper.stringToRarityString(material?.rarity ?? '')}
+                            />
+                            <span className="text-sm font-normal text-(--soft-fg)">{material?.material}</span>
+                        </div>
                     ) : (
                         <UnitShardIcon icon={goal.unitRoundIcon} />
                     )}
@@ -397,6 +412,15 @@ export const EditGoalDialog: React.FC<Props> = ({ isOpen, onClose, goal, unit })
                                     quantity: Math.max(1, quantity),
                                 }));
                             }}
+                        />
+                    )}
+
+                    {form.type === PersonalGoalType.PreFarmMaterialForGoals && allGoals && (
+                        <PreFarmGoalSelector
+                            materialId={form.upgradeMaterialId}
+                            allGoals={allGoals}
+                            selectedGoalIds={form.goalIds}
+                            onChange={goalIds => setForm(current => ({ ...current, goalIds }))}
                         />
                     )}
 

--- a/src/shared-components/goals/pre-farm-goal-selector.tsx
+++ b/src/shared-components/goals/pre-farm-goal-selector.tsx
@@ -2,6 +2,7 @@ import { Pause, Play } from 'lucide-react';
 import React, { useMemo } from 'react';
 
 import { Rank } from '@/fsd/5-shared/model';
+import { Button } from '@/fsd/5-shared/ui';
 import { RarityIcon, UnitShardIcon } from '@/fsd/5-shared/ui/icons';
 
 import { PersonalGoalType } from '@/fsd/4-entities/goal';
@@ -110,9 +111,13 @@ export const PreFarmGoalSelector: React.FC<Props> = ({ materialId, allGoals, sel
         <div className="flex flex-col gap-1">
             <div className="flex items-center justify-between">
                 <label className="text-sm font-medium text-(--soft-fg)">Goals that require this material</label>
-                <button type="button" onClick={toggleAll} className="text-xs text-(--primary) hover:underline">
+                <Button
+                    appearance="plain"
+                    size="extra-small"
+                    onPress={toggleAll}
+                    className="text-xs text-(--primary) hover:underline">
                     {allSelected ? 'Deselect all' : 'Select all'}
-                </button>
+                </Button>
             </div>
             <div className="flex flex-col gap-1 rounded-lg border border-(--border) p-2">
                 {eligibleGoals.map(goal => {

--- a/src/shared-components/goals/pre-farm-goal-selector.tsx
+++ b/src/shared-components/goals/pre-farm-goal-selector.tsx
@@ -1,0 +1,146 @@
+import { Pause, Play } from 'lucide-react';
+import React, { useMemo } from 'react';
+
+import { Rank } from '@/fsd/5-shared/model';
+import { RarityIcon, UnitShardIcon } from '@/fsd/5-shared/ui/icons';
+
+import { PersonalGoalType } from '@/fsd/4-entities/goal';
+
+import { ICharacterUpgradeMow, ICharacterUpgradeRankGoal, TypedGoalSelect } from '@/fsd/3-features/goals/goals.models';
+import { UpgradesService } from '@/fsd/3-features/goals/upgrades.service';
+
+const RANK_ABBREV: Record<number, string> = {
+    [Rank.Stone1]: 'St1',
+    [Rank.Stone2]: 'St2',
+    [Rank.Stone3]: 'St3',
+    [Rank.Iron1]: 'I1',
+    [Rank.Iron2]: 'I2',
+    [Rank.Iron3]: 'I3',
+    [Rank.Bronze1]: 'Br1',
+    [Rank.Bronze2]: 'Br2',
+    [Rank.Bronze3]: 'Br3',
+    [Rank.Silver1]: 'S1',
+    [Rank.Silver2]: 'S2',
+    [Rank.Silver3]: 'S3',
+    [Rank.Gold1]: 'G1',
+    [Rank.Gold2]: 'G2',
+    [Rank.Gold3]: 'G3',
+    [Rank.Diamond1]: 'D1',
+    [Rank.Diamond2]: 'D2',
+    [Rank.Diamond3]: 'D3',
+    [Rank.Adamantine1]: 'A1',
+    [Rank.Adamantine2]: 'A2',
+    [Rank.Adamantine3]: 'A3',
+};
+
+function rankLabel(rank: number, point5: boolean, appliedUpgrades: number): string {
+    const base = RANK_ABBREV[rank] ?? String(rank);
+    if (rank >= Rank.Diamond3 && appliedUpgrades > 0) return `${base}.${appliedUpgrades}`;
+    if (rank < Rank.Diamond3 && point5) return `${base}.5`;
+    return base;
+}
+
+function GoalSummary({ goal }: { goal: ICharacterUpgradeRankGoal | ICharacterUpgradeMow }) {
+    if (goal.type === PersonalGoalType.UpgradeRank) {
+        const start = rankLabel(goal.rankStart, goal.rankStartPoint5, goal.rankStartAppliedUpgrades ?? 0);
+        const end = rankLabel(goal.rankEnd, goal.rankPoint5, goal.rankAppliedUpgrades ?? 0);
+        const sortedRarities =
+            goal.upgradesRarity && goal.upgradesRarity.length > 0 ? goal.upgradesRarity.toSorted((a, b) => a - b) : [];
+        return (
+            <span className="flex items-center gap-1 text-sm text-(--fg)">
+                <span>
+                    {start} → {end}
+                </span>
+                {sortedRarities.length > 0 && (
+                    <span className="flex items-center gap-0.5">
+                        {sortedRarities.map(r => (
+                            <RarityIcon key={r} rarity={r} />
+                        ))}
+                    </span>
+                )}
+            </span>
+        );
+    }
+
+    const parts: string[] = [];
+    if (goal.primaryEnd > goal.primaryStart) parts.push(`P: ${goal.primaryStart}→${goal.primaryEnd}`);
+    if (goal.secondaryEnd > goal.secondaryStart) parts.push(`S: ${goal.secondaryStart}→${goal.secondaryEnd}`);
+    return <span className="text-sm text-(--fg)">{parts.join('  ')}</span>;
+}
+
+interface Props {
+    materialId: string;
+    allGoals: TypedGoalSelect[];
+    selectedGoalIds: string[];
+    onChange: (goalIds: string[]) => void;
+}
+
+export const PreFarmGoalSelector: React.FC<Props> = ({ materialId, allGoals, selectedGoalIds, onChange }) => {
+    const eligibleGoals = useMemo(() => {
+        return allGoals.filter((g): g is ICharacterUpgradeRankGoal | ICharacterUpgradeMow => {
+            if (g.type !== PersonalGoalType.UpgradeRank && g.type !== PersonalGoalType.MowAbilities) return false;
+            return UpgradesService.computeRawMaterialCountForGoal(materialId, g) > 0;
+        });
+    }, [materialId, allGoals]);
+
+    const allSelected = eligibleGoals.length > 0 && eligibleGoals.every(g => selectedGoalIds.includes(g.goalId));
+
+    const toggle = (goalId: string) => {
+        if (selectedGoalIds.includes(goalId)) {
+            onChange(selectedGoalIds.filter(id => id !== goalId));
+        } else {
+            onChange([...selectedGoalIds, goalId]);
+        }
+    };
+
+    const toggleAll = () => {
+        if (allSelected) {
+            onChange(selectedGoalIds.filter(id => !eligibleGoals.some(g => g.goalId === id)));
+        } else {
+            const toAdd = eligibleGoals.map(g => g.goalId).filter(id => !selectedGoalIds.includes(id));
+            onChange([...selectedGoalIds, ...toAdd]);
+        }
+    };
+
+    if (eligibleGoals.length === 0) {
+        return <div className="text-sm text-(--soft-fg)">No rank-up or MoW goals require this material.</div>;
+    }
+
+    return (
+        <div className="flex flex-col gap-1">
+            <div className="flex items-center justify-between">
+                <label className="text-sm font-medium text-(--soft-fg)">Goals that require this material</label>
+                <button type="button" onClick={toggleAll} className="text-xs text-(--primary) hover:underline">
+                    {allSelected ? 'Deselect all' : 'Select all'}
+                </button>
+            </div>
+            <div className="flex flex-col gap-1 rounded-lg border border-(--border) p-2">
+                {eligibleGoals.map(goal => {
+                    const checked = selectedGoalIds.includes(goal.goalId);
+                    const count = UpgradesService.computeRawMaterialCountForGoal(materialId, goal);
+                    return (
+                        <label
+                            key={goal.goalId}
+                            className="flex cursor-pointer items-center gap-2 rounded px-2 py-1 hover:bg-(--neutral)">
+                            <input
+                                type="checkbox"
+                                className="h-4 w-4 shrink-0"
+                                checked={checked}
+                                onChange={() => toggle(goal.goalId)}
+                            />
+                            {goal.include ? (
+                                <Play className="size-3.5 shrink-0 text-(--primary)" />
+                            ) : (
+                                <Pause className="size-3.5 shrink-0 text-(--soft-fg)" />
+                            )}
+                            <UnitShardIcon icon={goal.unitRoundIcon} width={28} height={28} name={goal.unitName} />
+                            <span className="min-w-0 shrink-0 text-sm font-medium text-(--fg)">{goal.unitName}</span>
+                            <GoalSummary goal={goal} />
+                            <span className="ml-auto shrink-0 text-xs text-(--soft-fg) tabular-nums">×{count}</span>
+                        </label>
+                    );
+                })}
+            </div>
+        </div>
+    );
+};

--- a/src/shared-components/goals/set-goal-dialog.tsx
+++ b/src/shared-components/goals/set-goal-dialog.tsx
@@ -28,6 +28,9 @@ import { IMaterial, UpgradeMaterialAutocomplete, UpgradesService } from '@/fsd/4
 
 import { CharactersAbilitiesService } from '@/fsd/3-features/characters/characters-abilities.service';
 import { ICharacter2, IUnit } from '@/fsd/3-features/characters/characters.models';
+import { GoalsService } from '@/fsd/3-features/goals/goals.service';
+
+import { PreFarmGoalSelector } from './pre-farm-goal-selector';
 
 const GOAL_TYPE_OPTIONS = [
     PersonalGoalType.UpgradeRank,
@@ -36,6 +39,7 @@ const GOAL_TYPE_OPTIONS = [
     PersonalGoalType.MowAbilities,
     PersonalGoalType.CharacterAbilities,
     PersonalGoalType.UpgradeMaterial,
+    PersonalGoalType.PreFarmMaterialForGoals,
 ];
 
 const GOAL_TYPE_LABELS: Record<number, string> = {
@@ -45,6 +49,7 @@ const GOAL_TYPE_LABELS: Record<number, string> = {
     [PersonalGoalType.MowAbilities]: 'MoW Abilities',
     [PersonalGoalType.CharacterAbilities]: 'Character Abilities',
     [PersonalGoalType.UpgradeMaterial]: 'Specific Upgrade Material',
+    [PersonalGoalType.PreFarmMaterialForGoals]: 'Pre-farm Material for Goals',
 };
 
 const getDefaultForm = (priority: number): IPersonalGoal => ({
@@ -64,12 +69,18 @@ const getDefaultForm = (priority: number): IPersonalGoal => ({
     upgradesRarity: [],
     upgradeMaterialId: undefined,
     upgradeMaterialQuantity: 0,
+    preFarmGoalIds: [],
 });
 
 export const SetGoalDialog = ({ onClose }: { onClose?: (goal?: IPersonalGoal) => void }) => {
     const { characters, mows, goals, campaignsProgress, onslaughtPreferences } = useContext(StoreContext);
 
     const resolvedMows = useMemo(() => MowsService.resolveAllFromStorage(mows), [mows]);
+
+    const allTypedGoals = useMemo(
+        () => GoalsService.prepareGoals(goals, [...characters, ...resolvedMows], false).allGoals,
+        [goals, characters, resolvedMows]
+    );
 
     const allAvailableMaterials = useMemo(
         () =>
@@ -109,6 +120,11 @@ export const SetGoalDialog = ({ onClose }: { onClose?: (goal?: IPersonalGoal) =>
                     {
                         variant: 'success',
                     }
+                );
+            } else if (goal.type === PersonalGoalType.PreFarmMaterialForGoals) {
+                enqueueSnackbar(
+                    `Pre-farm goal for ${UpgradesService.getUpgradeMaterial(goal.upgradeMaterialId ?? '(none)')?.material ?? 'material'} is added`,
+                    { variant: 'success' }
                 );
             } else {
                 const character = characters.find(c => c.snowprintId === goal.character);
@@ -209,7 +225,9 @@ export const SetGoalDialog = ({ onClose }: { onClose?: (goal?: IPersonalGoal) =>
             (newGoalType !== PersonalGoalType.Unlock && form.type === PersonalGoalType.Unlock) ||
             (newGoalType === PersonalGoalType.MowAbilities && form.type !== PersonalGoalType.MowAbilities) ||
             (newGoalType !== PersonalGoalType.MowAbilities && form.type === PersonalGoalType.MowAbilities) ||
-            newGoalType === PersonalGoalType.UpgradeMaterial
+            newGoalType === PersonalGoalType.UpgradeMaterial ||
+            newGoalType === PersonalGoalType.PreFarmMaterialForGoals ||
+            form.type === PersonalGoalType.PreFarmMaterialForGoals
         ) {
             setUnit(undefined);
         }
@@ -242,7 +260,9 @@ export const SetGoalDialog = ({ onClose }: { onClose?: (goal?: IPersonalGoal) =>
     };
 
     const isDisabled = () => {
-        if (unit === undefined && form.type !== PersonalGoalType.UpgradeMaterial) return true;
+        const noUnitRequired =
+            form.type === PersonalGoalType.UpgradeMaterial || form.type === PersonalGoalType.PreFarmMaterialForGoals;
+        if (unit === undefined && !noUnitRequired) return true;
 
         if (form.type === PersonalGoalType.UpgradeRank && isCharacter(unit)) {
             const startingRank = (form.startingRank ?? unit.rank ?? Rank.Stone1) as number;
@@ -283,6 +303,10 @@ export const SetGoalDialog = ({ onClose }: { onClose?: (goal?: IPersonalGoal) =>
                 form.upgradeMaterialQuantity === undefined ||
                 form.upgradeMaterialQuantity <= 0
             );
+        }
+
+        if (form.type === PersonalGoalType.PreFarmMaterialForGoals) {
+            return !form.upgradeMaterialId;
         }
 
         return false;
@@ -340,7 +364,11 @@ export const SetGoalDialog = ({ onClose }: { onClose?: (goal?: IPersonalGoal) =>
                         />
                     </div>
 
-                    <Conditional condition={form.type !== PersonalGoalType.UpgradeMaterial}>
+                    <Conditional
+                        condition={
+                            form.type !== PersonalGoalType.UpgradeMaterial &&
+                            form.type !== PersonalGoalType.PreFarmMaterialForGoals
+                        }>
                         <UnitsAutocomplete
                             // eslint-disable-next-line unicorn/no-null -- Autocomplete requires null
                             unit={unit ?? null}
@@ -517,6 +545,33 @@ export const SetGoalDialog = ({ onClose }: { onClose?: (goal?: IPersonalGoal) =>
                             <Conditional
                                 condition={!form.upgradeMaterialId || (form.upgradeMaterialQuantity ?? 0) <= 0}>
                                 <div className="text-sm text-(--danger)">Please select material and quantity</div>
+                            </Conditional>
+                        </div>
+                    )}
+
+                    {form.type === PersonalGoalType.PreFarmMaterialForGoals && (
+                        <div className="flex flex-col gap-4">
+                            <UpgradeMaterialAutocomplete
+                                value={UpgradesService.getUpgradeMaterial(form.upgradeMaterialId ?? '(none)')}
+                                options={allAvailableMaterials}
+                                onChange={material =>
+                                    setForm(current => ({
+                                        ...current,
+                                        upgradeMaterialId: material?.snowprintId,
+                                        preFarmGoalIds: [],
+                                    }))
+                                }
+                            />
+                            {form.upgradeMaterialId && (
+                                <PreFarmGoalSelector
+                                    materialId={form.upgradeMaterialId}
+                                    allGoals={allTypedGoals}
+                                    selectedGoalIds={form.preFarmGoalIds ?? []}
+                                    onChange={preFarmGoalIds => setForm(current => ({ ...current, preFarmGoalIds }))}
+                                />
+                            )}
+                            <Conditional condition={!form.upgradeMaterialId}>
+                                <div className="text-sm text-(--danger)">Please select a material</div>
                             </Conditional>
                         </div>
                     )}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for **“Pre-farm Material”** goals across goal cards, tables, daily raids, and estimate calculations.
  * You can now choose an **upgrade material**, select the related goals it covers, and view pre-farm specific summaries/labels.
  * The active goals and editing flows now include this goal type with the correct material-based presentation.

* **Bug Fixes**
  * Deleting a goal now also removes it from any related pre-farm goal selections.
  * Estimates and raid suggestions now recalculate properly when pre-farm selections change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->