### PR TITLE
Update dates for Lucius final event

### DIFF
--- a/src/fsd/4-entities/lre/data/10-Lucius.json
+++ b/src/fsd/4-entities/lre/data/10-Lucius.json
@@ -3,9 +3,9 @@
     "unitSnowprintId": "emperLucius",
     "name": "Lucius",
     "wikiLink": "https://tacticus.wiki.gg/wiki/Legendary_Character_Events",
-    "eventStage": 2,
-    "nextEventDate": "February 01, 2026",
-    "nextEventDateUtc": "Sun, 01 February 2026 00:00:00 GMT",
+    "eventStage": 3,
+    "nextEventDate": "July 26, 2026",
+    "nextEventDateUtc": "Sun, 26 July 2026 00:00:00 GMT",
     "finished": false,
     "regularMissions": [
         "Defeat 5 waves of enemies in any wave-based game mode, Deal 1000 damage",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated Lucius’s event schedule to stage 3.
  * Rescheduled the next event to July 26, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->