### PR TITLE
feat: enhance loops tab texts and layout

### DIFF
--- a/src/fsd/1-pages/learn-guild-performance/guild-performance.components.tsx
+++ b/src/fsd/1-pages/learn-guild-performance/guild-performance.components.tsx
@@ -313,16 +313,21 @@ const CARD_GRID_COLS = {
 export const CardGrid = ({
     min = 430,
     gap = 'gap-3',
+    align = 'start',
     children,
     ref,
 }: {
     min?: keyof typeof CARD_GRID_COLS;
     gap?: string;
+    /** `stretch` matches every card in a row to the tallest one; `start` (default) sizes to content. */
+    align?: 'start' | 'stretch';
     children: ReactNode;
     /** Forwarded so a tile group can be handed to {@link useCaptureElement}. */
     ref?: React.Ref<HTMLDivElement>;
 }) => (
-    <div ref={ref} className={cn('grid items-start', gap, CARD_GRID_COLS[min])}>
+    <div
+        ref={ref}
+        className={cn('grid', align === 'start' ? 'items-start' : 'items-stretch', gap, CARD_GRID_COLS[min])}>
         {children}
     </div>
 );

--- a/src/fsd/1-pages/learn-guild-performance/tabs/loops-tab.components.tsx
+++ b/src/fsd/1-pages/learn-guild-performance/tabs/loops-tab.components.tsx
@@ -18,6 +18,7 @@ import {
     formatMetricValue,
     metricDefinition,
     OUTCOME_WORD,
+    primeEffectCaption,
     primeName,
     primeTitle,
     type BoardBar,
@@ -302,7 +303,10 @@ const CardLoopRow = ({
                         <span>not reached</span>
                     ) : (
                         <>
-                            {hasOutcomeData && <Dot outcome={cell.boss} title={`Boss ${OUTCOME_WORD[cell.boss]}`} />}
+                            {/* Kill is implied by having reached this boss; only "still alive" is news. */}
+                            {hasOutcomeData && cell.boss === 'alive' && (
+                                <Dot outcome={cell.boss} title={`Boss ${OUTCOME_WORD[cell.boss]}`} />
+                            )}
                             {showPrimes && (
                                 <>
                                     <PrimeValue
@@ -369,7 +373,11 @@ const BossCard = ({
     hasOutcomeData: boolean;
     onOpen: () => void;
 }) => (
-    <TableCard>
+    // `flex flex-col`: with the grid stretching every card in a row to the same height, the extra
+    // room has to go somewhere. It goes to the loop list (`flex-1`) rather than the header or
+    // footer, so those two sit at the same height on every card and only the list — already the
+    // part that varies bar to bar — absorbs the difference.
+    <TableCard className="flex flex-col">
         {/* The header is the control, not the whole card: the rows below hold selectable numbers, and
             a click target wrapping them would fight text selection on every drag. */}
         <button
@@ -391,7 +399,7 @@ const BossCard = ({
                 {formatMetricValue(boss.seasonValue, metric)}
             </span>
         </button>
-        <div className="py-1">
+        <div className="flex-1 py-1">
             {boss.bars.map(bar => (
                 <CardLoopRow
                     key={bar.loopNumber}
@@ -402,8 +410,6 @@ const BossCard = ({
                 />
             ))}
         </div>
-        {/* The season figures the rows no longer each restate. `rangeLabel` is the trend in words,
-            which a staircase shows but cannot name. */}
         <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-t border-(--hairline) px-3 py-1.5 text-[11px] text-(--soft-fg)">
             {boss.rangeLabel !== '' && <span className="tabular-nums">{boss.rangeLabel}</span>}
             {metric === 'tokens' && (
@@ -411,12 +417,12 @@ const BossCard = ({
                     L {boss.leftTotal} · R {boss.rightTotal}
                 </span>
             )}
-            {hasOutcomeData && (
-                <span className={`tabular-nums ${boss.kills === boss.reached ? '' : 'text-(--warning)'}`}>
-                    {boss.kills} of {boss.reached} killed
-                </span>
-            )}
         </div>
+        {boss.primeEffect !== undefined && (
+            <div className="border-t border-(--hairline) px-3 py-1 text-[11px] text-(--soft-fg)">
+                {primeEffectCaption(boss.primeEffect)}
+            </div>
+        )}
     </TableCard>
 );
 
@@ -455,7 +461,7 @@ export const SeasonCards = ({
                 At 300 the same screen fits all five on one row in either sidebar state, and a phone
                 still collapses to one column via the `min(…,100%)`. Cards stay equal width at every
                 size, which the All-bosses scale needs: same value, same bar length, any card. */}
-            <CardGrid ref={capture.ref} min={300}>
+            <CardGrid ref={capture.ref} min={300} align="stretch">
                 {board.bosses.map(boss => (
                     <BossCard
                         key={boss.columnIndex}
@@ -516,7 +522,10 @@ const LoopDetailRow = ({ loop, detail }: { loop: BossLoopDetail; detail: BossDet
                                 style={{ width: `${loop.percent}%` }}
                             />
                         </span>
-                        {hasOutcomeData && <Dot outcome={cell.boss} title={`Boss ${OUTCOME_WORD[cell.boss]}`} />}
+                        {/* Kill implied, never shown — see the matching card-row comment above. */}
+                        {hasOutcomeData && cell.boss === 'alive' && (
+                            <Dot outcome={cell.boss} title={`Boss ${OUTCOME_WORD[cell.boss]}`} />
+                        )}
                         {loop.paceLabel !== '' && (
                             <span className="shrink-0 text-xs text-(--soft-fg)">{loop.paceLabel}</span>
                         )}
@@ -652,6 +661,9 @@ export const BossDialog = ({
                     <p className="text-xs text-(--soft-fg)">
                         Kill and prime outcomes aren&apos;t stored for past seasons — token counts only.
                     </p>
+                )}
+                {detail.primeEffect !== undefined && (
+                    <p className="text-xs text-(--soft-fg)">{primeEffectCaption(detail.primeEffect)}</p>
                 )}
             </PortalDialog.Body>
         </PortalDialog>

--- a/src/fsd/1-pages/learn-guild-performance/tabs/loops-tab.tsx
+++ b/src/fsd/1-pages/learn-guild-performance/tabs/loops-tab.tsx
@@ -147,13 +147,12 @@ const Legend = ({
 // Summary tiles — fixed, not driven by the metric switcher. They are the season verdict.
 // ---------------------------------------------------------------------------
 
-/** A boss skipped on every single loop is a standing habit worth naming, not a one-off. */
-const skippedCaption = (summary: LoopSummary): string => {
+/** Names the boss whose primes are skipped every loop — a habit the tile's value alone doesn't say. */
+const skippedCaption = (summary: LoopSummary): string | undefined => {
     if (summary.alwaysSkippedTier !== '') {
-        return `${summary.alwaysSkippedTier} skipped every loop — deliberate, or forgotten?`;
+        return `${summary.alwaysSkippedTier} skipped every loop — full strength every time`;
     }
-    if (summary.primesSkipped > 0) return 'Skipping primes saves tokens but leaves the boss at full strength';
-    return 'Every boss met at reduced strength';
+    return undefined;
 };
 
 /** The season's verdict in four tiles. Fixed, not driven by the switcher — see the section note. */
@@ -176,7 +175,7 @@ const SummaryTiles = ({ summary, hasOutcomeData }: { summary: LoopSummary; hasOu
                 title="Season summary"
                 meta={<CaptureButton onCapture={capture.onCapture} isCapturing={capture.isCapturing} />}
             />
-            <CardGrid min={255} gap="gap-2.5">
+            <CardGrid min={255} gap="gap-2.5" align="stretch">
                 <ReadinessTile
                     label="Loops completed"
                     value={String(summary.loopsCompleted)}

--- a/src/fsd/1-pages/learn-guild-performance/tabs/loops-tab.utils.spec.ts
+++ b/src/fsd/1-pages/learn-guild-performance/tabs/loops-tab.utils.spec.ts
@@ -19,12 +19,15 @@ import {
     buildLoopSummary,
     buildMetricView,
     efficiencyOf,
+    primeEffectFor,
     primeOutcome,
     resolveLadderPrimes,
     type BarScale,
     type BossLoopRow,
+    type LadderCell,
     type LoopMetric,
     type LoopTokenCounts,
+    type Outcome,
 } from './loops-tab.utils';
 
 // Bosses must use *distinct* GuildBoss families: `buildBossLoopRows` groups by `prefix:rarity`, so two
@@ -203,6 +206,34 @@ describe('outcome derivation', () => {
         expect(cell.left).toBe('skip');
         expect(cell.right).toBe('skip');
         expect(buildLoopSummary(ladder, tierOf, bossNameOf).primesSkipped).toBe(1);
+    });
+});
+
+const finalCell = (bossTokens: number, left: Outcome): LadderCell => ({
+    loop: { boss: bossTokens } as LoopTokenCounts,
+    boss: 'kill',
+    left,
+    right: 'skip',
+});
+
+describe('primeEffectFor', () => {
+    it('ignores the still-running loop, whose boss cost is not final yet', () => {
+        const finalized: LadderCell[] = [
+            finalCell(10, 'kill'),
+            finalCell(10, 'kill'),
+            finalCell(10, 'skip'),
+            finalCell(10, 'skip'),
+        ];
+        // Cheap only because the fight isn't over — folded into the killed group unfiltered, its 1
+        // token would drop that mean to 7, clearing the 15% threshold against the finalized 10 and
+        // reporting a false "lower".
+        const withRunningLoop: LadderCell[] = [
+            ...finalized,
+            { loop: { boss: 1 } as LoopTokenCounts, boss: 'alive', left: 'kill', right: 'skip' },
+        ];
+
+        expect(primeEffectFor(finalized)?.effect).toBe('none');
+        expect(primeEffectFor(withRunningLoop)).toEqual(primeEffectFor(finalized));
     });
 });
 

--- a/src/fsd/1-pages/learn-guild-performance/tabs/loops-tab.utils.spec.ts
+++ b/src/fsd/1-pages/learn-guild-performance/tabs/loops-tab.utils.spec.ts
@@ -255,10 +255,18 @@ const metricEntries = () => [
     boss({ unitId: L2_BOSS, set: 1, remainingHp: 0, maxHp: 10_000_000, userId: 'a' }),
 ];
 
-/** A big cheap boss and a small expensive one, plus an unfinished loop. */
+/**
+ * A big cheap boss and a small expensive one, cleared identically on two full loops, plus a third,
+ * unfinished loop. Two completed loops (not one) so `leastEfficient` has an actual pair of samples
+ * per boss to compare rather than crowning a verdict off a single data point.
+ */
 const summaryEntries = () => [
     boss({ set: 0, remainingHp: 0, maxHp: 30_000_000, completedOn: START + DAY }),
-    boss({ unitId: L2_BOSS, set: 1, remainingHp: 0, maxHp: 10_000_000, completedOn: START + 3 * DAY }),
+    boss({ unitId: L2_BOSS, set: 1, remainingHp: 0, maxHp: 10_000_000, completedOn: START + 2 * DAY }),
+    // set drops back to 0 → loop 2, cleared the same way
+    boss({ set: 0, remainingHp: 0, maxHp: 30_000_000, completedOn: START + 3 * DAY }),
+    boss({ unitId: L2_BOSS, set: 1, remainingHp: 0, maxHp: 10_000_000, completedOn: START + 4 * DAY }),
+    // loop 3 — still running, only the cheap boss reached so far
     boss({ set: 0, remainingHp: 700, completedOn: START + 8 * DAY }),
 ];
 
@@ -329,11 +337,29 @@ describe('metric view', () => {
         expect(efficiencyOf({ total: 5 } as LoopTokenCounts, 0)).toBeUndefined();
     });
 
-    it('calls a single-valued column flat and says so in words', () => {
-        const view = buildMetricView(metricLadder(), 'tokens');
+    it('calls a column flat once two loops repeat the same cost, and says so in words', () => {
+        // A single loop is excluded on purpose: one data point calling itself "flat" overclaims a
+        // trend from a sample of one. Two loops costing the same is the smallest real repeat.
+        const flatEntries = [
+            boss({ set: 0, remainingHp: 0, maxHp: 20_000_000, completedOn: START + DAY }),
+            leftPrime({ set: 0, remainingHp: 0, completedOn: START + DAY }),
+            boss({ unitId: L2_BOSS, set: 1, remainingHp: 0, maxHp: 10_000_000, completedOn: START + 2 * DAY }),
+            // set drops back to 0 → a new loop, L1 costing the same again
+            boss({ set: 0, remainingHp: 0, maxHp: 20_000_000, completedOn: START + 3 * DAY }),
+            leftPrime({ set: 0, remainingHp: 0, completedOn: START + 3 * DAY }),
+        ];
+        const view = buildMetricView(buildLoopLadder(buildBossLoopRows(flatEntries), tierOf, NOW), 'tokens');
 
         expect(view.columns[0].isFlat).toBe(true);
         expect(view.columns[0].rangeLabel).toBe('flat at 2');
+    });
+
+    it('gives a single-loop column no range label at all', () => {
+        // Same shape as the flat case above but with only the first loop — nothing to range over yet.
+        const view = buildMetricView(metricLadder(), 'tokens');
+
+        expect(view.columns[0].isFlat).toBe(true);
+        expect(view.columns[0].rangeLabel).toBe('');
     });
 
     it('sums tokens but peaks players', () => {

--- a/src/fsd/1-pages/learn-guild-performance/tabs/loops-tab.utils.ts
+++ b/src/fsd/1-pages/learn-guild-performance/tabs/loops-tab.utils.ts
@@ -607,6 +607,8 @@ export function primeEffectFor(cells: LadderCell[]): PrimeEffect | undefined {
     const killedBoss: number[] = [];
     const unkilledBoss: number[] = [];
     for (const cell of cells) {
+        // Still running: its boss cost keeps climbing, so it isn't a final figure to compare with.
+        if (cell.boss !== 'kill') continue;
         (cell.left === 'kill' || cell.right === 'kill' ? killedBoss : unkilledBoss).push(cell.loop.boss);
     }
     if (killedBoss.length < PRIME_EFFECT_MIN_SAMPLE || unkilledBoss.length < PRIME_EFFECT_MIN_SAMPLE) {

--- a/src/fsd/1-pages/learn-guild-performance/tabs/loops-tab.utils.ts
+++ b/src/fsd/1-pages/learn-guild-performance/tabs/loops-tab.utils.ts
@@ -586,6 +586,57 @@ function paceLabelFor({
 }
 
 // ---------------------------------------------------------------------------
+// Prime effect — does killing a prime actually lower what the boss itself costs, for this guild
+// ---------------------------------------------------------------------------
+
+/** Below this fraction cheaper, a killed-loop boss cost reads as noise, not an effect. */
+const PRIME_EFFECT_THRESHOLD = 0.15;
+/** Minimum loops needed in each group — else one fluke loop decides the verdict. */
+const PRIME_EFFECT_MIN_SAMPLE = 2;
+
+const mean = (values: number[]): number => values.reduce((sum, value) => sum + value, 0) / values.length;
+
+export interface PrimeEffect {
+    effect: 'lower' | 'none';
+    killedMean: number;
+    unkilledMean: number;
+}
+
+/** Compares a boss's own token cost between loops where a prime died and loops where neither did. */
+export function primeEffectFor(cells: LadderCell[]): PrimeEffect | undefined {
+    const killedBoss: number[] = [];
+    const unkilledBoss: number[] = [];
+    for (const cell of cells) {
+        (cell.left === 'kill' || cell.right === 'kill' ? killedBoss : unkilledBoss).push(cell.loop.boss);
+    }
+    if (killedBoss.length < PRIME_EFFECT_MIN_SAMPLE || unkilledBoss.length < PRIME_EFFECT_MIN_SAMPLE) {
+        return undefined;
+    }
+
+    const killedMean = mean(killedBoss);
+    const unkilledMean = mean(unkilledBoss);
+    const effect = unkilledMean > 0 && killedMean <= unkilledMean * (1 - PRIME_EFFECT_THRESHOLD) ? 'lower' : 'none';
+    return { effect, killedMean, unkilledMean };
+}
+
+/** {@link primeEffectFor} for every ladder column. Every entry is undefined for a season with no outcome data. */
+export function buildPrimeEffects(ladder: LoopLadder): (PrimeEffect | undefined)[] {
+    if (!ladder.hasOutcomeData) return Array.from<PrimeEffect | undefined>({ length: ladder.ladder.length });
+    return ladder.ladder.map((_, index) => {
+        const cells = ladder.rows.map(row => row.cells[index]).filter((cell): cell is LadderCell => cell !== undefined);
+        return primeEffectFor(cells);
+    });
+}
+
+/** The card/dialog caption for one boss's {@link PrimeEffect}. */
+export function primeEffectCaption(result: PrimeEffect | undefined): string | undefined {
+    if (result === undefined) return undefined;
+    return result.effect === 'lower'
+        ? `Prime kills cut boss cost: ${result.killedMean.toFixed(1)} vs ${result.unkilledMean.toFixed(1)} tokens/loop`
+        : 'Prime kills showed no clear effect on boss cost';
+}
+
+// ---------------------------------------------------------------------------
 // Metric switcher
 // ---------------------------------------------------------------------------
 
@@ -730,31 +781,41 @@ export function buildMetricView(ladder: LoopLadder, metric: LoopMetric): MetricV
 
     const columns: ColumnSeries[] = ladder.ladder.map((column, index) => {
         const values: number[] = [];
+        // Range and L/R totals are season-verdict numbers, so both skip the still-running boss's
+        // partial spend — only "final" loops count (killed, or all of them for a past season).
+        const finalValues: number[] = [];
         let kills = 0;
-        let leftTotal = 0;
-        let rightTotal = 0;
+        let finalLeftTotal = 0;
+        let finalRightTotal = 0;
         for (const row of ladder.rows) {
             const cell = row.cells[index];
             if (cell === undefined) continue;
             const value = cellAggregateValue(metric, cell, column);
             if (value !== undefined) values.push(value);
             if (cell.boss === 'kill') kills++;
-            leftTotal += cell.loop.left;
-            rightTotal += cell.loop.right;
+            const isFinal = !ladder.hasOutcomeData || cell.boss === 'kill';
+            if (isFinal) {
+                if (value !== undefined) finalValues.push(value);
+                finalLeftTotal += cell.loop.left;
+                finalRightTotal += cell.loop.right;
+            }
         }
+        // `min`/`max` stay unfiltered: they scale the bars, and the running loop's bar must still fit.
         const min = values.length > 0 ? Math.min(...values) : undefined;
         const max = values.length > 0 ? Math.max(...values) : undefined;
-        const isFlat = min !== undefined && max !== undefined && min === max;
+        const finalMin = finalValues.length > 0 ? Math.min(...finalValues) : undefined;
+        const finalMax = finalValues.length > 0 ? Math.max(...finalValues) : undefined;
+        const isFlat = finalMin !== undefined && finalMax !== undefined && finalMin === finalMax;
         return {
             values,
             seasonValue: rollUp(values, definition.aggregate),
             min,
             max,
             isFlat,
-            rangeLabel: rangeLabelFor(min, max, isFlat, metric),
+            rangeLabel: rangeLabelFor(finalMin, finalMax, isFlat, metric, finalValues.length),
             kills,
-            leftTotal,
-            rightTotal,
+            leftTotal: finalLeftTotal,
+            rightTotal: finalRightTotal,
         };
     });
 
@@ -777,8 +838,15 @@ export function buildMetricView(ladder: LoopLadder, metric: LoopMetric): MetricV
     };
 }
 
-function rangeLabelFor(min: number | undefined, max: number | undefined, isFlat: boolean, metric: LoopMetric): string {
-    if (min === undefined || max === undefined) return '';
+/** `count < 2` guards "flat at X" — one data point isn't a trend. */
+function rangeLabelFor(
+    min: number | undefined,
+    max: number | undefined,
+    isFlat: boolean,
+    metric: LoopMetric,
+    count: number
+): string {
+    if (min === undefined || max === undefined || count < 2) return '';
     if (isFlat) return `flat at ${formatMetric(min, metric)}`;
     return `${formatMetric(min, metric)}–${formatMetric(max, metric)} per loop`;
 }
@@ -859,6 +927,8 @@ export interface BoardBoss {
     rangeLabel: string;
     leftTotal: number;
     rightTotal: number;
+    /** Undefined when there's nothing to compare — see {@link primeEffectFor}. */
+    primeEffect: PrimeEffect | undefined;
 }
 
 export interface BoardLoop {
@@ -909,6 +979,8 @@ export type BarScale = 'boss' | 'board';
 export function buildLoopBoard(ladder: LoopLadder, view: MetricView, scale: BarScale): LoopBoard {
     // The busiest single loop anywhere on the board, for the shared scale.
     const boardMax = Math.max(0, ...view.columns.map(series => series.max ?? 0));
+    // Metric-independent, so computed once rather than per metric.
+    const primeEffects = buildPrimeEffects(ladder);
 
     return {
         loops: ladder.rows.map((row, index) => ({
@@ -946,6 +1018,7 @@ export function buildLoopBoard(ladder: LoopLadder, view: MetricView, scale: BarS
                 rangeLabel: series.rangeLabel,
                 leftTotal: series.leftTotal,
                 rightTotal: series.rightTotal,
+                primeEffect: primeEffects[index],
             };
         }),
     };
@@ -989,6 +1062,8 @@ export interface BossDetail {
     /** Range of encounter totals across the loops that reached this boss. */
     rangeLabel: string;
     hasOutcomeData: boolean;
+    /** Undefined when there's nothing to compare — see {@link primeEffectFor}. */
+    primeEffect: PrimeEffect | undefined;
 }
 
 export function buildBossDetail(ladder: LoopLadder, columnIndex: number): BossDetail {
@@ -1050,8 +1125,9 @@ export function buildBossDetail(ladder: LoopLadder, columnIndex: number): BossDe
         kills,
         reached: reachedCells.length,
         efficiencyMean: rollUp(efficiencies, 'mean'),
-        rangeLabel: rangeLabelFor(min, max, min === max, 'tokens'),
+        rangeLabel: rangeLabelFor(min, max, min === max, 'tokens', encounterTotals.length),
         hasOutcomeData: ladder.hasOutcomeData,
+        primeEffect: ladder.hasOutcomeData ? primeEffectFor(reachedCells) : undefined,
     };
 }
 
@@ -1140,8 +1216,7 @@ export function buildLoopSummary(
 
     const runningRow = ladder.rows.find(row => row.isRunning);
 
-    // Efficiency over completed loops only: a partial loop has spent tokens without a kill to show
-    // for them, which would make its boss look worse than it is.
+    // Completed loops only, and at least two — one loop is no data point to average.
     let leastEfficient: LoopSummary['leastEfficient'] = undefined;
     for (const [index, column] of ladder.ladder.entries()) {
         const values: number[] = [];
@@ -1151,6 +1226,7 @@ export function buildLoopSummary(
             const value = efficiencyOf(cell.loop, column.bossMaxHp);
             if (value !== undefined) values.push(value);
         }
+        if (values.length < 2) continue;
         const mean = rollUp(values, 'mean');
         if (mean === undefined) continue;
         if (leastEfficient === undefined || mean > leastEfficient.value) {
@@ -1165,12 +1241,13 @@ export function buildLoopSummary(
         }
     }
 
+    // At least two loops reaching the boss — "skipped every loop" needs more than one loop.
     let alwaysSkippedTier = '';
     for (const [index, column] of ladder.ladder.entries()) {
         const reached = ladder.rows
             .map(row => row.cells[index])
             .filter((cell): cell is LadderCell => cell !== undefined);
-        if (reached.length === 0) continue;
+        if (reached.length < 2) continue;
         if (reached.every(cell => cell.left === 'skip' || cell.right === 'skip')) {
             alwaysSkippedTier = tierOf(column);
             break;


### PR DESCRIPTION
Just minor fixes and tweaks per discussion in hydepark

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added prime-effect insights showing whether defeating bosses is associated with lower token costs.
  * Added prime-effect captions to boss cards and loop details.
  * Improved card layout consistency with stretch alignment options.

* **Bug Fixes**
  * Boss outcome indicators now appear only for living bosses.
  * Running-loop partial data is excluded from final performance ranges and summaries.
  * Summary labels now require sufficient completed-loop data for accurate results.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->