### PR TITLE
fix(goals): persist reorder and add tests

### DIFF
--- a/src/fsd/1-pages/goals/goal-card/actions.spec.tsx
+++ b/src/fsd/1-pages/goals/goal-card/actions.spec.tsx
@@ -1,0 +1,92 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { GoalCardActions } from './actions';
+
+/**
+ * The shared Button is react-aria's, which reacts to `onPress` rather than `onClick` — a bare
+ * `fireEvent.click` never reaches the handler. Fire the pointer sequence `usePress` listens for.
+ */
+const press = (element: HTMLElement) => {
+    fireEvent.pointerDown(element, { pointerId: 1, pointerType: 'mouse', button: 0 });
+    fireEvent.pointerUp(element, { pointerId: 1, pointerType: 'mouse', button: 0 });
+    fireEvent.click(element);
+};
+
+const upButton = () => screen.getByRole('button', { name: 'Increase Goal Priority' });
+const downButton = () => screen.getByRole('button', { name: 'Decrease Goal Priority' });
+
+/** Renders with a goal in the middle of its section, so both arrows are live unless overridden. */
+const renderActions = (props: Partial<React.ComponentProps<typeof GoalCardActions>> = {}) => {
+    const onMove = vi.fn();
+    const menuItemSelect = vi.fn();
+    render(<GoalCardActions menuItemSelect={menuItemSelect} onMove={onMove} canMoveUp canMoveDown {...props} />);
+    return { onMove, menuItemSelect };
+};
+
+describe('GoalCardActions priority arrows', () => {
+    it('moves the goal up by one position', () => {
+        const { onMove } = renderActions();
+
+        press(upButton());
+
+        expect(onMove).toHaveBeenCalledWith(-1);
+    });
+
+    it('moves the goal down by one position', () => {
+        const { onMove } = renderActions();
+
+        press(downButton());
+
+        expect(onMove).toHaveBeenCalledWith(1);
+    });
+
+    it('disables the up arrow only for the globally first goal', () => {
+        const { onMove } = renderActions({ canMoveUp: false });
+
+        expect(upButton()).toBeDisabled();
+        press(upButton());
+        expect(onMove).not.toHaveBeenCalled();
+    });
+
+    it('disables the down arrow only for the globally last goal', () => {
+        const { onMove } = renderActions({ canMoveDown: false });
+
+        expect(downButton()).toBeDisabled();
+        press(downButton());
+        expect(onMove).not.toHaveBeenCalled();
+    });
+
+    it('enables arrows purely on position, independent of whether a handler is wired up', () => {
+        renderActions({ onMove: undefined });
+
+        expect(upButton()).toBeEnabled();
+        expect(downButton()).toBeEnabled();
+    });
+
+    it('pressing an arrow without a handler is a safe no-op', () => {
+        renderActions({ onMove: undefined });
+
+        expect(() => press(upButton())).not.toThrow();
+    });
+
+    it('disables an arrow whose direction is not supplied', () => {
+        // A caller that omits the position flags gets disabled arrows rather than dead-looking live
+        // ones — see GoalSection, which always passes both.
+        renderActions({ canMoveUp: undefined, canMoveDown: undefined });
+
+        expect(upButton()).toBeDisabled();
+        expect(downButton()).toBeDisabled();
+    });
+
+    it('keeps edit and delete working while the arrows are disabled', () => {
+        const { menuItemSelect } = renderActions({ canMoveUp: false, canMoveDown: false });
+
+        press(screen.getByRole('button', { name: 'Edit Goal' }));
+        press(screen.getByRole('button', { name: 'Delete Goal' }));
+
+        expect(menuItemSelect).toHaveBeenNthCalledWith(1, 'edit');
+        expect(menuItemSelect).toHaveBeenNthCalledWith(2, 'delete');
+    });
+});

--- a/src/fsd/1-pages/goals/goal-card/actions.spec.tsx
+++ b/src/fsd/1-pages/goals/goal-card/actions.spec.tsx
@@ -17,7 +17,7 @@ const press = (element: HTMLElement) => {
 const upButton = () => screen.getByRole('button', { name: 'Increase Goal Priority' });
 const downButton = () => screen.getByRole('button', { name: 'Decrease Goal Priority' });
 
-/** Renders with a goal in the middle of its section, so both arrows are live unless overridden. */
+/** Both arrows live unless overridden. */
 const renderActions = (props: Partial<React.ComponentProps<typeof GoalCardActions>> = {}) => {
     const onMove = vi.fn();
     const menuItemSelect = vi.fn();
@@ -72,8 +72,6 @@ describe('GoalCardActions priority arrows', () => {
     });
 
     it('disables an arrow whose direction is not supplied', () => {
-        // A caller that omits the position flags gets disabled arrows rather than dead-looking live
-        // ones — see GoalSection, which always passes both.
         renderActions({ canMoveUp: undefined, canMoveDown: undefined });
 
         expect(upButton()).toBeDisabled();

--- a/src/fsd/1-pages/goals/goal-card/actions.tsx
+++ b/src/fsd/1-pages/goals/goal-card/actions.tsx
@@ -4,13 +4,17 @@ import React from 'react';
 import { Button } from '@/fsd/5-shared/ui';
 
 interface Props {
-    menuItemSelect?: (item: 'edit' | 'delete' | 'moveUp' | 'moveDown') => void;
+    menuItemSelect?: (item: 'edit' | 'delete') => void;
+    /** Moves the goal by one position within its section. Negative is up. */
+    onMove?: (delta: number) => void;
+    canMoveUp?: boolean;
+    canMoveDown?: boolean;
 }
 
 const actionButton = '[--btn-accent:var(--soft-fg)]';
 
 /** Renders the edit/delete/priority action buttons for a goal card header as a compact 2×2 grid. */
-export const GoalCardActions: React.FC<Props> = ({ menuItemSelect }) => {
+export const GoalCardActions: React.FC<Props> = ({ menuItemSelect, onMove, canMoveUp, canMoveDown }) => {
     if (!menuItemSelect) return;
     return (
         <div className="grid grid-cols-2 gap-0.5 text-(--soft-fg)">
@@ -19,7 +23,8 @@ export const GoalCardActions: React.FC<Props> = ({ menuItemSelect }) => {
                 appearance="plain"
                 className={actionButton}
                 aria-label="Increase Goal Priority"
-                onPress={() => menuItemSelect('moveUp')}>
+                isDisabled={!canMoveUp}
+                onPress={() => onMove?.(-1)}>
                 <ArrowUp data-slot="icon" />
             </Button>
             <Button
@@ -35,7 +40,8 @@ export const GoalCardActions: React.FC<Props> = ({ menuItemSelect }) => {
                 appearance="plain"
                 className={actionButton}
                 aria-label="Decrease Goal Priority"
-                onPress={() => menuItemSelect('moveDown')}>
+                isDisabled={!canMoveDown}
+                onPress={() => onMove?.(1)}>
                 <ArrowDown data-slot="icon" />
             </Button>
             <Button

--- a/src/fsd/1-pages/goals/goal-card/goal-card.tsx
+++ b/src/fsd/1-pages/goals/goal-card/goal-card.tsx
@@ -40,7 +40,7 @@ interface GoalCardParts {
 interface Props {
     goal: TypedGoalSelect;
     goalEstimate?: IGoalEstimate;
-    menuItemSelect?: (item: 'edit' | 'delete' | 'moveUp' | 'moveDown') => void;
+    menuItemSelect?: (item: 'edit' | 'delete') => void;
     onToggleInclude?: () => void;
     bgColor: string;
     characters: ICharacter2[];
@@ -48,6 +48,10 @@ interface Props {
     bookRarity: Rarity;
     /** When provided, renders a drag grip in the header wired to the dnd-kit sortable activator. */
     dragHandle?: GoalDragHandle;
+    /** Moves the goal by one position within its section. Negative is up. */
+    onMove?: (delta: number) => void;
+    canMoveUp?: boolean;
+    canMoveDown?: boolean;
 }
 
 /** Renders a full goal card: header, type-specific body, notes, and status/raids footer. */
@@ -61,6 +65,9 @@ export const GoalCard: React.FC<Props> = ({
     mows,
     bookRarity,
     dragHandle,
+    onMove,
+    canMoveUp,
+    canMoveDown,
 }: Props) => {
     const goalEstimate: IGoalEstimate = passed ?? {
         goalId: goal.goalId,
@@ -240,7 +247,12 @@ export const GoalCard: React.FC<Props> = ({
                     />
                 </div>
                 <div className="shrink-0">
-                    <GoalCardActions menuItemSelect={menuItemSelect} />
+                    <GoalCardActions
+                        menuItemSelect={menuItemSelect}
+                        onMove={onMove}
+                        canMoveUp={canMoveUp}
+                        canMoveDown={canMoveDown}
+                    />
                 </div>
             </div>
 

--- a/src/fsd/3-features/shop-rewards/reward-info.render.spec.tsx
+++ b/src/fsd/3-features/shop-rewards/reward-info.render.spec.tsx
@@ -66,5 +66,7 @@ describe('every shop slot can be displayed', () => {
 
         expect(seen.size).toBeGreaterThan(0);
         expect(failures, `Reward types that failed to render a real icon:\n${failures.join('\n')}`).toHaveLength(0);
-    });
+        // Renders every reward type of every shop/day — ~2s alone, but enough slower under a full
+        // parallel suite run to trip the 5s default. Explicit headroom so it isn't load-dependent.
+    }, 20_000);
 });

--- a/src/fsd/4-entities/goal/goal-order.ts
+++ b/src/fsd/4-entities/goal/goal-order.ts
@@ -1,0 +1,9 @@
+/**
+ * Array order is the source of truth for goal ordering. The `priority` field is derived from it and
+ * re-derived on every load (see the `GlobalState` constructor), so persisting a `priority` that
+ * disagrees with the array position silently loses the reorder on the next refresh.
+ *
+ * Every write that changes goal order must return through here.
+ */
+export const normalizeGoalOrder = <T extends { priority: number }>(goals: readonly T[]): T[] =>
+    goals.map((goal, index) => ({ ...goal, priority: index + 1 }));

--- a/src/fsd/4-entities/goal/goal-order.ts
+++ b/src/fsd/4-entities/goal/goal-order.ts
@@ -1,9 +1,8 @@
 /**
- * Array order is the source of truth for goal ordering. The `priority` field is derived from it and
- * re-derived on every load (see the `GlobalState` constructor), so persisting a `priority` that
- * disagrees with the array position silently loses the reorder on the next refresh.
- *
- * Every write that changes goal order must return through here.
+ * Array order is the source of truth for goal ordering; `priority` is derived from it and re-derived
+ * on every load (see the `GlobalState` constructor). Persisting a `priority` that disagrees with the
+ * array position silently loses the reorder on the next refresh, so every write that changes goal
+ * order must return through here.
  */
 export const normalizeGoalOrder = <T extends { priority: number }>(goals: readonly T[]): T[] =>
     goals.map((goal, index) => ({ ...goal, priority: index + 1 }));

--- a/src/fsd/4-entities/goal/index.ts
+++ b/src/fsd/4-entities/goal/index.ts
@@ -1,4 +1,5 @@
 export { PersonalGoalType, CampaignsLocationsUsage } from './enums';
+export { normalizeGoalOrder } from './goal-order';
 export type {
     ICharacterUpgradeRankGoal,
     ICharacterUpgradeMow,

--- a/src/fsd/5-shared/lib/array-utils.spec.ts
+++ b/src/fsd/5-shared/lib/array-utils.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { arrayToKeyedObject, filterMap } from './array-utils';
+import { arrayToKeyedObject, filterMap, moveItem } from './array-utils';
 
 describe('filterMap', () => {
     describe('mapping behavior', () => {
@@ -86,6 +86,55 @@ describe('filterMap', () => {
             const result = filterMap(input, x => (x === 2 ? null : x));
             // eslint-disable-next-line unicorn/no-null
             expect(result).toEqual([1, null, 3]);
+        });
+    });
+});
+
+describe('moveItem', () => {
+    describe('basic behavior', () => {
+        it('moves an element forward', () => {
+            expect(moveItem(['a', 'b', 'c', 'd'], 0, 2)).toEqual(['b', 'c', 'a', 'd']);
+        });
+
+        it('moves an element backward', () => {
+            expect(moveItem(['a', 'b', 'c', 'd'], 3, 1)).toEqual(['a', 'd', 'b', 'c']);
+        });
+
+        it('moves an element by one position', () => {
+            expect(moveItem(['a', 'b', 'c'], 1, 0)).toEqual(['b', 'a', 'c']);
+        });
+
+        it('moves the first element to last', () => {
+            expect(moveItem(['a', 'b', 'c'], 0, 2)).toEqual(['b', 'c', 'a']);
+        });
+
+        it('moves the last element to first', () => {
+            expect(moveItem(['a', 'b', 'c'], 2, 0)).toEqual(['c', 'a', 'b']);
+        });
+
+        it('preserves element identity rather than cloning', () => {
+            const first = { id: 'a' };
+            const second = { id: 'b' };
+            const result = moveItem([first, second], 1, 0);
+            expect(result[0]).toBe(second);
+            expect(result[1]).toBe(first);
+        });
+    });
+
+    describe('edge cases', () => {
+        it('returns an equal array when the indices are the same', () => {
+            expect(moveItem(['a', 'b', 'c'], 1, 1)).toEqual(['a', 'b', 'c']);
+        });
+
+        it('returns a copy rather than mutating the input', () => {
+            const input = ['a', 'b', 'c'];
+            const result = moveItem(input, 0, 2);
+            expect(input).toEqual(['a', 'b', 'c']);
+            expect(result).not.toBe(input);
+        });
+
+        it('returns an equal array for a single-element array', () => {
+            expect(moveItem(['a'], 0, 0)).toEqual(['a']);
         });
     });
 });

--- a/src/fsd/5-shared/lib/array-utils.ts
+++ b/src/fsd/5-shared/lib/array-utils.ts
@@ -15,6 +15,17 @@ export const filterMap = <Element, Output>(
 };
 
 /**
+ * Returns a copy of `array` with the element at `fromIndex` moved to `toIndex`.
+ * Both indices are assumed to be in range — callers guard their own bounds.
+ */
+export const moveItem = <T>(array: readonly T[], fromIndex: number, toIndex: number): T[] => {
+    const result = [...array];
+    const [moved] = result.splice(fromIndex, 1);
+    result.splice(toIndex, 0, moved);
+    return result;
+};
+
+/**
  * Converts an array into an object keyed by the specified property.
  * If multiple elements share the same key value, the last one wins.
  */

--- a/src/models/__tests__/global-state.goals.spec.ts
+++ b/src/models/__tests__/global-state.goals.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { defaultData } from '@/models/constants';
+import { PersonalGoalType } from '@/models/enums';
+import { GlobalState } from '@/models/global-state';
+import { IGlobalState, IPersonalData2, IPersonalGoal } from '@/models/interfaces';
+import { goalsReducer } from '@/reducers/goals.reducer';
+
+const createGoal = (id: string, priority: number): IPersonalGoal => ({
+    id,
+    character: `char-${id}`,
+    type: PersonalGoalType.UpgradeRank,
+    priority,
+    dailyRaids: true,
+});
+
+const orderOf = (goals: IPersonalGoal[]) => goals.map(goal => goal.id);
+
+describe('GlobalState goals persistence', () => {
+    it('keeps a reorder across save/load', () => {
+        const baseState = new GlobalState(defaultData);
+        const goals = [createGoal('a', 1), createGoal('b', 2), createGoal('c', 3)];
+
+        const reordered = goalsReducer(goals, { type: 'Reorder', orderedIds: ['c', 'a', 'b'] });
+        expect(orderOf(reordered)).toEqual(['c', 'a', 'b']);
+
+        const stateToSave: IGlobalState = { ...baseState, goals: reordered };
+        const stored = GlobalState.toStore(stateToSave);
+        const restored = new GlobalState(stored);
+
+        expect(orderOf(restored.goals)).toEqual(['c', 'a', 'b']);
+        expect(restored.goals.map(goal => goal.priority)).toEqual([1, 2, 3]);
+    });
+
+    it('derives priority from array order, ignoring stored priority values', () => {
+        // Ordering lives in the array, not the field — a payload whose priorities disagree with its
+        // order (older data, or a caller that only rewrote the numbers) resolves to the array order.
+        const stored: IPersonalData2 = {
+            ...defaultData,
+            goals: [createGoal('a', 30), createGoal('b', 10), createGoal('c', 20)],
+        };
+
+        const restored = new GlobalState(stored);
+
+        expect(orderOf(restored.goals)).toEqual(['a', 'b', 'c']);
+        expect(restored.goals.map(goal => goal.priority)).toEqual([1, 2, 3]);
+    });
+});

--- a/src/models/global-state.ts
+++ b/src/models/global-state.ts
@@ -6,6 +6,7 @@ import { Rank, Rarity, UnitType, RarityStars, RarityMapper } from '@/fsd/5-share
 
 import { CampaignsService, ICampaignsProgress } from '@/fsd/4-entities/campaign';
 import { CharacterBias, CharactersService, ICharacter2 } from '@/fsd/4-entities/character';
+import { normalizeGoalOrder } from '@/fsd/4-entities/goal';
 import { IMow, IMow2, IMowDatabase, mows2Data, mowsData, MowsService } from '@/fsd/4-entities/mow';
 import { shopEvents as shopEventsRegistry } from '@/fsd/4-entities/shops';
 import { CharactersPowerService } from '@/fsd/4-entities/unit/characters-power.service';
@@ -88,9 +89,11 @@ export class GlobalState implements IGlobalState {
         this.characters = GlobalState.initCharacters(chars);
         this.mows = GlobalState.initMows(personalData.mows);
 
-        this.goals = personalData.goals.map((goal, index) => {
+        // Array order is the source of truth for goal ordering; `priority` is derived from it here
+        // and re-derived on every write by goalsReducer. See normalizeGoalOrder.
+        this.goals = normalizeGoalOrder(personalData.goals).map(goal => {
             const relatedChar = this.characters.find(x => x.name === goal.character);
-            return { ...goal, priority: index + 1, currentRank: relatedChar?.rank, currentRarity: relatedChar?.rarity };
+            return { ...goal, currentRank: relatedChar?.rank, currentRarity: relatedChar?.rarity };
         });
 
         this.modifiedDate = personalData.modifiedDate;

--- a/src/models/global-state.ts
+++ b/src/models/global-state.ts
@@ -89,8 +89,6 @@ export class GlobalState implements IGlobalState {
         this.characters = GlobalState.initCharacters(chars);
         this.mows = GlobalState.initMows(personalData.mows);
 
-        // Array order is the source of truth for goal ordering; `priority` is derived from it here
-        // and re-derived on every write by goalsReducer. See normalizeGoalOrder.
         this.goals = normalizeGoalOrder(personalData.goals).map(goal => {
             const relatedChar = this.characters.find(x => x.name === goal.character);
             return { ...goal, currentRank: relatedChar?.rank, currentRarity: relatedChar?.rarity };

--- a/src/reducers/__tests__/goals.reducer.spec.ts
+++ b/src/reducers/__tests__/goals.reducer.spec.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+
+import { PersonalGoalType } from '@/models/enums';
+import { IPersonalGoal } from '@/models/interfaces';
+import { goalsReducer } from '@/reducers/goals.reducer';
+
+const createGoal = (id: string, priority: number, overrides: Partial<IPersonalGoal> = {}): IPersonalGoal => ({
+    id,
+    character: `char-${id}`,
+    type: PersonalGoalType.UpgradeRank,
+    priority,
+    dailyRaids: true,
+    ...overrides,
+});
+
+/** Three "upgrade" goals interleaved with two "shard" goals, mimicking the goals page's sections. */
+const createInterleavedState = (): IPersonalGoal[] => [
+    createGoal('upgrade-a', 1),
+    createGoal('shard-a', 2, { type: PersonalGoalType.Ascend }),
+    createGoal('upgrade-b', 3),
+    createGoal('shard-b', 4, { type: PersonalGoalType.Ascend }),
+    createGoal('upgrade-c', 5),
+];
+
+const orderOf = (goals: IPersonalGoal[]) => goals.map(goal => goal.id);
+
+describe('goalsReducer Reorder', () => {
+    it('reorders one section without disturbing goals outside it', () => {
+        const next = goalsReducer(createInterleavedState(), {
+            type: 'Reorder',
+            orderedIds: ['upgrade-c', 'upgrade-a', 'upgrade-b'],
+        });
+
+        // The section's goals are rewritten into the slots they already occupied (0, 2, 4), so the
+        // shard goals keep their exact array positions.
+        expect(orderOf(next)).toEqual(['upgrade-c', 'shard-a', 'upgrade-a', 'shard-b', 'upgrade-b']);
+    });
+
+    it('re-indexes priority to match array position', () => {
+        const next = goalsReducer(createInterleavedState(), {
+            type: 'Reorder',
+            orderedIds: ['upgrade-c', 'upgrade-a', 'upgrade-b'],
+        });
+
+        expect(next.map(goal => goal.priority)).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it('is a no-op when an id is not in state', () => {
+        const state = createInterleavedState();
+
+        const next = goalsReducer(state, {
+            type: 'Reorder',
+            orderedIds: ['upgrade-c', 'upgrade-a', 'does-not-exist'],
+        });
+
+        expect(next).toBe(state);
+    });
+
+    it('is a no-op when ids are duplicated', () => {
+        const state = createInterleavedState();
+
+        const next = goalsReducer(state, {
+            type: 'Reorder',
+            orderedIds: ['upgrade-a', 'upgrade-a', 'upgrade-b'],
+        });
+
+        expect(next).toBe(state);
+    });
+});
+
+describe('goalsReducer Set', () => {
+    it('normalizes priority to array order', () => {
+        // A caller that rewrote priority numbers without reordering the array — the exact shape that
+        // silently lost drag-reorders, since only array order survives a save/load round trip.
+        const misaligned = [createGoal('a', 3), createGoal('b', 1), createGoal('c', 2)];
+
+        const next = goalsReducer([], { type: 'Set', value: misaligned });
+
+        expect(orderOf(next)).toEqual(['a', 'b', 'c']);
+        expect(next.map(goal => goal.priority)).toEqual([1, 2, 3]);
+    });
+});
+
+describe('goalsReducer Delete', () => {
+    it('re-indexes and strips the deleted id from other goals preFarmGoalIds', () => {
+        const state = [createGoal('a', 1), createGoal('b', 2, { preFarmGoalIds: ['a', 'c'] }), createGoal('c', 3)];
+
+        const next = goalsReducer(state, { type: 'Delete', goalId: 'a' });
+
+        expect(orderOf(next)).toEqual(['b', 'c']);
+        expect(next.map(goal => goal.priority)).toEqual([1, 2]);
+        expect(next[0].preFarmGoalIds).toEqual(['c']);
+    });
+});

--- a/src/reducers/goals.reducer.ts
+++ b/src/reducers/goals.reducer.ts
@@ -5,17 +5,13 @@ import { GoalsService } from '@/fsd/3-features/goals/goals.service';
 
 import { IPersonalGoal, SetStateAction } from '../models/interfaces';
 
-/**
- * Goal ordering lives in the array order, not in the `priority` field — every branch below returns
- * through `normalizeGoalOrder` so the two can never disagree. See `goal-order.ts` for why.
- */
 export type GoalsAction =
     | {
           type: 'Update';
           goal: TypedGoalSelect;
       }
     | {
-          /** Ids of one section's goals in their new order. Goals outside the set keep their slots. */
+          /** The reordered goals in their new order. Goals not listed keep their array slots. */
           type: 'Reorder';
           orderedIds: string[];
       }
@@ -42,9 +38,8 @@ export const goalsReducer = (state: IPersonalGoal[], action: GoalsAction) => {
             return normalizeGoalOrder(action.value);
         }
         case 'Reorder': {
-            // Works in array-slot space: the section's goals are rewritten into the slots they
-            // already occupy, so goals outside the section keep their exact positions and no
-            // assumption is made about the current array being priority-sorted.
+            // Rewrites the listed goals into the slots they already occupy, so everything else keeps
+            // its position and no assumption is made about the array being priority-sorted.
             const idSet = new Set(action.orderedIds);
             const slots: number[] = [];
             for (const [index, goal] of state.entries()) {

--- a/src/reducers/goals.reducer.ts
+++ b/src/reducers/goals.reducer.ts
@@ -1,17 +1,23 @@
-﻿import { TypedGoalSelect } from '@/fsd/3-features/goals/goals.models';
+﻿import { normalizeGoalOrder } from '@/fsd/4-entities/goal';
+
+import { TypedGoalSelect } from '@/fsd/3-features/goals/goals.models';
 import { GoalsService } from '@/fsd/3-features/goals/goals.service';
 
 import { IPersonalGoal, SetStateAction } from '../models/interfaces';
 
+/**
+ * Goal ordering lives in the array order, not in the `priority` field — every branch below returns
+ * through `normalizeGoalOrder` so the two can never disagree. See `goal-order.ts` for why.
+ */
 export type GoalsAction =
     | {
           type: 'Update';
           goal: TypedGoalSelect;
       }
     | {
-          type: 'Swap';
-          goalId: string;
-          neighborId: string;
+          /** Ids of one section's goals in their new order. Goals outside the set keep their slots. */
+          type: 'Reorder';
+          orderedIds: string[];
       }
     | {
           type: 'Add';
@@ -33,23 +39,28 @@ export type GoalsAction =
 export const goalsReducer = (state: IPersonalGoal[], action: GoalsAction) => {
     switch (action.type) {
         case 'Set': {
-            return action.value;
+            return normalizeGoalOrder(action.value);
         }
-        case 'Swap': {
-            const { goalId, neighborId } = action;
-            const newState = state.toSorted((a, b) => a.priority - b.priority);
-
-            const indexA = newState.findIndex(x => x.id === goalId);
-            const indexB = newState.findIndex(x => x.id === neighborId);
-
-            if (indexA !== -1 && indexB !== -1) {
-                // Swap them in the array
-                [newState[indexA], newState[indexB]] = [newState[indexB], newState[indexA]];
-
-                // Re-index priorities 1..N
-                return newState.map((g, index) => ({ ...g, priority: index + 1 }));
+        case 'Reorder': {
+            // Works in array-slot space: the section's goals are rewritten into the slots they
+            // already occupy, so goals outside the section keep their exact positions and no
+            // assumption is made about the current array being priority-sorted.
+            const idSet = new Set(action.orderedIds);
+            const slots: number[] = [];
+            for (const [index, goal] of state.entries()) {
+                if (idSet.has(goal.id)) slots.push(index);
             }
-            return state;
+            // Unknown or duplicated ids would drop goals — refuse the whole operation instead.
+            if (slots.length !== action.orderedIds.length) {
+                return state;
+            }
+
+            const byId = new Map(state.map(goal => [goal.id, goal]));
+            const newState = [...state];
+            for (const [position, slot] of slots.entries()) {
+                newState[slot] = byId.get(action.orderedIds[position])!;
+            }
+            return normalizeGoalOrder(newState);
         }
         case 'Add': {
             if (state.some(x => x.id === action.goal.id)) {
@@ -60,21 +71,16 @@ export const goalsReducer = (state: IPersonalGoal[], action: GoalsAction) => {
             const targetIndex = Math.max(0, Math.min(action.goal.priority - 1, newState.length));
             newState.splice(targetIndex, 0, action.goal);
 
-            // Return a new array with re-indexed priorities to ensure reactivity
-            return newState.map((x, index) => ({
-                ...x,
-                priority: index + 1,
-            }));
+            return normalizeGoalOrder(newState);
         }
         case 'Delete': {
             const deletedId = action.goalId;
-            return state
+            const remaining = state
                 .filter(x => x.id !== deletedId)
-                .map((x, index) => ({
-                    ...x,
-                    priority: index + 1,
-                    ...(x.preFarmGoalIds ? { preFarmGoalIds: x.preFarmGoalIds.filter(id => id !== deletedId) } : {}),
-                }));
+                .map(x =>
+                    x.preFarmGoalIds ? { ...x, preFarmGoalIds: x.preFarmGoalIds.filter(id => id !== deletedId) } : x
+                );
+            return normalizeGoalOrder(remaining);
         }
         case 'DeleteAll': {
             return [];
@@ -104,7 +110,7 @@ export const goalsReducer = (state: IPersonalGoal[], action: GoalsAction) => {
 
             const finalGoals = [...otherGoals.slice(0, targetIndex), goalWithUpdates, ...otherGoals.slice(targetIndex)];
 
-            return finalGoals.map((g, index) => ({ ...g, priority: index + 1 }));
+            return normalizeGoalOrder(finalGoals);
         }
         case 'UpdateDailyRaids': {
             const { value } = action;

--- a/src/routes/goals/goal-section.tsx
+++ b/src/routes/goals/goal-section.tsx
@@ -61,8 +61,7 @@ export const GoalSection: React.FC<Props> = ({
     onMenuItemSelect,
     onToggleInclude,
 }) => {
-    // Keyed lookup so cards don't scan the estimate list on every render — dnd-kit re-renders every
-    // sortable in the section on each reorder transition.
+    // Keyed lookup — cards would otherwise scan the estimate list once each, per render.
     const estimateById = useMemo(() => new Map(estimates.map(estimate => [estimate.goalId, estimate])), [estimates]);
 
     return (

--- a/src/routes/goals/goal-section.tsx
+++ b/src/routes/goals/goal-section.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { Rarity } from '@/fsd/5-shared/model';
 import { Accordion, AccordionBody, AccordionHeader } from '@/fsd/5-shared/ui';
@@ -32,8 +32,13 @@ interface Props {
     bookRarity: Rarity;
     characters: ICharacter2[];
     mows: IMow2[];
+    /** Section-scoped drag reorder — ids of this section's goals in their new order. */
     onReorder: (orderedIds: string[], movedId: string) => void;
-    onMenuItemSelect: (goalId: string, item: 'edit' | 'delete' | 'moveUp' | 'moveDown') => void;
+    /** Priority-arrow move by one position in the GLOBAL order; may cross a section boundary. */
+    onMove: (goalId: string, delta: number) => void;
+    /** Total goal count across all sections — the upper bound of the global priority range. */
+    totalGoals: number;
+    onMenuItemSelect: (goalId: string, item: 'edit' | 'delete') => void;
     onToggleInclude: (goalId: string) => void;
 }
 
@@ -51,45 +56,55 @@ export const GoalSection: React.FC<Props> = ({
     characters,
     mows,
     onReorder,
+    onMove,
+    totalGoals,
     onMenuItemSelect,
     onToggleInclude,
-}) => (
-    <Accordion expanded={expanded} onToggle={onToggle}>
-        <AccordionHeader>{header}</AccordionHeader>
-        <AccordionBody>
-            {tableView ? (
-                <GoalsTable
-                    variant={variant}
-                    rows={items}
-                    estimate={estimates}
-                    goalsColorCoding={colorMode}
-                    menuItemSelect={onMenuItemSelect}
-                    onToggleInclude={onToggleInclude}
-                    onReorder={onReorder}
-                />
-            ) : (
-                <SortableGoalGrid
-                    items={items}
-                    onReorder={onReorder}
-                    className={GRID_CLASS}
-                    renderCard={(goal, dragHandle) => {
-                        const estimate = estimates.find(x => x.goalId === goal.goalId);
-                        return (
+}) => {
+    // Keyed lookup so cards don't scan the estimate list on every render — dnd-kit re-renders every
+    // sortable in the section on each reorder transition.
+    const estimateById = useMemo(() => new Map(estimates.map(estimate => [estimate.goalId, estimate])), [estimates]);
+
+    return (
+        <Accordion expanded={expanded} onToggle={onToggle}>
+            <AccordionHeader>{header}</AccordionHeader>
+            <AccordionBody>
+                {tableView ? (
+                    <GoalsTable
+                        variant={variant}
+                        rows={items}
+                        estimate={estimates}
+                        goalsColorCoding={colorMode}
+                        menuItemSelect={onMenuItemSelect}
+                        onToggleInclude={onToggleInclude}
+                        onReorder={onReorder}
+                        onMove={onMove}
+                        totalGoals={totalGoals}
+                    />
+                ) : (
+                    <SortableGoalGrid
+                        items={items}
+                        onReorder={onReorder}
+                        className={GRID_CLASS}
+                        renderCard={(goal, dragHandle) => (
                             <GoalCard
                                 goal={goal}
-                                goalEstimate={estimate}
+                                goalEstimate={estimateById.get(goal.goalId)}
                                 bookRarity={bookRarity}
                                 characters={characters}
                                 mows={mows}
                                 menuItemSelect={item => onMenuItemSelect(goal.goalId, item)}
                                 onToggleInclude={() => onToggleInclude(goal.goalId)}
-                                bgColor={GoalService.getBackgroundColor(colorMode, estimate)}
+                                bgColor={GoalService.getBackgroundColor(colorMode, estimateById.get(goal.goalId))}
                                 dragHandle={dragHandle}
+                                onMove={delta => onMove(goal.goalId, delta)}
+                                canMoveUp={goal.priority > 1}
+                                canMoveDown={goal.priority < totalGoals}
                             />
-                        );
-                    }}
-                />
-            )}
-        </AccordionBody>
-    </Accordion>
-);
+                        )}
+                    />
+                )}
+            </AccordionBody>
+        </Accordion>
+    );
+};

--- a/src/routes/goals/goals-table.tsx
+++ b/src/routes/goals/goals-table.tsx
@@ -79,6 +79,10 @@ interface Props {
     onToggleInclude?: (goalId: string) => void;
     /** Section-scoped reorder — same contract as the card grid (new order of ids + which id moved). */
     onReorder: (orderedIds: string[], movedId: string) => void;
+    /** Priority-arrow move by one position in the GLOBAL order; may cross a section boundary. */
+    onMove: (goalId: string, delta: number) => void;
+    /** Total goal count across all sections — the upper bound of the global priority range. */
+    totalGoals: number;
 }
 
 const emptyCell = <div className="flex h-full items-center text-sm leading-normal text-(--soft-fg) opacity-50">—</div>;
@@ -109,6 +113,8 @@ export const GoalsTable: React.FC<Props> = ({
     menuItemSelect,
     onToggleInclude,
     onReorder,
+    onMove,
+    totalGoals,
 }) => {
     // All frequently-changing values live in refs so columnDefs can have stable deps and never
     // recompute — which would reset user-resized column widths.
@@ -116,27 +122,27 @@ export const GoalsTable: React.FC<Props> = ({
     const savedWidthsReference = useRef<Record<string, number>>({});
     const statusColWidthReference = useRef(STATUS_COL_DEFAULT_WIDTH);
     // True while any column sort is active. Managed row-drag is suppressed by ag-grid under a sort,
-    // so the grip is disabled/dimmed then; the arrows still reorder in priority space (see prioCol).
+    // so the grip is disabled/dimmed then; the arrows still work, since they move the goal in global
+    // priority space rather than in display order (see prioCol).
     const sortActiveReference = useRef(false);
     const goalsColorCodingReference = useRef(goalsColorCoding);
     const onToggleIncludeReference = useRef(onToggleInclude);
     const menuItemSelectReference = useRef(menuItemSelect);
     const onReorderReference = useRef(onReorder);
-    const rowsReference = useRef(rows);
+    const onMoveReference = useRef(onMove);
+    const totalGoalsReference = useRef(totalGoals);
     // Map keyed by goalId for O(1) lookups in cell renderers.
     const estimateMapReference = useRef<Map<string, IGoalEstimate>>(new Map());
-    // Priority-order index per goalId (rows are priority-sorted) — O(1) lookup for the reorder arrows.
-    const priorityIndexReference = useRef<Map<string, number>>(new Map());
 
     useLayoutEffect(() => {
         goalsColorCodingReference.current = goalsColorCoding;
         onToggleIncludeReference.current = onToggleInclude;
         menuItemSelectReference.current = menuItemSelect;
         onReorderReference.current = onReorder;
-        rowsReference.current = rows;
+        onMoveReference.current = onMove;
+        totalGoalsReference.current = totalGoals;
         estimateMapReference.current = new Map(estimate.map(est => [est.goalId, est]));
-        priorityIndexReference.current = new Map(rows.map((row, index) => [row.goalId, index]));
-    }, [estimate, goalsColorCoding, menuItemSelect, onReorder, onToggleInclude, rows]);
+    }, [estimate, goalsColorCoding, menuItemSelect, onMove, onReorder, onToggleInclude, rows, totalGoals]);
 
     // Redraw rows (not columns) when estimates OR the colour-coding mode change, so cell content,
     // row classes and row styles (getRowStyle reads the colour-mode ref) stay current without
@@ -172,18 +178,6 @@ export const GoalsTable: React.FC<Props> = ({
         }
     }, []);
 
-    /** Moves the row at fromIndex to toIndex within this section and persists the reorder. */
-    const moveRow = useCallback((fromIndex: number, toIndex: number) => {
-        const ordered = [...rowsReference.current];
-        if (toIndex < 0 || toIndex >= ordered.length) return;
-        const [moved] = ordered.splice(fromIndex, 1);
-        ordered.splice(toIndex, 0, moved);
-        onReorderReference.current(
-            ordered.map(row => row.goalId),
-            moved.goalId
-        );
-    }, []);
-
     const handleRowDragEnd = useCallback((event_: RowDragEndEvent<TypedGoalSelect>) => {
         // Under an active sort the post-sort node order isn't the user's intended manual order, so
         // never persist it (ag-grid also suppresses managed drag while sorted — this is a guard).
@@ -198,8 +192,9 @@ export const GoalsTable: React.FC<Props> = ({
 
     const handleSortChanged = useCallback((event_: SortChangedEvent) => {
         sortActiveReference.current = event_.api.getColumnState().some(column => !!column.sort);
-        // Re-render the grip so its enabled/dimmed state matches the new sort state.
-        event_.api.refreshCells({ force: true });
+        // Full row redraw (not refreshCells) so both the grip's dimmed state and the `rowDrag`
+        // callback are re-evaluated — rowDrag is read when the cell is built, not on a cell refresh.
+        event_.api.redrawRows();
     }, []);
 
     // columnDefs recomputes only when the variant changes (stable per mounted table). All changing
@@ -235,33 +230,34 @@ export const GoalsTable: React.FC<Props> = ({
             valueGetter: params => params.data?.priority ?? 0,
             cellClass: 'prio-cell',
             cellRenderer: (params: ICellRendererParams<TypedGoalSelect>) => {
-                if (!params.data) return;
-                // Index in PRIORITY order (rows are always priority-sorted), not the display index —
-                // so the arrows reorder the clicked goal correctly even under a column sort. O(1) via
-                // the prebuilt map so redraws don't re-scan the section per row.
-                const index = priorityIndexReference.current.get(params.data.goalId) ?? 0;
-                const total = priorityIndexReference.current.size;
+                const { data } = params;
+                if (!data) return;
+                // Priority is GLOBAL (1..totalGoals across every section), so the arrows are live
+                // whenever a neighbour exists anywhere in that range — the goal one step up may sit
+                // in a different accordion section, which is a legitimate move.
+                const { priority } = data;
+                const total = totalGoalsReference.current;
                 return (
                     <div className="flex h-full w-full">
                         <div className="flex flex-1 items-center px-3">
                             <span className="min-w-[20px] text-center text-sm font-medium text-(--soft-fg) tabular-nums">
-                                {params.data.priority}
+                                {priority}
                             </span>
                         </div>
                         <div className="flex w-10 flex-col border-l border-(--border)">
                             <button
                                 type="button"
                                 title="Move Up"
-                                disabled={index <= 0}
-                                onClick={() => moveRow(index, index - 1)}
+                                disabled={priority <= 1}
+                                onClick={() => onMoveReference.current(data.goalId, -1)}
                                 className="flex w-full flex-1 cursor-pointer items-center justify-center text-(--soft-fg) transition-colors hover:bg-(--primary)/15 hover:text-(--primary) disabled:cursor-not-allowed disabled:opacity-25">
                                 <ArrowUp className="size-3" />
                             </button>
                             <button
                                 type="button"
                                 title="Move Down"
-                                disabled={index >= total - 1}
-                                onClick={() => moveRow(index, index + 1)}
+                                disabled={priority >= total}
+                                onClick={() => onMoveReference.current(data.goalId, 1)}
                                 className="flex w-full flex-1 cursor-pointer items-center justify-center text-(--soft-fg) transition-colors hover:bg-(--primary)/15 hover:text-(--primary) disabled:cursor-not-allowed disabled:opacity-25">
                                 <ArrowDown className="size-3" />
                             </button>
@@ -918,7 +914,7 @@ export const GoalsTable: React.FC<Props> = ({
             ...(variant === 'rank' ? [upgradesCol] : []),
             notesCol,
         ];
-    }, [variant, moveRow]);
+    }, [variant]);
 
     const getRowStyle = useCallback((params: RowClassParams<TypedGoalSelect>): RowStyle | undefined => {
         const goalEstimate = params.data ? estimateMapReference.current.get(params.data.goalId) : undefined;

--- a/src/routes/goals/goals-table.tsx
+++ b/src/routes/goals/goals-table.tsx
@@ -121,9 +121,8 @@ export const GoalsTable: React.FC<Props> = ({
     const gridApiReference = useRef<GridApi | null>(null);
     const savedWidthsReference = useRef<Record<string, number>>({});
     const statusColWidthReference = useRef(STATUS_COL_DEFAULT_WIDTH);
-    // True while any column sort is active. Managed row-drag is suppressed by ag-grid under a sort,
-    // so the grip is disabled/dimmed then; the arrows still work, since they move the goal in global
-    // priority space rather than in display order (see prioCol).
+    // True while any column sort is active — ag-grid suppresses managed row-drag then, so the grip
+    // is dimmed. The arrows still work: they move in global priority space, not display order.
     const sortActiveReference = useRef(false);
     const goalsColorCodingReference = useRef(goalsColorCoding);
     const onToggleIncludeReference = useRef(onToggleInclude);
@@ -232,9 +231,7 @@ export const GoalsTable: React.FC<Props> = ({
             cellRenderer: (params: ICellRendererParams<TypedGoalSelect>) => {
                 const { data } = params;
                 if (!data) return;
-                // Priority is GLOBAL (1..totalGoals across every section), so the arrows are live
-                // whenever a neighbour exists anywhere in that range — the goal one step up may sit
-                // in a different accordion section, which is a legitimate move.
+                // Priority is GLOBAL (1..totalGoals), so a neighbour in another section still counts.
                 const { priority } = data;
                 const total = totalGoalsReference.current;
                 return (

--- a/src/routes/goals/goals.tsx
+++ b/src/routes/goals/goals.tsx
@@ -34,6 +34,7 @@ import { GoalsService } from '@/fsd/3-features/goals/goals.service';
 import { UpgradesService } from '@/fsd/3-features/goals/upgrades.service';
 
 import { GoalColorCodingToggle, GoalColorMode } from './goal-color-coding-toggle';
+import { moveGoalInOrder } from './reorder';
 
 const MYTHIC_UNCRAFTABLE_UPGRADES = [
     {
@@ -142,21 +143,30 @@ export const Goals = () => {
     const sortedAbilities = upgradeAbilities.toSorted((a, b) => a.priority - b.priority);
 
     /**
-     * Reorders one section by drag. Preserves that section's set of priority numbers and reassigns
-     * them to the new visual order (mirrors the ui-kit table's applyPriorities), then persists the
-     * full goal list so global ordering outside the section stays stable.
+     * Reorders one section. The reducer rewrites the section's goals into the array slots they
+     * already occupy, so goals in the other sections keep their global positions.
      */
     const handleReorder = (orderedGoalIds: string[], movedId: string): void => {
-        const idSet = new Set(orderedGoalIds);
-        const sectionPriorities = goals
-            .filter(g => idSet.has(g.id))
-            .map(g => g.priority)
-            .toSorted((a, b) => a - b);
-        const newPriorityById = new Map<string, number>();
-        for (const [index, id] of orderedGoalIds.entries()) newPriorityById.set(id, sectionPriorities[index]);
-        const next = goals.map(g => (newPriorityById.has(g.id) ? { ...g, priority: newPriorityById.get(g.id)! } : g));
-        dispatch.goals({ type: 'Set', value: next });
-        setAnnouncement(`Goal moved to priority ${newPriorityById.get(movedId)}.`);
+        dispatch.goals({ type: 'Reorder', orderedIds: orderedGoalIds });
+        setAnnouncement(
+            `Goal moved to position ${orderedGoalIds.indexOf(movedId) + 1} of ${orderedGoalIds.length} in its section.`
+        );
+    };
+
+    /**
+     * Moves a goal one position in the GLOBAL priority order. Priority numbers are global, so the
+     * neighbour one step away may sit in a different accordion section — the arrows can cross that
+     * boundary even though drag reorder cannot.
+     */
+    const handleMove = (goalId: string, delta: number): void => {
+        const reordered = moveGoalInOrder(
+            goals.map(g => g.id),
+            goalId,
+            delta
+        );
+        if (!reordered) return;
+        dispatch.goals({ type: 'Reorder', orderedIds: reordered });
+        setAnnouncement(`Goal moved to priority ${reordered.indexOf(goalId) + 1}.`);
     };
 
     /** Toggles a goal's daily-raids inclusion and announces the change politely. */
@@ -261,8 +271,7 @@ export const Goals = () => {
         dispatch.viewPreferences({ type: 'Update', setting: 'goalsTableView', value: tableView });
     };
 
-    const handleMenuItemSelect = (goalId: string, item: 'edit' | 'delete' | 'moveUp' | 'moveDown') => {
-        const currentGoals = goals.toSorted((a, b) => a.priority - b.priority);
+    const handleMenuItemSelect = (goalId: string, item: 'edit' | 'delete') => {
         if (item === 'delete' && confirm('Are you sure? The goal will be permanently deleted!')) {
             removeGoal(goalId);
         }
@@ -284,26 +293,6 @@ export const Goals = () => {
             ) {
                 setEditUnit(relatedUnit);
                 setEditGoal(goal);
-            }
-        }
-
-        if (item === 'moveUp' || item === 'moveDown') {
-            const isUp = item === 'moveUp';
-
-            // Find current position in the flattened list
-            const currentIndex = currentGoals.findIndex(x => x.id === goalId);
-            const targetIndex = isUp ? currentIndex - 1 : currentIndex + 1;
-
-            // 2. Boundary Check
-            if (targetIndex >= 0 && targetIndex < currentGoals.length) {
-                const neighbor = currentGoals[targetIndex];
-
-                // 3. Dispatch atomic swap
-                dispatch.goals({
-                    type: 'Swap',
-                    goalId: goalId,
-                    neighborId: neighbor.id,
-                });
             }
         }
     };
@@ -656,7 +645,7 @@ export const Goals = () => {
                     </Accordion>
                 </div>
             )}
-            {upgradeRankOrMowGoals.length + upgradeMaterialGoals.length > 0 && (
+            {sortedUpgrades.length > 0 && (
                 <GoalSection
                     expanded={sectionsExpanded.upgrades}
                     onToggle={expanded => setSectionsExpanded(previous => ({ ...previous, upgrades: expanded }))}
@@ -669,6 +658,8 @@ export const Goals = () => {
                     characters={characters}
                     mows={resolvedMows as IMow2[]}
                     onReorder={handleReorder}
+                    onMove={handleMove}
+                    totalGoals={goals.length}
                     onMenuItemSelect={handleMenuItemSelect}
                     onToggleInclude={handleToggleIncludeById}
                     header={
@@ -701,6 +692,8 @@ export const Goals = () => {
                     characters={characters}
                     mows={resolvedMows as IMow2[]}
                     onReorder={handleReorder}
+                    onMove={handleMove}
+                    totalGoals={goals.length}
                     onMenuItemSelect={handleMenuItemSelect}
                     onToggleInclude={handleToggleIncludeById}
                     header={
@@ -732,6 +725,8 @@ export const Goals = () => {
                     characters={characters}
                     mows={resolvedMows as IMow2[]}
                     onReorder={handleReorder}
+                    onMove={handleMove}
+                    totalGoals={goals.length}
                     onMenuItemSelect={handleMenuItemSelect}
                     onToggleInclude={handleToggleIncludeById}
                     header={

--- a/src/routes/goals/goals.tsx
+++ b/src/routes/goals/goals.tsx
@@ -142,10 +142,7 @@ export const Goals = () => {
         .toSorted((a, b) => a.priority - b.priority);
     const sortedAbilities = upgradeAbilities.toSorted((a, b) => a.priority - b.priority);
 
-    /**
-     * Reorders one section. The reducer rewrites the section's goals into the array slots they
-     * already occupy, so goals in the other sections keep their global positions.
-     */
+    /** Drag reorder within one section; the other sections keep their global positions. */
     const handleReorder = (orderedGoalIds: string[], movedId: string): void => {
         dispatch.goals({ type: 'Reorder', orderedIds: orderedGoalIds });
         setAnnouncement(
@@ -153,11 +150,7 @@ export const Goals = () => {
         );
     };
 
-    /**
-     * Moves a goal one position in the GLOBAL priority order. Priority numbers are global, so the
-     * neighbour one step away may sit in a different accordion section — the arrows can cross that
-     * boundary even though drag reorder cannot.
-     */
+    /** Arrow move in the GLOBAL priority order — unlike drag, this can cross a section boundary. */
     const handleMove = (goalId: string, delta: number): void => {
         const reordered = moveGoalInOrder(
             goals.map(g => g.id),

--- a/src/routes/goals/reorder.spec.ts
+++ b/src/routes/goals/reorder.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import { moveGoalInOrder } from './reorder';
+
+// The global goal order, interleaving two accordion sections the way the goals page does — the
+// arrows move a goal one step in THIS list, so a move can cross a section boundary.
+const ORDER = ['ascend-1', 'upgrade-2', 'upgrade-3', 'ascend-4'];
+
+describe('moveGoalInOrder', () => {
+    describe('moving up', () => {
+        it('swaps the goal with the one above it', () => {
+            expect(moveGoalInOrder(ORDER, 'upgrade-3', -1)).toEqual(['ascend-1', 'upgrade-3', 'upgrade-2', 'ascend-4']);
+        });
+
+        it('moves a goal past a neighbour from another section', () => {
+            // upgrade-2 is first in its own section but second globally, so it can still move up.
+            expect(moveGoalInOrder(ORDER, 'upgrade-2', -1)).toEqual(['upgrade-2', 'ascend-1', 'upgrade-3', 'ascend-4']);
+        });
+
+        it('returns undefined only for the globally first goal', () => {
+            expect(moveGoalInOrder(ORDER, 'ascend-1', -1)).toBeUndefined();
+        });
+    });
+
+    describe('moving down', () => {
+        it('swaps the goal with the one below it', () => {
+            expect(moveGoalInOrder(ORDER, 'upgrade-2', 1)).toEqual(['ascend-1', 'upgrade-3', 'upgrade-2', 'ascend-4']);
+        });
+
+        it('returns undefined only for the globally last goal', () => {
+            expect(moveGoalInOrder(ORDER, 'ascend-4', 1)).toBeUndefined();
+        });
+    });
+
+    describe('edge cases', () => {
+        it('returns undefined when the goal is not in the list', () => {
+            expect(moveGoalInOrder(ORDER, 'not-here', 1)).toBeUndefined();
+        });
+
+        it('returns undefined for a single-goal list in either direction', () => {
+            expect(moveGoalInOrder(['only'], 'only', -1)).toBeUndefined();
+            expect(moveGoalInOrder(['only'], 'only', 1)).toBeUndefined();
+        });
+
+        it('returns undefined when a multi-step move would overshoot the end', () => {
+            expect(moveGoalInOrder(ORDER, 'upgrade-3', 2)).toBeUndefined();
+        });
+
+        it('supports multi-step moves that stay in range', () => {
+            expect(moveGoalInOrder(ORDER, 'ascend-1', 3)).toEqual(['upgrade-2', 'upgrade-3', 'ascend-4', 'ascend-1']);
+        });
+
+        it('does not mutate the list', () => {
+            const order = ['a', 'b', 'c'];
+            moveGoalInOrder(order, 'a', 1);
+            expect(order).toEqual(['a', 'b', 'c']);
+        });
+    });
+});

--- a/src/routes/goals/reorder.spec.ts
+++ b/src/routes/goals/reorder.spec.ts
@@ -2,8 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { moveGoalInOrder } from './reorder';
 
-// The global goal order, interleaving two accordion sections the way the goals page does — the
-// arrows move a goal one step in THIS list, so a move can cross a section boundary.
+// Global order, interleaving two accordion sections the way the goals page does.
 const ORDER = ['ascend-1', 'upgrade-2', 'upgrade-3', 'ascend-4'];
 
 describe('moveGoalInOrder', () => {

--- a/src/routes/goals/reorder.ts
+++ b/src/routes/goals/reorder.ts
@@ -1,0 +1,21 @@
+import { moveItem } from '@/fsd/5-shared/lib';
+
+/**
+ * Computes the new order when one goal moves by `delta` positions (negative is up).
+ *
+ * Used by the priority arrows against the *global* goal order, so a move can cross an accordion
+ * section boundary — priority numbers are global, and the neighbour one step up may well live in a
+ * different section. Drag reorder is separate and stays within a section.
+ *
+ * Returns `undefined` when the move is not possible — unknown goal, or a move that would run past
+ * either end of the list — so callers can skip dispatching a no-op reorder.
+ */
+export const moveGoalInOrder = (orderedIds: readonly string[], goalId: string, delta: number): string[] | undefined => {
+    const from = orderedIds.indexOf(goalId);
+    if (from === -1) return;
+
+    const to = from + delta;
+    if (to < 0 || to >= orderedIds.length) return;
+
+    return moveItem(orderedIds, from, to);
+};

--- a/src/routes/goals/reorder.ts
+++ b/src/routes/goals/reorder.ts
@@ -1,14 +1,11 @@
 import { moveItem } from '@/fsd/5-shared/lib';
 
 /**
- * Computes the new order when one goal moves by `delta` positions (negative is up).
+ * Computes the new order when one goal moves by `delta` positions (negative is up). Used by the
+ * priority arrows against the *global* order, so a move can cross an accordion section boundary.
  *
- * Used by the priority arrows against the *global* goal order, so a move can cross an accordion
- * section boundary — priority numbers are global, and the neighbour one step up may well live in a
- * different section. Drag reorder is separate and stays within a section.
- *
- * Returns `undefined` when the move is not possible — unknown goal, or a move that would run past
- * either end of the list — so callers can skip dispatching a no-op reorder.
+ * Returns `undefined` when the move is not possible — unknown goal, or past either end — so callers
+ * can skip dispatching a no-op reorder.
  */
 export const moveGoalInOrder = (orderedIds: readonly string[], goalId: string, delta: number): string[] | undefined => {
     const from = orderedIds.indexOf(goalId);

--- a/src/routes/goals/sortable-goal-grid.tsx
+++ b/src/routes/goals/sortable-goal-grid.tsx
@@ -36,9 +36,8 @@ interface SortableItemProps<T> {
     renderCard: (item: T, dragHandle: GoalDragHandle) => React.ReactNode;
 }
 
-// Not memoised on purpose: dnd-kit re-renders every sortable on each reorder transition via the
-// useSortable context subscription, which React.memo cannot block. The cost that mattered was the
-// per-card estimate lookup, which GoalSection now does through a keyed map.
+// Deliberately not memoised: dnd-kit re-renders every sortable through the useSortable context
+// subscription, which React.memo cannot block.
 const SortableGoalCard = <T extends { goalId: string }>({ item, renderCard }: SortableItemProps<T>) => {
     const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } = useSortable({
         id: item.goalId,
@@ -72,27 +71,25 @@ export const SortableGoalGrid = <T extends { goalId: string }>({
         useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
     );
     const [activeId, setActiveId] = useState<UniqueIdentifier | undefined>();
-    // Grid cards are stretched to the row height by `h-full`, which resolves to `auto` inside the
-    // overlay — pin both dimensions so the dragged card doesn't collapse to its content height.
+    // `h-full` resolves to `auto` inside the overlay, so pin both dimensions or the card collapses.
     const [activeSize, setActiveSize] = useState<{ width: number; height: number } | undefined>();
 
-    // `items` comes back through the global store, which commits in a POST-PAINT effect — so the
-    // reordered list arrives a render after the drop, and the grid would otherwise paint the old
-    // order first and visibly jump. Holding the dropped order locally paints it immediately, and
-    // also lets dnd-kit's drop animation land on the slot the card was actually dropped into.
+    // `items` returns through the global store, which commits in a POST-PAINT effect — so without
+    // this the grid paints the pre-drop order first and visibly jumps.
     const [dropOrder, setDropOrder] = useState<string[]>();
 
-    const propertyIdsKey = items.map(item => item.goalId).join('|');
-    // Release the optimistic order once the store catches up, or the section changes underneath us.
+    // Keyed on id CONTENT: the goals page rebuilds these arrays with .toSorted() every render, so an
+    // identity-keyed effect would clear the order immediately.
+    const itemIdsKey = items.map(item => item.goalId).join('|');
     useEffect(() => {
         setDropOrder(undefined);
-    }, [propertyIdsKey]);
+    }, [itemIdsKey]);
 
     const orderedItems = useMemo(() => {
         if (!dropOrder) return items;
         const byId = new Map(items.map(item => [item.goalId, item]));
         const reordered = filterMap(dropOrder, id => byId.get(id));
-        // Fall back to the props order if the section membership changed while we held a drop order.
+        // Section membership changed while we held a drop order — defer to props.
         return reordered.length === items.length ? reordered : items;
     }, [items, dropOrder]);
 

--- a/src/routes/goals/sortable-goal-grid.tsx
+++ b/src/routes/goals/sortable-goal-grid.tsx
@@ -18,7 +18,9 @@ import {
     useSortable,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+
+import { filterMap } from '@/fsd/5-shared/lib';
 
 type SortableReturn = ReturnType<typeof useSortable>;
 
@@ -34,6 +36,9 @@ interface SortableItemProps<T> {
     renderCard: (item: T, dragHandle: GoalDragHandle) => React.ReactNode;
 }
 
+// Not memoised on purpose: dnd-kit re-renders every sortable on each reorder transition via the
+// useSortable context subscription, which React.memo cannot block. The cost that mattered was the
+// per-card estimate lookup, which GoalSection now does through a keyed map.
 const SortableGoalCard = <T extends { goalId: string }>({ item, renderCard }: SortableItemProps<T>) => {
     const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } = useSortable({
         id: item.goalId,
@@ -67,14 +72,37 @@ export const SortableGoalGrid = <T extends { goalId: string }>({
         useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
     );
     const [activeId, setActiveId] = useState<UniqueIdentifier | undefined>();
-    const [activeWidth, setActiveWidth] = useState<number>();
+    // Grid cards are stretched to the row height by `h-full`, which resolves to `auto` inside the
+    // overlay — pin both dimensions so the dragged card doesn't collapse to its content height.
+    const [activeSize, setActiveSize] = useState<{ width: number; height: number } | undefined>();
 
-    const ids = items.map(item => item.goalId);
-    const activeItem = items.find(item => item.goalId === activeId);
+    // `items` comes back through the global store, which commits in a POST-PAINT effect — so the
+    // reordered list arrives a render after the drop, and the grid would otherwise paint the old
+    // order first and visibly jump. Holding the dropped order locally paints it immediately, and
+    // also lets dnd-kit's drop animation land on the slot the card was actually dropped into.
+    const [dropOrder, setDropOrder] = useState<string[]>();
+
+    const propertyIdsKey = items.map(item => item.goalId).join('|');
+    // Release the optimistic order once the store catches up, or the section changes underneath us.
+    useEffect(() => {
+        setDropOrder(undefined);
+    }, [propertyIdsKey]);
+
+    const orderedItems = useMemo(() => {
+        if (!dropOrder) return items;
+        const byId = new Map(items.map(item => [item.goalId, item]));
+        const reordered = filterMap(dropOrder, id => byId.get(id));
+        // Fall back to the props order if the section membership changed while we held a drop order.
+        return reordered.length === items.length ? reordered : items;
+    }, [items, dropOrder]);
+
+    const ids = orderedItems.map(item => item.goalId);
+    const activeItem = orderedItems.find(item => item.goalId === activeId);
 
     const handleStart = (event: DragStartEvent) => {
         setActiveId(event.active.id);
-        setActiveWidth(event.active.rect.current.initial?.width);
+        const rect = event.active.rect.current.initial;
+        setActiveSize(rect ? { width: rect.width, height: rect.height } : undefined);
     };
     const handleEnd = (event: DragEndEvent) => {
         const { active, over } = event;
@@ -82,7 +110,9 @@ export const SortableGoalGrid = <T extends { goalId: string }>({
             const oldIndex = ids.indexOf(active.id as string);
             const newIndex = ids.indexOf(over.id as string);
             if (oldIndex !== -1 && newIndex !== -1) {
-                onReorder(arrayMove(ids, oldIndex, newIndex), active.id as string);
+                const next = arrayMove(ids, oldIndex, newIndex);
+                setDropOrder(next);
+                onReorder(next, active.id as string);
             }
         }
         setActiveId(undefined);
@@ -97,13 +127,13 @@ export const SortableGoalGrid = <T extends { goalId: string }>({
             onDragCancel={() => setActiveId(undefined)}>
             <SortableContext items={ids} strategy={rectSortingStrategy}>
                 <div className={className}>
-                    {items.map(item => (
+                    {orderedItems.map(item => (
                         <SortableGoalCard key={item.goalId} item={item} renderCard={renderCard} />
                     ))}
                 </div>
             </SortableContext>
             <DragOverlay>
-                {activeItem ? <div style={{ width: activeWidth }}>{renderCard(activeItem, {})}</div> : undefined}
+                {activeItem ? <div style={activeSize}>{renderCard(activeItem, {})}</div> : undefined}
             </DragOverlay>
         </DndContext>
     );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added global goal reordering with up/down controls and drag-and-drop support across sections.
  - Goal priorities now consistently reflect their displayed order.
  - Reordering safely handles boundary positions and invalid requests.
  - Edit and delete actions remain available when movement is disabled.

- **Bug Fixes**
  - Improved drag-and-drop rendering to prevent brief order flickers.
  - Enhanced drag preview sizing.

- **Tests**
  - Added coverage for goal movement, persistence, priority normalization, and action controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->