### PR TITLE
Spruce up the teams2 page, wyo page, and guild snapshots

### DIFF
--- a/src/fsd/1-pages/input-guild-roster-snapshots/roster-snapshots-tab.tsx
+++ b/src/fsd/1-pages/input-guild-roster-snapshots/roster-snapshots-tab.tsx
@@ -8,6 +8,7 @@ import { StoreContext } from '@/reducers/store.provider';
 import { isLikelyUserId, obfuscateUserId } from '@/fsd/5-shared/lib';
 import { DebugJson } from '@/fsd/5-shared/ui';
 import { Button } from '@/fsd/5-shared/ui/button';
+import { UnitShardIcon } from '@/fsd/5-shared/ui/icons';
 
 import { RosterSnapshotShowVariableSettings } from '@/fsd/3-features/view-settings';
 
@@ -20,9 +21,11 @@ import { RosterSnapshotsService } from '../input-roster-snapshots/roster-snapsho
 import { RosterSnapshotsUnitDiffDetailed } from '../input-roster-snapshots/roster-snapshots-unit-diff-detailed';
 
 import {
+    ALL_RAID_COMPS,
     CurrentRosterMember,
     MemberState,
     PlayerRosterChainResponse,
+    RaidComp,
     RosterSnapshotInfo,
     deleteGuildRosterSnapshotByIdApi,
     getGuildRosterPlayerChainApi,
@@ -30,6 +33,7 @@ import {
     postGuildRosterMigrateApi,
     postGuildRosterSnapshotApi,
 } from './guild-roster-snapshots.models';
+import { getRaidCompIconProps } from './raid-comp-icon';
 import { RaidTeamFilterDropdown } from './raid-team-filter-dropdown';
 import {
     DiffEntry,
@@ -40,8 +44,28 @@ import {
     snapshotCharPower,
     snapshotMowPower,
 } from './roster-snapshots-tab.utils';
+import { standardCompCategories } from './rosters-tab.utils';
 
 const SHOW_ALL = RosterSnapshotShowVariableSettings.Always;
+
+const StandardCompBar = ({ selected, onToggle }: { selected: RaidComp[]; onToggle: (comp: RaidComp) => void }) => (
+    <div className="flex flex-wrap gap-1">
+        {ALL_RAID_COMPS.map(comp => {
+            const { icon, name } = getRaidCompIconProps(comp);
+            const isActive = selected.includes(comp);
+            return (
+                <button
+                    key={comp}
+                    type="button"
+                    title={comp}
+                    onClick={() => onToggle(comp)}
+                    className={`rounded ring-2 transition-all ${isActive ? 'ring-(--primary) grayscale-0' : 'opacity-60 ring-transparent grayscale hover:opacity-90'}`}>
+                    <UnitShardIcon icon={icon} name={name} width={28} height={28} />
+                </button>
+            );
+        })}
+    </div>
+);
 
 // ---------------------------------------------------------------------------
 // Module-level cache — persists across navigations within a session
@@ -137,6 +161,7 @@ export const RosterSnapshotsTab = ({ members, memberStates, onLoadMembers }: Ros
     const [leftSnapshotId, setLeftSnapshotId] = useState<string | undefined>();
     const [rightSnapshotId, setRightSnapshotId] = useState<string | 'current' | undefined>();
     const [selectedUserId, setSelectedUserId] = useState<string | undefined>();
+    const [selectedComps, setSelectedComps] = useState<RaidComp[]>([]);
     const [selectedRaidTeamNames, setSelectedRaidTeamNames] = useState<string[]>([]);
 
     // ---- migration state ----
@@ -171,11 +196,23 @@ export const RosterSnapshotsTab = ({ members, memberStates, onLoadMembers }: Ros
         if (error || !data) {
             setMetaError(typeof error === 'string' ? error : ((error as Error)?.message ?? 'Failed to load snapshots'));
         } else {
+            // A player's cached chain only covers snapshots that existed when it was fetched. If a
+            // new snapshot has shown up since (this user saved one, or another member's save was
+            // just picked up), previously cached chains are stale and must be refetched.
+            const previousIds = new Set((cache.snapshotMeta ?? []).map(s => s.snapshotId));
+            const hasNewSnapshot = data.snapshots.some(s => !previousIds.has(s.snapshotId));
+
             cacheSetMeta(data.snapshots, data.atCapacity, data.maxSnapshots, data.currentRosterMembers);
             setSnapshotMeta(data.snapshots);
             setAtCapacity(data.atCapacity);
             setMaxSnapshots(data.maxSnapshots);
             setCurrentRosterMembers(data.currentRosterMembers);
+
+            if (hasNewSnapshot) {
+                const emptyChainCache = new Map<string, PlayerRosterChainResponse>();
+                cacheSetPlayerChainCache(emptyChainCache);
+                setPlayerChainCache(emptyChainCache);
+            }
         }
         setIsLoadingMeta(false);
     }, []);
@@ -256,17 +293,23 @@ export const RosterSnapshotsTab = ({ members, memberStates, onLoadMembers }: Ros
         return options;
     }, [leftSnapshotId, sortedMeta, members]);
 
+    const getMemberIdsFor = useCallback(
+        (snapshotId: string | 'current' | undefined): string[] => {
+            if (snapshotId === undefined) return [];
+            if (snapshotId === 'current') return currentRosterMembers.map(m => m.userId);
+            return sortedMeta.find(s => s.snapshotId === snapshotId)?.memberIds ?? [];
+        },
+        [sortedMeta, currentRosterMembers]
+    );
+
     // Players eligible for comparison: strict intersection of both sides' memberIds
     const membersInComparison = useMemo((): string[] => {
         if (leftSnapshotId === undefined || rightSnapshotId === undefined) return [];
-        const fromIds = new Set(sortedMeta.find(s => s.snapshotId === leftSnapshotId)?.memberIds);
+        const fromIds = new Set(getMemberIdsFor(leftSnapshotId));
         if (fromIds.size === 0) return [];
-        const toIds =
-            rightSnapshotId === 'current'
-                ? new Set(currentRosterMembers.map(m => m.userId))
-                : new Set(sortedMeta.find(s => s.snapshotId === rightSnapshotId)?.memberIds);
+        const toIds = new Set(getMemberIdsFor(rightSnapshotId));
         return [...fromIds].filter(id => toIds.has(id));
-    }, [leftSnapshotId, rightSnapshotId, sortedMeta, currentRosterMembers]);
+    }, [leftSnapshotId, rightSnapshotId, getMemberIdsFor]);
 
     const raidTeams = useMemo(() => teams2.filter(t => t.raid), [teams2]);
 
@@ -284,6 +327,18 @@ export const RosterSnapshotsTab = ({ members, memberStates, onLoadMembers }: Ros
                 next.add(teamName);
             }
             return [...next];
+        });
+    };
+
+    const toggleComp = (comp: RaidComp) => {
+        setSelectedComps(current => {
+            const next = new Set(current);
+            if (next.has(comp)) {
+                next.delete(comp);
+            } else {
+                next.add(comp);
+            }
+            return [...next] as RaidComp[];
         });
     };
 
@@ -357,10 +412,11 @@ export const RosterSnapshotsTab = ({ members, memberStates, onLoadMembers }: Ros
         return results;
     }, [selectedUserId, leftSnapshotId, rightSnapshotId, playerChainCache, memberStates]);
 
-    const selectedUnitIds = useMemo(
-        () => getUnitIdsFromTeamNames(raidTeams, selectedRaidTeamNames),
-        [raidTeams, selectedRaidTeamNames]
-    );
+    const selectedUnitIds = useMemo(() => {
+        const standardIds = standardCompCategories(selectedComps);
+        const customIds = getUnitIdsFromTeamNames(raidTeams, selectedRaidTeamNames);
+        return new Set([...standardIds.coreIds, ...standardIds.flexIds, ...standardIds.mowIds, ...customIds]);
+    }, [selectedComps, raidTeams, selectedRaidTeamNames]);
 
     const filteredDiffEntries = useMemo((): DiffEntry[] => {
         if (selectedUnitIds.size === 0) return diffEntries;
@@ -829,10 +885,15 @@ export const RosterSnapshotsTab = ({ members, memberStates, onLoadMembers }: Ros
                                     value={rightSnapshotId ?? ''}
                                     onChange={event_ => {
                                         const value = event_.target.value;
-                                        setRightSnapshotId(
-                                            value === '' ? undefined : value === 'current' ? 'current' : value
-                                        );
-                                        setSelectedUserId(undefined);
+                                        const nextRightSnapshotId =
+                                            value === '' ? undefined : value === 'current' ? 'current' : value;
+                                        setRightSnapshotId(nextRightSnapshotId);
+                                        if (
+                                            selectedUserId &&
+                                            !getMemberIdsFor(nextRightSnapshotId).includes(selectedUserId)
+                                        ) {
+                                            setSelectedUserId(undefined);
+                                        }
                                     }}
                                     className={`${selectClass} disabled:opacity-50`}>
                                     <option value="">— select a snapshot —</option>
@@ -845,6 +906,8 @@ export const RosterSnapshotsTab = ({ members, memberStates, onLoadMembers }: Ros
                             </div>
                         </>
                     )}
+
+                    <StandardCompBar selected={selectedComps} onToggle={toggleComp} />
 
                     {raidTeams.length > 0 && (
                         <RaidTeamFilterDropdown teams={raidTeamFilterOptions} onToggleTeam={toggleRaidTeam} />

--- a/src/fsd/1-pages/input-guild-roster-snapshots/roster-snapshots-tab.utils.ts
+++ b/src/fsd/1-pages/input-guild-roster-snapshots/roster-snapshots-tab.utils.ts
@@ -33,11 +33,15 @@ export interface DiffEntry {
  * Reconstructs a player's roster state at a given snapshot by walking their
  * chain from the base entry (index 0) forward, applying deltas in order.
  * Returns undefined if the player has no entry for that snapshotId.
+ *
+ * The chain isn't guaranteed to arrive in chronological order (same as the
+ * snapshot metadata list), so it's sorted here before walking it.
  */
 export function getRosterAtSnapshot(chain: PlayerRosterChainEntry[], snapshotId: string): IRosterSnapshot | undefined {
+    const orderedChain = [...chain].toSorted((a, b) => a.createdAt.localeCompare(b.createdAt));
     let current: IRosterSnapshot | undefined;
 
-    for (const entry of chain) {
+    for (const entry of orderedChain) {
         const member = entry.memberData as GuildRosterSnapshotMember | undefined;
         if (!member) {
             if (entry.snapshotId === snapshotId) return current;

--- a/src/fsd/1-pages/plan-teams2/team-flow.tsx
+++ b/src/fsd/1-pages/plan-teams2/team-flow.tsx
@@ -42,9 +42,9 @@ export const TeamFlow: React.FC<Props> = ({
                         onClick={() => onCharClicked(char)}
                         className="cursor-pointer transition-transform duration-100 hover:brightness-110 active:scale-95">
                         <RosterSnapshotCharacter
-                            showMythicShards={RosterSnapshotShowVariableSettings.Never}
-                            showShards={RosterSnapshotShowVariableSettings.Never}
-                            showXpLevel={RosterSnapshotShowVariableSettings.Never}
+                            showMythicShards={RosterSnapshotShowVariableSettings.Always}
+                            showShards={RosterSnapshotShowVariableSettings.Always}
+                            showXpLevel={RosterSnapshotShowVariableSettings.Always}
                             showAbilities={RosterSnapshotShowVariableSettings.Always}
                             showEquipment={showEquipment}
                             showTooltip={false}
@@ -64,9 +64,9 @@ export const TeamFlow: React.FC<Props> = ({
                                 onClick={() => onCharClicked(char)}
                                 className="cursor-pointer transition-transform duration-100 hover:brightness-110 active:scale-95">
                                 <RosterSnapshotCharacter
-                                    showMythicShards={RosterSnapshotShowVariableSettings.Never}
-                                    showShards={RosterSnapshotShowVariableSettings.Never}
-                                    showXpLevel={RosterSnapshotShowVariableSettings.Never}
+                                    showMythicShards={RosterSnapshotShowVariableSettings.Always}
+                                    showShards={RosterSnapshotShowVariableSettings.Always}
+                                    showXpLevel={RosterSnapshotShowVariableSettings.Always}
                                     showAbilities={RosterSnapshotShowVariableSettings.Always}
                                     showEquipment={showEquipment}
                                     showTooltip={false}
@@ -90,8 +90,8 @@ export const TeamFlow: React.FC<Props> = ({
                                 onClick={() => onMowClicked(mow)}
                                 className="cursor-pointer transition-transform duration-100 hover:brightness-110 active:scale-95">
                                 <RosterSnapshotCharacter
-                                    showMythicShards={RosterSnapshotShowVariableSettings.Never}
-                                    showShards={RosterSnapshotShowVariableSettings.Never}
+                                    showMythicShards={RosterSnapshotShowVariableSettings.Always}
+                                    showShards={RosterSnapshotShowVariableSettings.Always}
                                     showXpLevel={RosterSnapshotShowVariableSettings.Never}
                                     showAbilities={
                                         disabledUnits?.includes(mow.snowprintId)

--- a/src/fsd/1-pages/shared-roster/shared-roster.tsx
+++ b/src/fsd/1-pages/shared-roster/shared-roster.tsx
@@ -2,14 +2,15 @@
 /* eslint-disable boundaries/element-types */
 import Box from '@mui/material/Box';
 import { sum } from 'lodash';
-import { useContext, useState } from 'react';
+import { useCallback, useContext, useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import { GlobalState } from 'src/models/global-state';
-import { StoreContext } from 'src/reducers/store.provider';
+import { DispatchContext, StoreContext } from 'src/reducers/store.provider';
 
 import { LoaderWithText, Conditional } from '@/fsd/5-shared/ui';
 
+import { CharactersFilterBy } from '@/fsd/4-entities/character';
 import { MowsService } from '@/fsd/4-entities/mow/mows.service';
 import { CharactersPowerService, CharactersValueService } from '@/fsd/4-entities/unit';
 
@@ -28,14 +29,30 @@ import { CharactersViewControls, ICharactersViewControls } from '@/fsd/3-feature
 import { RosterSnapshotsAssetsProvider } from '../input-roster-snapshots/roster-snapshots-assets-provider';
 
 export const SharedRoster = () => {
-    const { viewPreferences } = useContext(StoreContext);
+    const { viewPreferences, teams2 } = useContext(StoreContext);
+    const dispatch = useContext(DispatchContext);
     const [viewControls, setViewControls] = useState<ICharactersViewControls>({
-        filterBy: viewPreferences.wyoFilter,
+        filterBy: viewPreferences.sharedRosterFilter,
         orderBy: viewPreferences.wyoOrder,
     });
     const [nameFilter, setNameFilter] = useState<string>();
 
     const [searchParams] = useSearchParams();
+
+    const updateViewControls = useCallback(
+        (value: ICharactersViewControls) => {
+            setViewControls(value);
+            dispatch.viewPreferences({ type: 'Update', setting: 'sharedRosterFilter', value: value.filterBy });
+        },
+        [dispatch]
+    );
+
+    useEffect(() => {
+        if (typeof viewControls.filterBy === 'string' && !teams2.some(team => team.name === viewControls.filterBy)) {
+            setViewControls(current => ({ ...current, filterBy: CharactersFilterBy.None }));
+            dispatch.viewPreferences({ type: 'Update', setting: 'sharedRosterFilter', value: CharactersFilterBy.None });
+        }
+    }, [teams2, viewControls.filterBy, dispatch]);
 
     const sharedUser = searchParams.get('username');
     const shareToken = searchParams.get('shareToken');
@@ -70,7 +87,7 @@ export const SharedRoster = () => {
 
     const sharedRoster: IUnit[] = [...GlobalState.initCharacters(data.characters), ...resolvedMows];
 
-    const charactersFiltered = CharactersService.filterUnits(sharedRoster, viewControls.filterBy, nameFilter);
+    const charactersFiltered = CharactersService.filterUnits(sharedRoster, viewControls.filterBy, nameFilter, teams2);
     const totalPower = sum(charactersFiltered.map(character => CharactersPowerService.getCharacterPower(character)));
     const totalValue = sum(charactersFiltered.map(character => CharactersValueService.getCharacterValue(character)));
 
@@ -95,7 +112,11 @@ export const SharedRoster = () => {
                     <RosterHeader totalValue={totalValue} totalPower={totalPower} filterChanges={setNameFilter}>
                         <TeamGraph units={charactersFiltered} />
                     </RosterHeader>
-                    <CharactersViewControls viewControls={viewControls} viewControlsChanges={setViewControls} />
+                    <CharactersViewControls
+                        viewControls={viewControls}
+                        viewControlsChanges={updateViewControls}
+                        teams={teams2}
+                    />
 
                     <Conditional condition={isFactionsView(viewControls.orderBy)}>
                         <FactionsGrid factions={factions} />

--- a/src/fsd/1-pages/who-you-own/who-you-own.tsx
+++ b/src/fsd/1-pages/who-you-own/who-you-own.tsx
@@ -2,14 +2,14 @@
 /* eslint-disable import-x/no-internal-modules */
 import Box from '@mui/material/Box';
 import { sum } from 'lodash';
-import { useCallback, useContext, useMemo, useState } from 'react';
+import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { Navigate, useSearchParams } from 'react-router-dom';
 
 import { DispatchContext, StoreContext } from 'src/reducers/store.provider';
 
 import { useAuth, UnitType } from '@/fsd/5-shared/model';
 
-import { ICharacter2 } from '@/fsd/4-entities/character';
+import { CharactersFilterBy, ICharacter2 } from '@/fsd/4-entities/character';
 import { CharactersService as FsdCharactersService } from '@/fsd/4-entities/character/characters.service';
 import { IMow2, MowsService } from '@/fsd/4-entities/mow';
 import { IUnit } from '@/fsd/4-entities/unit';
@@ -32,7 +32,7 @@ import { RosterSnapshotsAssetsProvider } from '../input-roster-snapshots/roster-
 import { UnitDetailsPage } from './unit-details-page';
 
 export const WhoYouOwn = () => {
-    const { characters: charactersDefault, mows, viewPreferences, inventory } = useContext(StoreContext);
+    const { characters: charactersDefault, mows, viewPreferences, inventory, teams2 } = useContext(StoreContext);
     const dispatch = useContext(DispatchContext);
     const { token: isLoggedIn, shareToken: isRosterShared } = useAuth();
 
@@ -58,9 +58,21 @@ export const WhoYouOwn = () => {
 
     const charactersFiltered = useMemo(
         () =>
-            CharactersService.filterUnits([...resolvedCharacters, ...resolvedMows], viewControls.filterBy, nameFilter),
-        [viewControls.filterBy, nameFilter, resolvedMows, resolvedCharacters]
+            CharactersService.filterUnits(
+                [...resolvedCharacters, ...resolvedMows],
+                viewControls.filterBy,
+                nameFilter,
+                teams2
+            ),
+        [viewControls.filterBy, nameFilter, resolvedMows, resolvedCharacters, teams2]
     );
+
+    useEffect(() => {
+        if (typeof viewControls.filterBy === 'string' && !teams2.some(team => team.name === viewControls.filterBy)) {
+            setViewControls(current => ({ ...current, filterBy: CharactersFilterBy.None }));
+            dispatch.viewPreferences({ type: 'Update', setting: 'wyoFilter', value: CharactersFilterBy.None });
+        }
+    }, [teams2, viewControls.filterBy, dispatch]);
 
     const factions = useMemo(
         () =>
@@ -193,7 +205,11 @@ export const WhoYouOwn = () => {
                         {!!isLoggedIn && <ShareRoster isRosterShared={!!isRosterShared} />}
                         <TeamGraph units={charactersFiltered} />
                     </RosterHeader>
-                    <CharactersViewControls viewControls={viewControls} viewControlsChanges={updatePreferences} />
+                    <CharactersViewControls
+                        viewControls={viewControls}
+                        viewControlsChanges={updatePreferences}
+                        teams={teams2}
+                    />
                     <div className="min-h-[10px]" />
 
                     {factionsView && <FactionsGrid factions={factions} onCharacterClick={handleUnitClick} />}

--- a/src/fsd/3-features/characters/characters.service.ts
+++ b/src/fsd/3-features/characters/characters.service.ts
@@ -27,6 +27,9 @@ import { isCharacter, isMow, isUnlocked } from '@/fsd/4-entities/unit/units.func
 // eslint-disable-next-line import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure
 import { rarityCaps } from '@/fsd/3-features/characters/characters.constants';
 
+// eslint-disable-next-line boundaries/element-types, import-x/no-internal-modules -- FSD boundary: team model lives under a page
+import { ITeam2 } from '@/fsd/1-pages/plan-teams2/models';
+
 import { IFaction } from './characters.models';
 // eslint-disable-next-line import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure
 import { blueStarReady } from './functions/blue-star-ready';
@@ -44,7 +47,12 @@ import { needToAscendCharacter } from './functions/need-to-ascend';
 import { needToLevelCharacter } from './functions/need-to-level';
 
 export class CharactersService {
-    static filterUnits(characters: IUnit[], filterBy: CharactersFilterBy, nameFilter?: string): IUnit[] {
+    static filterUnits(
+        characters: IUnit[],
+        filterBy: CharactersFilterBy | string,
+        nameFilter?: string,
+        teams: ITeam2[] = []
+    ): IUnit[] {
         const filteredCharactersByName = nameFilter
             ? characters.filter(
                   x =>
@@ -52,6 +60,12 @@ export class CharactersService {
                       ('shortName' in x && x.shortName?.toLowerCase().includes(nameFilter.toLowerCase()))
               )
             : characters;
+
+        if (typeof filterBy === 'string') {
+            const team = teams.find(x => x.name === filterBy);
+            const teamUnitIds = new Set([...(team?.chars ?? []), ...(team?.mows ?? [])]);
+            return filteredCharactersByName.filter(character => teamUnitIds.has(character.snowprintId));
+        }
 
         switch (filterBy) {
             case CharactersFilterBy.NeedToAscend: {

--- a/src/fsd/3-features/view-settings/model.ts
+++ b/src/fsd/3-features/view-settings/model.ts
@@ -25,8 +25,11 @@ export enum RosterSnapshotDiffStyle {
 export interface IViewPreferences
     extends ILreViewSettings, ILreTileSettings, IWyoViewSettings, IRosterSnapshotsViewSettings {
     // autoTeams: boolean;
-    wyoFilter: CharactersFilterBy;
+    // A CharactersFilterBy enum value, or a team name (from StoreContext.teams2) to filter by.
+    wyoFilter: CharactersFilterBy | string;
     wyoOrder: CharactersOrderBy;
+    // A CharactersFilterBy enum value, or a team name (from StoreContext.teams2) to filter by.
+    sharedRosterFilter: CharactersFilterBy | string;
     craftableItemsInInventory: boolean;
     inventoryShowAlphabet: boolean;
     inventoryShowPlusMinus: boolean;
@@ -89,5 +92,6 @@ interface IRosterSnapshotsViewSettings {
 
 export interface ICharactersViewControls {
     orderBy: CharactersOrderBy;
-    filterBy: CharactersFilterBy;
+    // A CharactersFilterBy enum value, or a team name to filter by.
+    filterBy: CharactersFilterBy | string;
 }

--- a/src/fsd/3-features/view-settings/view-controls.tsx
+++ b/src/fsd/3-features/view-settings/view-controls.tsx
@@ -1,4 +1,6 @@
-﻿import { FormControl, MenuItem, Select } from '@mui/material';
+﻿/* eslint-disable boundaries/element-types */
+/* eslint-disable import-x/no-internal-modules */
+import { FormControl, MenuItem, Select } from '@mui/material';
 import InputLabel from '@mui/material/InputLabel';
 
 import { getEnumValues } from '@/fsd/5-shared/lib';
@@ -6,21 +8,28 @@ import { FlexBox } from '@/fsd/5-shared/ui';
 
 import { CharactersFilterBy, CharactersOrderBy } from '@/fsd/4-entities/character';
 
+import { ITeam2 } from '@/fsd/1-pages/plan-teams2/models';
+
 import { ICharactersViewControls } from './model';
 import { ViewSettings } from './view-settings';
 
 export const CharactersViewControls = ({
     viewControls,
     viewControlsChanges,
+    teams,
 }: {
     viewControls: ICharactersViewControls;
     viewControlsChanges: (viewControls: ICharactersViewControls) => void;
+    teams?: ITeam2[];
 }) => {
-    const updatePreferences = (setting: keyof ICharactersViewControls, value: number) => {
+    const updatePreferences = (setting: keyof ICharactersViewControls, value: number | string) => {
         viewControlsChanges({ ...viewControls, [setting]: value });
     };
 
-    const filterEntries: number[] = getEnumValues(CharactersFilterBy);
+    const filterEntries: Array<number | string> = [
+        ...getEnumValues(CharactersFilterBy),
+        ...(teams ?? []).map(team => team.name),
+    ];
     const orderEntries: number[] = getEnumValues(CharactersOrderBy);
 
     const orderToString = (order: CharactersOrderBy): string => {
@@ -61,7 +70,10 @@ export const CharactersViewControls = ({
         }
     };
 
-    const filterToString = (filter: CharactersFilterBy): string => {
+    const filterToString = (filter: CharactersFilterBy | string): string => {
+        if (typeof filter === 'string') {
+            return filter;
+        }
         switch (filter) {
             case CharactersFilterBy.NeedToAscend: {
                 return 'Need to Ascend';
@@ -96,16 +108,16 @@ export const CharactersViewControls = ({
         }
     };
 
-    const getSelectControl = (
+    const getSelectControl = <T extends number | string>(
         label: string,
-        value: number,
+        value: T,
         name: keyof ICharactersViewControls,
-        entries: Array<number>,
-        getName: (value: number) => string
+        entries: Array<T>,
+        getName: (value: T) => string
     ) => (
         <FormControl className="w-1/2 max-w-[200px]">
             <InputLabel>{label}</InputLabel>
-            <Select label={name} value={value} onChange={event => updatePreferences(name, +event.target.value)}>
+            <Select label={name} value={value} onChange={event => updatePreferences(name, event.target.value as T)}>
                 {entries.map(value => (
                     <MenuItem key={value} value={value}>
                         {getName(value)}

--- a/src/fsd/4-entities/unit/unit-snapshot.converter.ts
+++ b/src/fsd/4-entities/unit/unit-snapshot.converter.ts
@@ -14,8 +14,8 @@ export function convertCharacterToSnapshot(charData: ICharacter2): ISnapshotChar
         rank: charData.rank,
         xpLevel: charData.level ?? 0,
         stars: charData.stars ?? 0,
-        shards: 0,
-        mythicShards: 0,
+        shards: charData.shards ?? 0,
+        mythicShards: charData.mythicShards ?? 0,
         equip0: EquipmentService.equipmentData.find(equip => equip.id === charData.equipment?.[0]?.id),
         equip1: EquipmentService.equipmentData.find(equip => equip.id === charData.equipment?.[1]?.id),
         equip2: EquipmentService.equipmentData.find(equip => equip.id === charData.equipment?.[2]?.id),
@@ -33,8 +33,8 @@ export function convertMowToSnapshot(mowData: IMow2): ISnapshotMachineOfWar {
         secondaryAbilityLevel: mowData.secondaryAbilityLevel ?? 0,
         rarity: mowData.rarity,
         stars: mowData.stars ?? 0,
-        shards: 0,
-        mythicShards: 0,
+        shards: mowData.shards ?? 0,
+        mythicShards: mowData.mythicShards ?? 0,
         locked: false,
     };
 }

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -222,6 +222,7 @@ export const defaultData: IPersonalData2 = {
         craftableItemsInInventory: false,
         wyoFilter: CharactersFilterBy.None,
         wyoOrder: CharactersOrderBy.Faction,
+        sharedRosterFilter: CharactersFilterBy.None,
         showShardsInRosterSnapshots: RosterSnapshotShowVariableSettings.Always,
         showMythicShardsInRosterSnapshots: RosterSnapshotShowVariableSettings.Always,
         showXpLevelInRosterSnapshots: RosterSnapshotShowVariableSettings.Always,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added team-name filtering to character views, including Shared Roster and Who You Own.
  - Added standard composition filtering to roster snapshot comparisons.
  - Snapshot comparisons now keep player and roster selections consistent when available snapshots change.
  - Team Flow views now display shard and mythic shard values.

- **Bug Fixes**
  - Roster snapshot data is applied in chronological order.
  - Saved filters are automatically reset when their team is no longer available.
  - Snapshot records now preserve shard and mythic shard values instead of displaying zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->