### PR TITLE
Add incremental ascension goals

### DIFF
--- a/src/fsd/1-pages/input-guild-roster-snapshots/guild-roster-snapshots.tsx
+++ b/src/fsd/1-pages/input-guild-roster-snapshots/guild-roster-snapshots.tsx
@@ -148,7 +148,12 @@ export const GuildRosterSnapshots = () => {
                     )}
                 />
 
-                <Tabs value={activeTab} onChange={(_, value: GuildTab) => setActiveTab(value)}>
+                <Tabs
+                    value={activeTab}
+                    onChange={(_, value: GuildTab) => setActiveTab(value)}
+                    variant="scrollable"
+                    scrollButtons="auto"
+                    allowScrollButtonsMobile>
                     <Tab label="Rosters" value="rosters" />
                     <Tab label="Roster Snapshots" value="roster-snapshots" />
                     <Tab label="Members" value="members" />

--- a/src/fsd/3-features/goals/goals.service.ts
+++ b/src/fsd/3-features/goals/goals.service.ts
@@ -445,13 +445,19 @@ export class GoalsService {
             }
 
             if (g.type === PersonalGoalType.Ascend) {
+                const rarityStart = Math.max(g.startingRarity ?? unit.rarity, unit.rarity) as Rarity;
+                const starsStart: RarityStars =
+                    rarityStart === unit.rarity
+                        ? (Math.max(g.startingStars ?? unit.stars, unit.stars) as RarityStars)
+                        : (g.startingStars ?? rarityToStars[rarityStart]);
+                const useActualProgress = rarityStart === unit.rarity && starsStart === unit.stars;
                 const result: ICharacterAscendGoal = {
                     type: PersonalGoalType.Ascend,
-                    rarityStart: unit.rarity,
+                    rarityStart,
                     rarityEnd: g.targetRarity!,
-                    shards: unit.shards,
-                    mythicShards: unit.mythicShards ?? 0,
-                    starsStart: unit.stars,
+                    shards: useActualProgress ? unit.shards : 0,
+                    mythicShards: useActualProgress ? (unit.mythicShards ?? 0) : 0,
+                    starsStart,
                     starsEnd: g.targetStars ?? rarityToStars[g.targetRarity!],
                     onslaughtShards:
                         (g.shardsPerToken || undefined) ??
@@ -511,13 +517,19 @@ export class GoalsService {
                               onslaughtPreferences
                           )
                         : 0;
+                const rarityStart = Math.max(g.startingRarity ?? unit.rarity, unit.rarity) as Rarity;
+                const starsStart: RarityStars =
+                    rarityStart === unit.rarity
+                        ? (Math.max(g.startingStars ?? unit.stars, unit.stars) as RarityStars)
+                        : (g.startingStars ?? rarityToStars[rarityStart]);
+                const useActualProgress = rarityStart === unit.rarity && starsStart === unit.stars;
                 const result: ICharacterAscendGoal = {
                     type: PersonalGoalType.Ascend,
-                    rarityStart: unit.rarity,
+                    rarityStart,
                     rarityEnd: g.targetRarity!,
-                    shards: unit.shards,
-                    mythicShards: unit.mythicShards ?? 0,
-                    starsStart: unit.stars,
+                    shards: useActualProgress ? unit.shards : 0,
+                    mythicShards: useActualProgress ? (unit.mythicShards ?? 0) : 0,
+                    starsStart,
                     starsEnd: targetStars,
                     onslaughtShards:
                         (g.shardsPerToken || undefined) ??
@@ -630,6 +642,8 @@ export class GoalsService {
                 return {
                     ...base,
                     character: goal.unitId,
+                    startingRarity: goal.rarityStart,
+                    startingStars: goal.starsStart,
                     targetRarity: goal.rarityEnd,
                     targetStars: goal.starsEnd,
                     campaignsUsage: goal.campaignsUsage,

--- a/src/fsd/3-features/goals/upgrades.service.ts
+++ b/src/fsd/3-features/goals/upgrades.service.ts
@@ -2218,11 +2218,9 @@ export class UpgradesService {
         }
         const locked = char ? char.rank === Rank.Locked : !mow?.unlocked;
         if (locked) return this.getTotalShardsNeededForGoal(chars, mows, goal);
-        const rarity = unit.rarity ?? Rarity.Common;
-        const stars = unit.stars ?? RarityStars.None;
         const totalShardsNeeded = this.getTotalShardsNeededForGoal(chars, mows, goal);
-        const shardsForCurrentRarityAndStars = SHARDS_AT_RARITY_AND_STARS[rarity]?.[stars] ?? 0;
-        return Math.max(totalShardsNeeded - shardsForCurrentRarityAndStars, 0);
+        const shardsForGoalStart = SHARDS_AT_RARITY_AND_STARS[goal.rarityStart]?.[goal.starsStart] ?? 0;
+        return Math.max(totalShardsNeeded - shardsForGoalStart, 0);
     }
 
     /**
@@ -2246,12 +2244,10 @@ export class UpgradesService {
         if (!unit) return 0;
         const locked = char ? char.rank === Rank.Locked : !mow?.unlocked;
         if (locked) return this.getTotalMythicShardsNeededForGoal(goal);
-        const rarity = unit.rarity ?? Rarity.Common;
-        const stars = unit.stars ?? RarityStars.None;
-        if (rarity < Rarity.Mythic) return this.getTotalMythicShardsNeededForGoal(goal);
+        if (goal.rarityStart < Rarity.Mythic) return this.getTotalMythicShardsNeededForGoal(goal);
         const totalShardsNeeded = this.getTotalMythicShardsNeededForGoal(goal);
-        const shardsForCurrentRarityAndStars = MYTHIC_SHARDS_AT_RARITY_AND_STARS[stars] ?? 0;
-        return Math.max(totalShardsNeeded - shardsForCurrentRarityAndStars, 0);
+        const shardsForGoalStart = MYTHIC_SHARDS_AT_RARITY_AND_STARS[goal.starsStart] ?? 0;
+        return Math.max(totalShardsNeeded - shardsForGoalStart, 0);
     }
 
     public static getShardsForGoal(

--- a/src/fsd/3-features/goals/upgrades.service.ts
+++ b/src/fsd/3-features/goals/upgrades.service.ts
@@ -1753,6 +1753,12 @@ export class UpgradesService {
         mows: IMow2[],
         goal: ICharacterAscendGoal
     ): number {
+        const char = characters.find(x => x.snowprintId === goal.unitId);
+        const mow = mows.find(x => x.snowprintId === goal.unitId);
+        const unit = char ?? mow;
+        if (unit && (unit.rarity > goal.rarityEnd || (unit.rarity === goal.rarityEnd && unit.stars >= goal.starsEnd))) {
+            return 0;
+        }
         const shardData = this.getShardsForGoal(characters, mows, goal);
         const canRegular = this.canOnslaughtCharacterForRegularShards(goal.unitId, characters, mows, goal, inventory);
         const canMythic = this.canOnslaughtCharacterForMythicShards(goal.unitId, characters, mows, goal, inventory);
@@ -2175,24 +2181,20 @@ export class UpgradesService {
 
     /** Returns the number of incremental shards this unit has over its current rarity and stars. */
     private static getIncrementalShards(
-        chars: ICharacter2[],
-        mows: IMow2[],
+        _chars: ICharacter2[],
+        _mows: IMow2[],
         goal: ICharacterAscendGoal | ICharacterUnlockGoal
     ): number {
-        const unit = chars.find(x => x.snowprintId === goal.unitId) ?? mows.find(x => x.snowprintId === goal.unitId);
-        if (!unit) return 0;
-        return unit.shards;
+        return goal.shards;
     }
 
     /** Returns the number of incremental mythic shards this unit has over its current rarity and stars. */
     private static getIncrementalMythicShards(
-        chars: ICharacter2[],
-        mows: IMow2[],
+        _chars: ICharacter2[],
+        _mows: IMow2[],
         goal: ICharacterAscendGoal | ICharacterUnlockGoal
     ): number {
-        const unit = chars.find(x => x.snowprintId === goal.unitId) ?? mows.find(x => x.snowprintId === goal.unitId);
-        if (!unit) return 0;
-        return unit.mythicShards;
+        return goal.mythicShards;
     }
 
     /**

--- a/src/models/interfaces.ts
+++ b/src/models/interfaces.ts
@@ -389,6 +389,8 @@ export interface IPersonalGoal {
     rankAppliedUpgrades?: number; // 1-5: Adamantine+ upgrades to include at target rank (replaces point5)
     upgradesRarity?: Rarity[];
     // ascend
+    startingRarity?: Rarity;
+    startingStars?: RarityStars;
     targetRarity?: Rarity;
     targetStars?: RarityStars;
     shardsPerToken?: number;

--- a/src/shared-components/goals/set-ascend-goal.tsx
+++ b/src/shared-components/goals/set-ascend-goal.tsx
@@ -58,14 +58,14 @@ export const SetAscendGoal: React.FC<Props> = ({
     }, [startingRarity, currentRarity, currentStars]);
 
     const targetRarityValues = useMemo(() => {
-        return getEnumValues(Rarity).filter(x => x >= currentRarity);
-    }, [currentRarity]);
+        return getEnumValues(Rarity).filter(x => x >= startingRarity);
+    }, [startingRarity]);
 
     const starsEntries = useMemo(() => {
-        const minStars = rarityToStars[targetRarity];
+        const minStars = targetRarity === startingRarity ? startingStars : rarityToStars[targetRarity];
         const maxStars = rarityToMaxStars[targetRarity];
         return getEnumValues(RarityStars).filter(x => x >= minStars && x <= maxStars);
-    }, [currentStars, targetRarity]);
+    }, [startingRarity, startingStars, targetRarity]);
 
     const shardRangeLabel = useMemo(() => {
         if (!alliance) return;
@@ -125,7 +125,8 @@ export const SetAscendGoal: React.FC<Props> = ({
                     value={targetRarity}
                     valueChanges={value => {
                         onChange('targetRarity', value);
-                        onChange('targetStars', rarityToStars[value as Rarity]);
+                        const minStars = value === startingRarity ? startingStars : rarityToStars[value as Rarity];
+                        onChange('targetStars', minStars);
                     }}
                 />
 

--- a/src/shared-components/goals/set-ascend-goal.tsx
+++ b/src/shared-components/goals/set-ascend-goal.tsx
@@ -21,6 +21,8 @@ interface Props {
     targetRarity: Rarity;
     currentStars: RarityStars;
     targetStars: RarityStars;
+    startingRarity: Rarity;
+    startingStars: RarityStars;
     possibleLocations: ICampaignBattleComposed[];
     unlockedLocations: string[];
     campaignsUsage: CampaignsLocationsUsage;
@@ -38,12 +40,24 @@ export const SetAscendGoal: React.FC<Props> = ({
     targetRarity,
     currentStars,
     currentRarity,
+    startingRarity,
+    startingStars,
     farmType,
     alliance,
     onslaughtPreferences = defaultOnslaughtPreferences,
     onChange,
 }) => {
-    const rarityValues = useMemo(() => {
+    const startingRarityValues = useMemo(() => {
+        return getEnumValues(Rarity).filter(x => x >= currentRarity);
+    }, [currentRarity]);
+
+    const startingStarsEntries = useMemo(() => {
+        const minStars = startingRarity === currentRarity ? currentStars : rarityToStars[startingRarity];
+        const maxStars = rarityToMaxStars[startingRarity];
+        return getEnumValues(RarityStars).filter(x => x >= minStars && x <= maxStars);
+    }, [startingRarity, currentRarity, currentStars]);
+
+    const targetRarityValues = useMemo(() => {
         return getEnumValues(Rarity).filter(x => x >= currentRarity);
     }, [currentRarity]);
 
@@ -81,8 +95,33 @@ export const SetAscendGoal: React.FC<Props> = ({
         <>
             <div className="flex items-center gap-3">
                 <RaritySelect
+                    label={'Starting Rarity'}
+                    rarityValues={startingRarityValues}
+                    value={startingRarity}
+                    valueChanges={value => {
+                        onChange('startingRarity', value);
+                        const minStars = value === currentRarity ? currentStars : rarityToStars[value as Rarity];
+                        onChange('startingStars', minStars);
+                        // If the new starting rarity exceeds the current target, advance the target too
+                        if (value > targetRarity) {
+                            onChange('targetRarity', value);
+                            onChange('targetStars', rarityToStars[value as Rarity]);
+                        }
+                    }}
+                />
+
+                <StarsSelect
+                    label={'Starting Stars'}
+                    starsValues={startingStarsEntries}
+                    value={startingStars}
+                    valueChanges={value => onChange('startingStars', value)}
+                />
+            </div>
+
+            <div className="flex items-center gap-3">
+                <RaritySelect
                     label={'Target Rarity'}
-                    rarityValues={rarityValues}
+                    rarityValues={targetRarityValues}
                     value={targetRarity}
                     valueChanges={value => {
                         onChange('targetRarity', value);

--- a/src/shared-components/goals/set-goal-dialog.tsx
+++ b/src/shared-components/goals/set-goal-dialog.tsx
@@ -58,6 +58,8 @@ const getDefaultForm = (priority: number): IPersonalGoal => ({
     type: PersonalGoalType.UpgradeRank,
     startingRank: Rank.Stone1,
     startingRankPoint5: false,
+    startingRarity: Rarity.Common,
+    startingStars: RarityStars.None,
     targetRarity: Rarity.Common,
     targetRank: Rank.Stone1,
     targetStars: RarityStars.None,
@@ -242,6 +244,8 @@ export const SetGoalDialog = ({ onClose }: { onClose?: (goal?: IPersonalGoal) =>
         if (isCharacter(value)) {
             setForm(current => ({
                 ...current,
+                startingRarity: value.rarity,
+                startingStars: value.stars,
                 targetRank: value.rank,
                 targetStars: value.stars,
                 targetRarity: value.rarity,
@@ -253,6 +257,8 @@ export const SetGoalDialog = ({ onClose }: { onClose?: (goal?: IPersonalGoal) =>
         if (isMow(value)) {
             setForm(current => ({
                 ...current,
+                startingRarity: value.rarity,
+                startingStars: value.stars,
                 firstAbilityLevel: value.primaryAbilityLevel,
                 secondAbilityLevel: value.secondaryAbilityLevel,
             }));
@@ -280,7 +286,9 @@ export const SetGoalDialog = ({ onClose }: { onClose?: (goal?: IPersonalGoal) =>
 
         if (form.type === PersonalGoalType.Ascend) {
             if (unit === undefined) return true;
-            return unit.rarity === form.targetRarity && unit.stars === form.targetStars;
+            const effectiveStartRarity = form.startingRarity ?? unit.rarity;
+            const effectiveStartStars = form.startingStars ?? unit.stars;
+            return effectiveStartRarity === form.targetRarity && effectiveStartStars === form.targetStars;
         }
 
         if (form.type === PersonalGoalType.MowAbilities && isMow(unit)) {
@@ -504,6 +512,8 @@ export const SetGoalDialog = ({ onClose }: { onClose?: (goal?: IPersonalGoal) =>
                             targetRarity={form.targetRarity!}
                             currentStars={unit.stars}
                             targetStars={form.targetStars!}
+                            startingRarity={form.startingRarity ?? unit.rarity}
+                            startingStars={form.startingStars ?? unit.stars}
                             possibleLocations={possibleLocations}
                             unlockedLocations={unlockedLocations}
                             campaignsUsage={form.campaignsUsage!}

--- a/src/shared-components/goals/set-goal-dialog.tsx
+++ b/src/shared-components/goals/set-goal-dialog.tsx
@@ -288,7 +288,10 @@ export const SetGoalDialog = ({ onClose }: { onClose?: (goal?: IPersonalGoal) =>
             if (unit === undefined) return true;
             const effectiveStartRarity = form.startingRarity ?? unit.rarity;
             const effectiveStartStars = form.startingStars ?? unit.stars;
-            return effectiveStartRarity === form.targetRarity && effectiveStartStars === form.targetStars;
+            return (
+                effectiveStartRarity > form.targetRarity! ||
+                (effectiveStartRarity === form.targetRarity && effectiveStartStars >= form.targetStars!)
+            );
         }
 
         if (form.type === PersonalGoalType.MowAbilities && isMow(unit)) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for selecting “starting” progression when creating ascend goals, including starting rarity and starting stars.
  * Ascend goal forms now prefill starting rarity and stars from the chosen unit.
* **Bug Fixes**
  * Goal and shard estimates now base incremental progress on the selected starting point.
  * Ascend goal conversion/validation now more accurately gates shards based on whether the start matches current progression.
* **UI Improvements**
  * Roster snapshot tabs now scroll more smoothly on smaller screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->