### PR TITLE
Suggest elites before uncommons since you save on raid tickets.

### DIFF
--- a/src/fsd/3-features/goals/upgrades.service.ts
+++ b/src/fsd/3-features/goals/upgrades.service.ts
@@ -2936,11 +2936,18 @@ export class UpgradesService {
                 for (const location of ignoredLocations) location.isSuggested = false;
             }
 
+            for (const location of combinedUpgrade.locations) {
+                location.isElite = location.campaignType === CampaignType.Elite;
+            }
             combinedUpgrade.locations = orderBy(
                 combinedUpgrade.locations,
-                ['isSelected', 'energyPerItem', 'nodeNumber'],
-                ['desc', 'asc', 'desc']
+                ['isSuggested', 'energyPerItem', 'isElite', 'nodeNumber'],
+                ['desc', 'asc', 'desc', 'desc']
             );
+
+            for (const loc of combinedUpgrade.locations) {
+                delete loc.isElite;
+            }
         }
     }
 

--- a/src/fsd/4-entities/campaign/model.ts
+++ b/src/fsd/4-entities/campaign/model.ts
@@ -32,6 +32,7 @@ export interface ICampaignBattleComposed {
     isPassFilter?: boolean;
     isCompleted?: boolean;
     isStarted?: boolean;
+    isElite?: boolean;
 }
 
 export interface IRewards {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Upgrade locations are now ordered more helpfully, prioritizing suggested locations, energy efficiency, Elite campaign status, and node number.
  * Elite campaign information is now supported when displaying campaign battles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->