### PR TITLE
Icons in selects

### DIFF
--- a/src/fsd/1-pages/learn-characters/characters.tsx
+++ b/src/fsd/1-pages/learn-characters/characters.tsx
@@ -21,7 +21,7 @@ import {
     Separator,
     StarsSelect,
 } from '@/fsd/5-shared/ui';
-import { MiscIcon, ComponentImage, TraitImage } from '@/fsd/5-shared/ui/icons';
+import { MiscIcon, AllianceImage, TraitImage } from '@/fsd/5-shared/ui/icons';
 import { Select, SelectMulti } from '@/fsd/5-shared/ui/selects';
 import { Switch } from '@/fsd/5-shared/ui/switch';
 
@@ -525,14 +525,14 @@ export const LearnCharacters = () => {
                                 placeholder="All alliances"
                                 renderOption={a => (
                                     <div className="flex items-center gap-2">
-                                        <ComponentImage alliance={a as Alliance} size="small" />
+                                        <AllianceImage alliance={a as Alliance} size={20} />
                                         <span>{a}</span>
                                     </div>
                                 )}
                                 renderValue={selected => (
                                     <div className="flex flex-wrap items-center gap-1">
                                         {selected.map(a => (
-                                            <ComponentImage key={a} alliance={a as Alliance} size="small" />
+                                            <AllianceImage key={a} alliance={a as Alliance} size={18} />
                                         ))}
                                     </div>
                                 )}

--- a/src/fsd/1-pages/learn-characters/characters.tsx
+++ b/src/fsd/1-pages/learn-characters/characters.tsx
@@ -8,7 +8,15 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { StoreContext } from 'src/reducers/store.provider';
 
 import { getEnumValues } from '@/fsd/5-shared/lib';
-import { Rarity, Alliance, DamageType, Trait, Rank, getTraitStringFromLabel } from '@/fsd/5-shared/model';
+import {
+    Rarity,
+    Alliance,
+    DamageType,
+    Trait,
+    Rank,
+    getTraitStringFromLabel,
+    allianceFromString,
+} from '@/fsd/5-shared/model';
 import { trackEvent } from '@/fsd/5-shared/monitoring';
 import {
     Accordion,
@@ -73,7 +81,7 @@ export const LearnCharacters = () => {
         distance: number | '';
         damageTypes: DamageType[];
         traits: string[];
-        alliance: string[];
+        alliance: Alliance[];
     };
 
     const [filter, setFilter] = useState<Filter>({
@@ -97,7 +105,12 @@ export const LearnCharacters = () => {
         const movement = searchParams.get('movement');
         const distance = searchParams.get('distance');
         const traits = searchParams.getAll('trait');
-        const alliance = searchParams.getAll('alliance');
+        // Query params are user-supplied, so drop anything that isn't a real alliance rather
+        // than letting it through as a filter value that matches nothing and has no icon.
+        const alliance = searchParams
+            .getAll('alliance')
+            .map(value => allianceFromString(value))
+            .filter((value): value is Alliance => value !== undefined);
         const newFilter: Filter = {
             name: name ?? '',
             minHits: minHits ? Number(minHits) : '',
@@ -517,7 +530,7 @@ export const LearnCharacters = () => {
                         </div>
 
                         <div className="min-w-[200px] flex-1">
-                            <SelectMulti<string>
+                            <SelectMulti<Alliance>
                                 options={Object.values(Alliance)}
                                 value={filter.alliance}
                                 onChange={v => handleFilterChange('alliance', v)}
@@ -525,14 +538,14 @@ export const LearnCharacters = () => {
                                 placeholder="All alliances"
                                 renderOption={a => (
                                     <div className="flex items-center gap-2">
-                                        <AllianceImage alliance={a as Alliance} size={20} />
+                                        <AllianceImage alliance={a} size={20} />
                                         <span>{a}</span>
                                     </div>
                                 )}
                                 renderValue={selected => (
                                     <div className="flex flex-wrap items-center gap-1">
                                         {selected.map(a => (
-                                            <AllianceImage key={a} alliance={a as Alliance} size={18} />
+                                            <AllianceImage key={a} alliance={a} size={18} />
                                         ))}
                                     </div>
                                 )}

--- a/src/fsd/1-pages/plan-teams2/add-team-dialog.tsx
+++ b/src/fsd/1-pages/plan-teams2/add-team-dialog.tsx
@@ -10,6 +10,7 @@ import { FactionId, Rank, Rarity } from '@/fsd/5-shared/model';
 import { AccessibleTooltip, Button, Select } from '@/fsd/5-shared/ui';
 import { RaritySelect } from '@/fsd/5-shared/ui/selects';
 
+import { CampaignImage } from '@/fsd/4-entities/campaign';
 import { IMow2 } from '@/fsd/4-entities/mow';
 
 import { CharacterSelectGrid, MowSelectGrid } from '@/fsd/2-widgets/unit-select-grid';
@@ -17,6 +18,7 @@ import { CharacterSelectGrid, MowSelectGrid } from '@/fsd/2-widgets/unit-select-
 import { RosterSnapshotsMagnificationSlider } from '../input-roster-snapshots/roster-snapshots-magnification-slider';
 
 import {
+    campaignStorylineIcon,
     campaignStorylineLabel,
     campaignStorylineOptions,
     campaignStorylineUsableFactionIds,
@@ -422,7 +424,22 @@ export const AddTeamDialog: React.FC<Props> = ({
                                         options={[undefined, ...campaignStorylineOptions.map(option => option.value)]}
                                         value={campaignStoryline}
                                         onChange={onCampaignStorylineChanged}
-                                        renderOption={value => (value ? campaignStorylineLabel(value) : 'None')}
+                                        renderOption={value =>
+                                            value ? (
+                                                <div className="flex items-center gap-2">
+                                                    {!!campaignStorylineIcon(value) && (
+                                                        <CampaignImage
+                                                            campaign={campaignStorylineIcon(value)!}
+                                                            size={24}
+                                                            showTooltip={false}
+                                                        />
+                                                    )}
+                                                    <span>{campaignStorylineLabel(value)}</span>
+                                                </div>
+                                            ) : (
+                                                'None'
+                                            )
+                                        }
                                         placeholder="Select a campaign..."
                                     />
                                     {campaignStoryline && (

--- a/src/fsd/1-pages/plan-teams2/campaign.constants.ts
+++ b/src/fsd/1-pages/plan-teams2/campaign.constants.ts
@@ -53,6 +53,12 @@ const storylineToCampaign: Record<string, Campaign> = {
 };
 
 /**
+ * The Campaign whose icon represents a storyline. Every storyline maps to a campaign that
+ * has an icon asset, so this doubles as the icon key. Returns undefined when unknown.
+ */
+export const campaignStorylineIcon = (storyline: string): Campaign | undefined => storylineToCampaign[storyline];
+
+/**
  * A short, human-readable hint of which factions are usable in a storyline, derived
  * from the campaign's allied factions. Standard campaigns allow a whole alliance, so
  * the alliance name is shown instead of every faction. Returns undefined when unknown.

--- a/src/fsd/3-features/goals/locations-filter.tsx
+++ b/src/fsd/3-features/goals/locations-filter.tsx
@@ -7,7 +7,7 @@ import factionsData from 'src/data/factions.json';
 import { factionLookup } from '@/fsd/5-shared/lib';
 import { Alliance, FactionId, Rarity } from '@/fsd/5-shared/model';
 import { Button, PortalDialog, MultipleSelectCheckmarks } from '@/fsd/5-shared/ui';
-import { ComponentImage, RarityIcon } from '@/fsd/5-shared/ui/icons';
+import { AllianceImage, RarityIcon } from '@/fsd/5-shared/ui/icons';
 import { ComboBox, SelectMulti } from '@/fsd/5-shared/ui/selects';
 
 import { CampaignsService, CampaignType, ICampaignsFilters } from '@/fsd/4-entities/campaign';
@@ -112,14 +112,14 @@ export const LocationsFilter: React.FC<Props> = ({ filter, filtersChange }) => {
                     placeholder="All alliances"
                     renderOption={a => (
                         <div className="flex items-center gap-2">
-                            <ComponentImage alliance={a} size="small" />
+                            <AllianceImage alliance={a} size={20} />
                             <span>{a}</span>
                         </div>
                     )}
                     renderValue={selected => (
                         <div className="flex flex-wrap items-center gap-1">
                             {selected.map(a => (
-                                <ComponentImage key={a} alliance={a} size="small" />
+                                <AllianceImage key={a} alliance={a} size={18} />
                             ))}
                         </div>
                     )}

--- a/src/fsd/5-shared/ui/icons/alliance-image.tsx
+++ b/src/fsd/5-shared/ui/icons/alliance-image.tsx
@@ -1,0 +1,19 @@
+import { Alliance } from '@/fsd/5-shared/model';
+
+import { tacticusIcons } from './icon-list';
+import { MiscIcon } from './misc.icon';
+
+/**
+ * The alliance emblems. Not to be confused with ComponentImage, which renders the
+ * alliance-coloured Machine of War component tokens.
+ */
+const allianceIcons: Record<Alliance, keyof typeof tacticusIcons> = {
+    [Alliance.Imperial]: 'allianceImperial',
+    [Alliance.Chaos]: 'allianceChaos',
+    [Alliance.Xenos]: 'allianceXenos',
+};
+
+/** The emblems aren't square, so only the height is constrained and the width follows. */
+export const AllianceImage = ({ alliance, size = 25 }: { alliance: Alliance; size?: number }) => (
+    <MiscIcon icon={allianceIcons[alliance]} width={0} height={size} />
+);

--- a/src/fsd/5-shared/ui/icons/index.ts
+++ b/src/fsd/5-shared/ui/icons/index.ts
@@ -5,6 +5,7 @@ export { MiscIcon } from './misc.icon';
 export { RarityIcon } from './rarity.icon';
 export { StarsIcon } from './stars.icon';
 export { UnitShardIcon } from './unit-shard.icon';
+export { AllianceImage } from './alliance-image';
 export { BadgeImage } from './badge-image';
 export { ComponentImage } from './component-image';
 export { ForgeBadgeImage } from './forge-badge-image';


### PR DESCRIPTION
Added those for campaings in teams and changed the ones for alliances. They are not ideal, but we dont have better. I can remove them if you dont think that they are good or if you can find any in the mines?
<img width="398" height="341" alt="image" src="https://github.com/user-attachments/assets/6a6b1a68-345b-4d1f-814f-f6785f5c117a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dedicated alliance icons to alliance selection fields and selected values.
  - Added campaign imagery to campaign storyline options in team planning.
  - Campaign storyline icons now match their corresponding campaigns.

- **UI Improvements**
  - Improved icon sizing and visual consistency across alliance and campaign selectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->