### PR TITLE
Fix XP book handling to goal cards and related components

### DIFF
--- a/src/fsd/1-pages/goals/goal-card/character-abilities.spec.tsx
+++ b/src/fsd/1-pages/goals/goal-card/character-abilities.spec.tsx
@@ -96,8 +96,22 @@ describe('GoalCardCharacterAbilities XP books row', () => {
         );
     });
 
-    it('renders no XP-book row when the character is already at the target level', () => {
+    // A character already at the target ability level produces exactly this estimate: getLegendaryTomesCount
+    // returns undefined, so _adjustGoalXp bails before assigning any book counts.
+    it('renders no XP-book row when the estimate carries no XP-book data', () => {
         render(<GoalCardCharacterAbilities goal={goal} bookRarity={Rarity.Legendary} goalEstimate={estimate()} />);
+
+        expect(screen.queryByRole('progressbar', { name: /XP Books/ })).toBeNull();
+    });
+
+    it('renders no XP-book row when the goal needs zero books', () => {
+        render(
+            <GoalCardCharacterAbilities
+                goal={goal}
+                bookRarity={Rarity.Legendary}
+                goalEstimate={estimate({ xpBooksApplied: 0, xpBooksRequired: 0 })}
+            />
+        );
 
         expect(screen.queryByRole('progressbar', { name: /XP Books/ })).toBeNull();
     });

--- a/src/fsd/1-pages/goals/goal-card/character-abilities.spec.tsx
+++ b/src/fsd/1-pages/goals/goal-card/character-abilities.spec.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { Alliance, Rarity } from '@/fsd/5-shared/model';
+
+import { PersonalGoalType } from '@/fsd/4-entities/goal';
+
+import { ICharacterUpgradeAbilities, IGoalEstimate } from '@/fsd/3-features/goals';
+
+import { GoalCardCharacterAbilities } from './character-abilities';
+
+const goal = {
+    type: PersonalGoalType.CharacterAbilities,
+    goalId: 'goal-1',
+    priority: 1,
+    include: true,
+    notes: '',
+    unitId: 'unit-1',
+    unitName: 'Unit',
+    unitIcon: '',
+    unitRoundIcon: '',
+    unitAlliance: Alliance.Imperial,
+    // Kept distinct from the level range below so the assertions can't match the ability blocks.
+    activeStart: 3,
+    activeEnd: 7,
+    passiveStart: 3,
+    passiveEnd: 3,
+} as ICharacterUpgradeAbilities;
+
+const estimate = (overrides: Partial<IGoalEstimate> = {}): IGoalEstimate => ({
+    goalId: goal.goalId,
+    daysLeft: 0,
+    daysTotal: 0,
+    energyTotal: 0,
+    oTokensTotal: 0,
+    xpBooksTotal: 0,
+    ...overrides,
+});
+
+describe('GoalCardCharacterAbilities XP books row', () => {
+    it('renders the XP-book row when the goal needs books', () => {
+        render(
+            <GoalCardCharacterAbilities
+                goal={goal}
+                bookRarity={Rarity.Legendary}
+                goalEstimate={estimate({
+                    xpBooksApplied: 3,
+                    xpBooksRequired: 8,
+                    // Ability goals carry xpEstimateAbilities, never xpEstimate.
+                    xpEstimateAbilities: {
+                        books: 5,
+                        bookRarity: Rarity.Legendary,
+                        gold: 2500,
+                        currentLevel: 12,
+                        targetLevel: 20,
+                        xpLeft: 62_500,
+                    },
+                })}
+            />
+        );
+
+        expect(screen.getByRole('progressbar', { name: 'Legendary XP Books' })).toBeTruthy();
+        expect(screen.getByText('3 / 8')).toBeTruthy();
+        // Level range comes from xpEstimateAbilities, not xpEstimate.
+        expect(screen.getByText('12')).toBeTruthy();
+        expect(screen.getByText('20')).toBeTruthy();
+    });
+
+    it('fills the meter by XP rather than by codex count', () => {
+        render(
+            <GoalCardCharacterAbilities
+                goal={goal}
+                bookRarity={Rarity.Legendary}
+                goalEstimate={estimate({
+                    // 24 000 of 25 000 XP covered, but only "1 of 2" codices — which would read 50%.
+                    xpRequiredTotal: 25_000,
+                    xpBooksApplied: 1,
+                    xpBooksRequired: 2,
+                    xpEstimateAbilities: {
+                        books: 1,
+                        bookRarity: Rarity.Legendary,
+                        gold: 500,
+                        currentLevel: 12,
+                        targetLevel: 20,
+                        xpLeft: 1000,
+                    },
+                })}
+            />
+        );
+
+        const bar = screen.getByRole('progressbar', { name: 'Legendary XP Books' });
+        expect(bar.getAttribute('aria-valuenow')).toBe('96');
+        // Built via toLocaleString so the assertion doesn't depend on the runner's locale separator.
+        expect(bar.getAttribute('aria-valuetext')).toBe(
+            `${(24_000).toLocaleString()} of ${(25_000).toLocaleString()} XP`
+        );
+    });
+
+    it('renders no XP-book row when the character is already at the target level', () => {
+        render(<GoalCardCharacterAbilities goal={goal} bookRarity={Rarity.Legendary} goalEstimate={estimate()} />);
+
+        expect(screen.queryByRole('progressbar', { name: /XP Books/ })).toBeNull();
+    });
+});

--- a/src/fsd/1-pages/goals/goal-card/character-abilities.tsx
+++ b/src/fsd/1-pages/goals/goal-card/character-abilities.tsx
@@ -1,19 +1,23 @@
 import React from 'react';
 
-import { getDoneByDays, ICharacterUpgradeAbilities, IGoalEstimate } from '@/fsd/3-features/goals';
+import { Rarity } from '@/fsd/5-shared/model';
+
+import { getDoneByDays, hasXpBooks, ICharacterUpgradeAbilities, IGoalEstimate } from '@/fsd/3-features/goals';
 
 import { GoalEstimateChips } from './estimate-chips';
 import { ResourceCostRow } from './resource-cost-row';
 import { buildAbilityCostItems } from './resource-items';
 import { StatBlockPair } from './stat-block-pair';
+import { XpBooksRow } from './xp-books-row';
 
 interface Props {
     goal: ICharacterUpgradeAbilities;
     goalEstimate: IGoalEstimate;
+    bookRarity: Rarity;
 }
 
-/** Body of a Character Abilities goal card: badge/gold costs + estimate on top, active/passive blocks below. */
-export const GoalCardCharacterAbilities: React.FC<Props> = ({ goal, goalEstimate }) => {
+/** Body of a Character Abilities goal card: costs + estimate, active/passive blocks, XP-book row. */
+export const GoalCardCharacterAbilities: React.FC<Props> = ({ goal, goalEstimate, bookRarity }) => {
     const blocks = [];
     if (goal.activeEnd > goal.activeStart)
         blocks.push({ label: 'Active', start: goal.activeStart, end: goal.activeEnd });
@@ -25,6 +29,7 @@ export const GoalCardCharacterAbilities: React.FC<Props> = ({ goal, goalEstimate
     const days = doneBy > 0 ? Math.ceil(doneBy) : undefined;
     const hasEstimate = days !== undefined || goalEstimate.energyTotal > 0;
     const hasTop = costItems.length > 0 || hasEstimate;
+    const showBooks = hasXpBooks(goalEstimate);
 
     return (
         <div className="flex flex-col gap-2.5">
@@ -37,6 +42,11 @@ export const GoalCardCharacterAbilities: React.FC<Props> = ({ goal, goalEstimate
             {blocks.length > 0 && (
                 <div className={hasTop ? 'border-t border-(--card-border) pt-2.5' : ''}>
                     <StatBlockPair blocks={blocks} />
+                </div>
+            )}
+            {showBooks && (
+                <div className={hasTop || blocks.length > 0 ? 'border-t border-(--card-border) pt-2.5' : ''}>
+                    <XpBooksRow goalEstimate={goalEstimate} bookRarity={bookRarity} />
                 </div>
             )}
         </div>

--- a/src/fsd/1-pages/goals/goal-card/goal-card.tsx
+++ b/src/fsd/1-pages/goals/goal-card/goal-card.tsx
@@ -116,7 +116,9 @@ export const GoalCard: React.FC<Props> = ({
                 return {
                     portrait: <UnitShardIcon icon={goal.unitRoundIcon} height={40} />,
                     title: goal.unitName ?? goal.unitId,
-                    body: <GoalCardCharacterAbilities goal={goal} goalEstimate={goalEstimate} />,
+                    body: (
+                        <GoalCardCharacterAbilities goal={goal} goalEstimate={goalEstimate} bookRarity={bookRarity} />
+                    ),
                     showRaids: false,
                     raidsTargetId: goal.unitId,
                 };

--- a/src/fsd/1-pages/goals/goal-card/upgrade-rank.tsx
+++ b/src/fsd/1-pages/goals/goal-card/upgrade-rank.tsx
@@ -6,7 +6,7 @@ import { RarityIcon } from '@/fsd/5-shared/ui/icons';
 
 import { ICharacterUpgradeRankGoal } from '@/fsd/4-entities/goal';
 
-import { IGoalEstimate } from '@/fsd/3-features/goals';
+import { hasXpBooks, IGoalEstimate } from '@/fsd/3-features/goals';
 
 import { ProgressionRow } from './progression-row';
 import { RankEmblem } from './rank-emblem';
@@ -20,9 +20,7 @@ interface Props {
 
 /** Body of an UpgradeRank goal card: rank progression (raid days) over an XP-book row (XP days). */
 export const GoalCardUpgradeRank: React.FC<Props> = ({ goal, goalEstimate, bookRarity }) => {
-    const applied = goalEstimate.xpBooksApplied;
-    const required = goalEstimate.xpBooksRequired;
-    const hasBooks = applied !== undefined && required !== undefined && required > 0;
+    const hasBooks = hasXpBooks(goalEstimate);
     // Top row shows days spent on raids (materials); the XP row below shows the XP-income days.
     const raidDays = goalEstimate.daysLeft > 0 ? Math.ceil(goalEstimate.daysLeft) : undefined;
 

--- a/src/fsd/1-pages/goals/goal-card/xp-books-row.model.ts
+++ b/src/fsd/1-pages/goals/goal-card/xp-books-row.model.ts
@@ -1,0 +1,66 @@
+import { Rarity, RarityMapper } from '@/fsd/5-shared/model';
+import { tacticusIcons } from '@/fsd/5-shared/ui/icons';
+
+import { hasXpBooks, IGoalEstimate } from '@/fsd/3-features/goals';
+
+type IconKey = keyof typeof tacticusIcons;
+
+const BOOK_ICON: Record<Rarity, IconKey> = {
+    [Rarity.Common]: 'commonBook',
+    [Rarity.Uncommon]: 'uncommonBook',
+    [Rarity.Rare]: 'rareBook',
+    [Rarity.Epic]: 'epicBook',
+    [Rarity.Legendary]: 'legendaryBook',
+    [Rarity.Mythic]: 'mythicBook',
+};
+
+/** Everything XpBooksRow renders, already resolved. `undefined` means the row shows nothing. */
+export interface XpBooksRowView {
+    applied: number;
+    required: number;
+    rarityLabel?: string;
+    bookIcon?: IconKey;
+    percent: number;
+    /** Human-readable progress for `aria-valuetext`. */
+    valueText: string;
+    levels?: { current: number; target: number };
+    xpDaysLeft?: number;
+    /** XP income finishes later than the material farm, so it's what gates completion. */
+    xpIsDriver: boolean;
+}
+
+export const buildXpBooksRowView = (
+    goalEstimate: IGoalEstimate,
+    fallbackRarity: Rarity | undefined
+): XpBooksRowView | undefined => {
+    if (!hasXpBooks(goalEstimate)) return;
+    const { xpBooksApplied: applied, xpBooksRequired: required } = goalEstimate;
+
+    // Rank goals carry xpEstimate, ability goals xpEstimateAbilities — only one is ever set.
+    const xpEstimate = goalEstimate.xpEstimate ?? goalEstimate.xpEstimateAbilities;
+    // The icon must match the rarity the counts are denominated in, not the page's preferred codex.
+    const rarity = xpEstimate?.bookRarity ?? fallbackRarity;
+
+    // Progress measures XP, not codices — codex counts are too coarse a denominator. Falls back to
+    // the book ratio for estimates that never went through adjustGoalEstimates and carry no total.
+    const totalXp = goalEstimate.xpRequiredTotal;
+    const outstandingXp = xpEstimate?.xpLeft;
+    const byXp = totalXp !== undefined && totalXp > 0 && outstandingXp !== undefined;
+    const percent = byXp
+        ? Math.min(100, Math.round(((totalXp - outstandingXp) / totalXp) * 100))
+        : Math.min(100, Math.round((applied / Math.max(1, required)) * 100));
+
+    return {
+        applied,
+        required,
+        rarityLabel: rarity === undefined ? undefined : RarityMapper.rarityToRarityString(rarity),
+        bookIcon: rarity === undefined ? undefined : BOOK_ICON[rarity],
+        percent,
+        valueText: byXp
+            ? `${(totalXp - outstandingXp).toLocaleString()} of ${totalXp.toLocaleString()} XP`
+            : `${applied} of ${required} books`,
+        levels: xpEstimate && { current: xpEstimate.currentLevel, target: xpEstimate.targetLevel },
+        xpDaysLeft: goalEstimate.xpDaysLeft,
+        xpIsDriver: (goalEstimate.xpDaysLeft ?? 0) > goalEstimate.daysLeft,
+    };
+};

--- a/src/fsd/1-pages/goals/goal-card/xp-books-row.tsx
+++ b/src/fsd/1-pages/goals/goal-card/xp-books-row.tsx
@@ -5,28 +5,39 @@ import { Rarity, RarityMapper } from '@/fsd/5-shared/model';
 import { AccessibleTooltip } from '@/fsd/5-shared/ui';
 import { MiscIcon } from '@/fsd/5-shared/ui/icons';
 
-import { IGoalEstimate } from '@/fsd/3-features/goals';
+import { hasXpBooks, IGoalEstimate } from '@/fsd/3-features/goals';
 
 interface Props {
     goalEstimate: IGoalEstimate;
+    /** Fallback codex rarity, used only when the estimate hasn't been assigned one. */
     bookRarity: Rarity | undefined;
 }
 
 /**
  * Compact XP-book progress row — book icon, applied/required, fill bar, level range and an XP-days
- * chip. Shared by the UpgradeRank card body and the goals table so both read identically. Renders
- * nothing when the goal needs no XP books.
+ * chip. Shared by the UpgradeRank/CharacterAbilities card bodies and the goals table so all read
+ * identically. Renders nothing when the goal needs no XP books.
  */
 export const XpBooksRow: React.FC<Props> = ({ goalEstimate, bookRarity }) => {
-    const { xpEstimate } = goalEstimate;
-    const applied = goalEstimate.xpBooksApplied;
-    const required = goalEstimate.xpBooksRequired;
-    if (applied === undefined || required === undefined || required === 0) return;
-    const rarityLabel = bookRarity === undefined ? undefined : RarityMapper.rarityToRarityString(bookRarity);
+    if (!hasXpBooks(goalEstimate)) return;
+    const { xpBooksApplied: applied, xpBooksRequired: required } = goalEstimate;
+    // Rank goals carry xpEstimate, ability goals xpEstimateAbilities — only one is ever set.
+    const xpEstimate = goalEstimate.xpEstimate ?? goalEstimate.xpEstimateAbilities;
+    // The icon must match the rarity the counts are denominated in, not the page's preferred codex.
+    const effectiveRarity = xpEstimate?.bookRarity ?? bookRarity;
+    const rarityLabel = effectiveRarity === undefined ? undefined : RarityMapper.rarityToRarityString(effectiveRarity);
     const bookIcon = rarityLabel === undefined ? undefined : ((rarityLabel.toLowerCase() + 'Book') as never);
     // XP income is the bottleneck when it finishes later than the material farm.
     const xpIsDriver = (goalEstimate.xpDaysLeft ?? 0) > goalEstimate.daysLeft;
-    const xpPct = Math.min(100, Math.round((applied / Math.max(1, required)) * 100));
+
+    // Fill measures XP, not codices — codex counts are too coarse a denominator. Falls back to the
+    // book ratio for estimates that never went through adjustGoalEstimates and so carry no total.
+    const totalXp = goalEstimate.xpRequiredTotal;
+    const outstandingXp = xpEstimate?.xpLeft;
+    const xpPct =
+        totalXp !== undefined && totalXp > 0 && outstandingXp !== undefined
+            ? Math.min(100, Math.round(((totalXp - outstandingXp) / totalXp) * 100))
+            : Math.min(100, Math.round((applied / Math.max(1, required)) * 100));
 
     return (
         <div className="flex min-h-[28px] flex-wrap items-center gap-x-2 gap-y-1">
@@ -40,6 +51,11 @@ export const XpBooksRow: React.FC<Props> = ({ goalEstimate, bookRarity }) => {
                 aria-valuenow={xpPct}
                 aria-valuemin={0}
                 aria-valuemax={100}
+                aria-valuetext={
+                    totalXp !== undefined && outstandingXp !== undefined
+                        ? `${(totalXp - outstandingXp).toLocaleString()} of ${totalXp.toLocaleString()} XP`
+                        : `${applied} of ${required} books`
+                }
                 className="h-2 min-w-[30px] flex-1 overflow-hidden rounded-full bg-(--fg)/12">
                 <div
                     className="h-full origin-left bg-(--primary) transition-transform duration-500 motion-reduce:transition-none"

--- a/src/fsd/1-pages/goals/goal-card/xp-books-row.tsx
+++ b/src/fsd/1-pages/goals/goal-card/xp-books-row.tsx
@@ -1,11 +1,13 @@
 import { Calendar } from 'lucide-react';
 import React from 'react';
 
-import { Rarity, RarityMapper } from '@/fsd/5-shared/model';
+import { Rarity } from '@/fsd/5-shared/model';
 import { AccessibleTooltip } from '@/fsd/5-shared/ui';
 import { MiscIcon } from '@/fsd/5-shared/ui/icons';
 
-import { hasXpBooks, IGoalEstimate } from '@/fsd/3-features/goals';
+import { IGoalEstimate } from '@/fsd/3-features/goals';
+
+import { buildXpBooksRowView } from './xp-books-row.model';
 
 interface Props {
     goalEstimate: IGoalEstimate;
@@ -19,66 +21,45 @@ interface Props {
  * identically. Renders nothing when the goal needs no XP books.
  */
 export const XpBooksRow: React.FC<Props> = ({ goalEstimate, bookRarity }) => {
-    if (!hasXpBooks(goalEstimate)) return;
-    const { xpBooksApplied: applied, xpBooksRequired: required } = goalEstimate;
-    // Rank goals carry xpEstimate, ability goals xpEstimateAbilities — only one is ever set.
-    const xpEstimate = goalEstimate.xpEstimate ?? goalEstimate.xpEstimateAbilities;
-    // The icon must match the rarity the counts are denominated in, not the page's preferred codex.
-    const effectiveRarity = xpEstimate?.bookRarity ?? bookRarity;
-    const rarityLabel = effectiveRarity === undefined ? undefined : RarityMapper.rarityToRarityString(effectiveRarity);
-    const bookIcon = rarityLabel === undefined ? undefined : ((rarityLabel.toLowerCase() + 'Book') as never);
-    // XP income is the bottleneck when it finishes later than the material farm.
-    const xpIsDriver = (goalEstimate.xpDaysLeft ?? 0) > goalEstimate.daysLeft;
-
-    // Fill measures XP, not codices — codex counts are too coarse a denominator. Falls back to the
-    // book ratio for estimates that never went through adjustGoalEstimates and so carry no total.
-    const totalXp = goalEstimate.xpRequiredTotal;
-    const outstandingXp = xpEstimate?.xpLeft;
-    const xpPct =
-        totalXp !== undefined && totalXp > 0 && outstandingXp !== undefined
-            ? Math.min(100, Math.round(((totalXp - outstandingXp) / totalXp) * 100))
-            : Math.min(100, Math.round((applied / Math.max(1, required)) * 100));
+    const view = buildXpBooksRowView(goalEstimate, bookRarity);
+    if (!view) return;
 
     return (
         <div className="flex min-h-[28px] flex-wrap items-center gap-x-2 gap-y-1">
-            {bookIcon && <MiscIcon icon={bookIcon} width={18} height={18} />}
+            {view.bookIcon && <MiscIcon icon={view.bookIcon} width={18} height={18} />}
             <span className="shrink-0 text-xs font-bold text-(--fg) tabular-nums">
-                {applied} / {required}
+                {view.applied} / {view.required}
             </span>
             <div
                 role="progressbar"
-                aria-label={rarityLabel === undefined ? 'XP Books' : `${rarityLabel} XP Books`}
-                aria-valuenow={xpPct}
+                aria-label={view.rarityLabel === undefined ? 'XP Books' : `${view.rarityLabel} XP Books`}
+                aria-valuenow={view.percent}
                 aria-valuemin={0}
                 aria-valuemax={100}
-                aria-valuetext={
-                    totalXp !== undefined && outstandingXp !== undefined
-                        ? `${(totalXp - outstandingXp).toLocaleString()} of ${totalXp.toLocaleString()} XP`
-                        : `${applied} of ${required} books`
-                }
+                aria-valuetext={view.valueText}
                 className="h-2 min-w-[30px] flex-1 overflow-hidden rounded-full bg-(--fg)/12">
                 <div
                     className="h-full origin-left bg-(--primary) transition-transform duration-500 motion-reduce:transition-none"
-                    style={{ transform: `scaleX(${xpPct / 100})` }}
+                    style={{ transform: `scaleX(${view.percent / 100})` }}
                 />
             </div>
-            {xpEstimate && (
+            {view.levels && (
                 <>
                     <span aria-hidden className="h-3 w-px shrink-0 bg-(--card-border)" />
                     <span className="shrink-0 text-xs whitespace-nowrap text-(--soft-fg) tabular-nums">
-                        Lv <span className="font-bold text-(--fg)">{xpEstimate.currentLevel}</span>→
-                        <span className="font-bold text-(--fg)">{xpEstimate.targetLevel}</span>
+                        Lv <span className="font-bold text-(--fg)">{view.levels.current}</span>→
+                        <span className="font-bold text-(--fg)">{view.levels.target}</span>
                     </span>
                 </>
             )}
-            {goalEstimate.xpDaysLeft !== undefined && (
+            {view.xpDaysLeft !== undefined && (
                 <>
                     <span aria-hidden className="h-3 w-px shrink-0 bg-(--card-border)" />
                     <AccessibleTooltip
-                        title={`${Math.ceil(goalEstimate.xpDaysLeft)} days — estimated from your XP Income settings${xpIsDriver ? ' (this is what gates completion)' : ''}`}>
+                        title={`${Math.ceil(view.xpDaysLeft)} days — estimated from your XP Income settings${view.xpIsDriver ? ' (this is what gates completion)' : ''}`}>
                         <span className="inline-flex shrink-0 items-center gap-0.5 text-xs text-(--soft-fg) tabular-nums">
                             <Calendar className="size-3.5" aria-hidden />
-                            <span className="font-bold text-(--fg)">{Math.ceil(goalEstimate.xpDaysLeft)}</span>d
+                            <span className="font-bold text-(--fg)">{Math.ceil(view.xpDaysLeft)}</span>d
                         </span>
                     </AccessibleTooltip>
                 </>

--- a/src/fsd/3-features/goals/estimate-days.ts
+++ b/src/fsd/3-features/goals/estimate-days.ts
@@ -6,3 +6,14 @@ import { IGoalEstimate } from './goals.models';
  */
 export const getDoneByDays = (estimate: Pick<IGoalEstimate, 'daysLeft' | 'xpDaysLeft'>): number =>
     Math.max(estimate.daysLeft, estimate.xpDaysLeft ?? 0, 0);
+
+type XpBookCounts = Pick<IGoalEstimate, 'xpBooksApplied' | 'xpBooksRequired'>;
+
+/**
+ * Whether the goal needs XP books. Single implementation of the condition: XpBooksRow narrows with
+ * it, the card bodies and table use it to decide whether to render the row's separator.
+ */
+export const hasXpBooks = (
+    estimate: XpBookCounts | undefined
+): estimate is XpBookCounts & { xpBooksApplied: number; xpBooksRequired: number } =>
+    estimate?.xpBooksApplied !== undefined && estimate.xpBooksRequired !== undefined && estimate.xpBooksRequired > 0;

--- a/src/fsd/3-features/goals/goals.models.ts
+++ b/src/fsd/3-features/goals/goals.models.ts
@@ -127,6 +127,8 @@ export interface IGoalEstimate {
     orbsEstimate?: ICharacterAscendOrbsTotal;
     xpBooksApplied?: number;
     xpBooksRequired?: number;
+    /** Total XP owed before held books were applied — `xpEstimate.xpLeft` keeps only the remainder. */
+    xpRequiredTotal?: number;
     materialQuantityInfo?: IMaterialQuantityInfo;
 
     /** If the goal is already done and no further raiding/onslaught is required. */

--- a/src/fsd/3-features/goals/goals.service.spec.ts
+++ b/src/fsd/3-features/goals/goals.service.spec.ts
@@ -1123,10 +1123,77 @@ describe('GoalsService.adjustGoalEstimates', () => {
                 targetLevel: 15,
                 xpLeft: 0,
             });
-            expect(adjustedGoal?.xpBooksApplied).toBe(1);
-            expect(adjustedGoal?.xpBooksRequired).toBe(1);
+            // 20 000 XP takes 2 Legendary codices (12 500 each); one falls short, so it rounds up.
+            expect(adjustedGoal?.xpBooksApplied).toBe(2);
+            expect(adjustedGoal?.xpBooksRequired).toBe(2);
             expect(adjustedGoal?.xpBooksTotal).toBe(0);
             expect(adjustedGoal?.xpDaysLeft).toBeUndefined();
+        });
+
+        it('steps down to the largest codex that fits when the preferred one overshoots', () => {
+            const goalId = 'goal-sub-one-book';
+            const estimate = makeGoalEstimate(goalId, true, {
+                xpEstimate: {
+                    books: 1,
+                    bookRarity: Rarity.Legendary,
+                    gold: 500,
+                    currentLevel: 10,
+                    targetLevel: 11,
+                    // Under one Legendary codex (12 500); Epic (2500) is the largest that fits → 4.
+                    xpLeft: 8000,
+                },
+            });
+
+            const goal = makePersonalGoal(goalId, PersonalGoalType.UpgradeRank, 1, true);
+
+            const result = GoalsService.adjustGoalEstimates(
+                [goal],
+                [estimate],
+                makeEmptyInventory(),
+                { ...noXpUse, useLegendary: true },
+                [],
+                [],
+                noXpIncome
+            );
+
+            const adjustedGoal = result.goalEstimates.find(goalEstimate => goalEstimate.goalId === goalId);
+
+            expect(adjustedGoal?.xpEstimate?.bookRarity).toBe(Rarity.Epic);
+            expect(adjustedGoal?.xpBooksRequired).toBe(4);
+            expect(adjustedGoal?.xpBooksApplied).toBe(0);
+            expect(adjustedGoal?.xpBooksTotal).toBe(4);
+            expect(result.neededXp).toBe(8000);
+        });
+
+        it('keeps the preferred codex when the goal owes at least one of them', () => {
+            const goalId = 'goal-preferred-codex';
+            const estimate = makeGoalEstimate(goalId, true, {
+                xpEstimate: {
+                    books: 2,
+                    bookRarity: Rarity.Legendary,
+                    gold: 1000,
+                    currentLevel: 10,
+                    targetLevel: 15,
+                    xpLeft: 20_000,
+                },
+            });
+
+            const goal = makePersonalGoal(goalId, PersonalGoalType.UpgradeRank, 1, true);
+
+            const result = GoalsService.adjustGoalEstimates(
+                [goal],
+                [estimate],
+                makeEmptyInventory(),
+                { ...noXpUse, useLegendary: true },
+                [],
+                [],
+                noXpIncome
+            );
+
+            const adjustedGoal = result.goalEstimates.find(goalEstimate => goalEstimate.goalId === goalId);
+
+            expect(adjustedGoal?.xpEstimate?.bookRarity).toBe(Rarity.Legendary);
+            expect(adjustedGoal?.xpBooksRequired).toBe(2);
         });
     });
 

--- a/src/fsd/3-features/goals/goals.service.ts
+++ b/src/fsd/3-features/goals/goals.service.ts
@@ -6,7 +6,15 @@ import { rankToLevel, rarityToStars } from 'src/models/constants';
 import { CampaignsLocationsUsage, PersonalGoalType } from 'src/models/enums';
 import { IInventory, IPersonalGoal } from 'src/models/interfaces';
 
-import { Alliance, Rank, Rarity, RarityStars, XP_BOOK_VALUE, XP_BOOK_ORDER } from '@/fsd/5-shared/model';
+import {
+    Alliance,
+    Rank,
+    Rarity,
+    RarityStars,
+    XP_BOOK_VALUE,
+    XP_BOOK_ORDER,
+    pickXpBookRarity,
+} from '@/fsd/5-shared/model';
 
 import { CharactersService } from '@/fsd/4-entities/character';
 import { ICharacter2 } from '@/fsd/4-entities/character/model';
@@ -954,15 +962,19 @@ export class GoalsService {
             return { xpNeeded: 0, newXpBooksAccrual: xpBooksAccrual };
         }
 
-        goal.xpBooksRequired = Math.floor(remainingXp / XP_BOOK_VALUE[xpBookRarityToUse]);
+        const displayRarity = pickXpBookRarity(remainingXp, xpBookRarityToUse);
+        const displayBookValue = XP_BOOK_VALUE[displayRarity];
+        // Codices are indivisible, so every XP→book conversion rounds UP.
+        goal.xpBooksRequired = Math.ceil(remainingXp / displayBookValue);
+        goal.xpRequiredTotal = remainingXp;
         const xpNeeded = this.adjustNeededXp(remainingXp, heldBooks);
-        goal.xpBooksApplied = goal.xpBooksRequired - Math.floor(xpNeeded / XP_BOOK_VALUE[xpBookRarityToUse]);
+        goal.xpBooksApplied = goal.xpBooksRequired - Math.ceil(xpNeeded / displayBookValue);
         goal.xpDaysLeft = undefined;
 
         let newAccrual = xpBooksAccrual;
 
-        goal.xpBooksTotal = Math.floor(xpNeeded / XP_BOOK_VALUE[xpBookRarityToUse]);
-        currentEstimate.bookRarity = xpBookRarityToUse;
+        goal.xpBooksTotal = Math.ceil(xpNeeded / displayBookValue);
+        currentEstimate.bookRarity = displayRarity;
         if (xpNeeded === 0) {
             currentEstimate.books = 0;
             currentEstimate.gold = 0;
@@ -970,10 +982,12 @@ export class GoalsService {
             return { xpNeeded: 0, newXpBooksAccrual: xpBooksAccrual };
         }
 
-        currentEstimate.books = Math.floor(xpNeeded / XP_BOOK_VALUE[xpBookRarityToUse]);
+        currentEstimate.books = Math.ceil(xpNeeded / displayBookValue);
         currentEstimate.xpLeft = xpNeeded;
 
         if (xpIncomeState.manualCodicesPerDay > 0) {
+            // Accrual stays in the PREFERRED codex — income is earned in those, not in whatever
+            // rarity the meter happens to display.
             const booksToAccrue = Math.ceil(xpNeeded / XP_BOOK_VALUE[xpBookRarityToUse]);
             newAccrual = this.processGoalAccrual(booksToAccrue, xpBooksAccrual, xpIncomeState.manualCodicesPerDay);
             goal.xpDaysLeft = Math.ceil((newAccrual.accruedDate.getTime() - today.getTime()) / 86_400_000);

--- a/src/fsd/3-features/goals/index.ts
+++ b/src/fsd/3-features/goals/index.ts
@@ -5,7 +5,7 @@ export type {
     IMowMaterialsTotal,
 } from './goals.models';
 export { isGoalReached } from './goal-status';
-export { getDoneByDays } from './estimate-days';
+export { getDoneByDays, hasXpBooks } from './estimate-days';
 export { getMaterialBar } from './material-progress';
 export { UpgradesService } from './upgrades.service';
 export { ShardsService } from './shards.service';

--- a/src/fsd/5-shared/model/enums/index.ts
+++ b/src/fsd/5-shared/model/enums/index.ts
@@ -2,7 +2,7 @@
 import type factions from '@/data/factions.json';
 
 export { Alliance, allianceFromString } from './alliance.enum';
-export { Rarity, RarityString, XP_BOOK_ORDER, XP_BOOK_VALUE } from './rarity.enum';
+export { Rarity, RarityString, XP_BOOK_ORDER, XP_BOOK_VALUE, pickXpBookRarity } from './rarity.enum';
 export { RarityStars } from './rarity-stars.enum';
 export { Rank, rankToString } from './rank.enum';
 export { Trait, getTraitStringFromLabel, getLabelFromTraitString } from './trait.enum';

--- a/src/fsd/5-shared/model/enums/rarity.enum.ts
+++ b/src/fsd/5-shared/model/enums/rarity.enum.ts
@@ -28,3 +28,12 @@ export const XP_BOOK_VALUE: Record<Rarity, number> = {
 export const XP_BOOK_ORDER: Rarity[] = Object.entries(XP_BOOK_VALUE)
     .toSorted(([, a], [, b]) => b - a)
     .map(([key]) => Number(key) as Rarity);
+
+/**
+ * The codex rarity to count `xp` in: the preferred codex, or the largest that fits when a single
+ * preferred codex would overshoot. Smallest codex if even that overshoots — any XP costs one book.
+ */
+export const pickXpBookRarity = (xp: number, preferred: Rarity): Rarity => {
+    if (XP_BOOK_VALUE[preferred] <= xp) return preferred;
+    return XP_BOOK_ORDER.find(rarity => XP_BOOK_VALUE[rarity] <= xp) ?? XP_BOOK_ORDER.at(-1)!;
+};

--- a/src/routes/goals/goals-table.tsx
+++ b/src/routes/goals/goals-table.tsx
@@ -40,7 +40,7 @@ import { MiscIcon, RarityIcon, StarsIcon, UnitShardIcon } from '@/fsd/5-shared/u
 
 import { UpgradeImage, UpgradesService } from '@/fsd/4-entities/upgrade';
 
-import { getDoneByDays, getMaterialBar, isGoalReached } from '@/fsd/3-features/goals';
+import { getDoneByDays, getMaterialBar, hasXpBooks, isGoalReached } from '@/fsd/3-features/goals';
 import { IGoalEstimate, TypedGoalSelect } from '@/fsd/3-features/goals/goals.models';
 import { ShardsService } from '@/fsd/3-features/goals/shards.service';
 
@@ -618,9 +618,7 @@ export const GoalsTable: React.FC<Props> = ({
                 if (!data) return emptyCell;
                 const est = estimateMapReference.current.get(data.goalId);
                 if (data.type === PersonalGoalType.UpgradeRank) {
-                    const applied = est?.xpBooksApplied;
-                    const required = est?.xpBooksRequired;
-                    if (!est || applied === undefined || required === undefined || required === 0) return emptyCell;
+                    if (!est || !hasXpBooks(est)) return emptyCell;
                     return (
                         <div className="flex h-full w-full flex-col justify-center py-1">
                             <XpBooksRow goalEstimate={est} bookRarity={est.xpEstimate?.bookRarity} />


### PR DESCRIPTION
<img width="1847" height="627" alt="image" src="https://github.com/user-attachments/assets/37db9a55-c7bb-4d4b-a374-566a9cd97754" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Goal cards now display XP-book requirements and progress for character abilities and rank upgrades.
  - XP-book progress supports XP totals, book counts, level ranges, and accessible progress descriptions.
  - Book rarity is automatically selected based on the remaining XP requirement.

- **Bug Fixes**
  - Improved XP-book calculations and fallback behavior when the preferred book rarity does not fit the requirement.
  - Consistent handling of XP-book rows across goal cards and tables.

- **Tests**
  - Added coverage for XP-book rendering, progress calculations, level ranges, and rarity selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->