### PR TITLE
feat: add hideRandomShopDeals preference and tooltip

### DIFF
--- a/src/fsd/3-features/view-settings/model.ts
+++ b/src/fsd/3-features/view-settings/model.ts
@@ -45,6 +45,7 @@ export interface IViewPreferences
     showWarShop?: boolean;
     showRogueTrader?: boolean;
     showCrusadeShop?: boolean;
+    hideRandomShopDeals?: boolean;
     leaderboardBossTopN: number;
     leaderboardPrimeTopN: number;
 }

--- a/src/fsd/5-shared/ui/icons/misc.icon.tsx
+++ b/src/fsd/5-shared/ui/icons/misc.icon.tsx
@@ -14,7 +14,7 @@ interface MiscIconProps extends Omit<ImgHTMLAttributes<HTMLImageElement>, 'src' 
  * passing clicks through to their parent unchanged.
  */
 export const MiscIcon = forwardRef<HTMLImageElement, MiscIconProps>(function MiscIcon(
-    { icon, width = 30, height = 30, className = '', style = {}, onClick, ...rest },
+    { icon, width = 30, height = 30, className = '', style = {}, onClick, onKeyDown, ...rest },
     reference
 ) {
     const details = tacticusIcons[icon] ?? { file: '', label: icon };
@@ -33,6 +33,13 @@ export const MiscIcon = forwardRef<HTMLImageElement, MiscIconProps>(function Mis
             height={height > 0 ? height : undefined}
             alt={details.label}
             onClick={onClick}
+            onKeyDown={event => {
+                onKeyDown?.(event);
+                if (!event.defaultPrevented && (event.key === 'Enter' || event.key === ' ')) {
+                    event.preventDefault();
+                    event.currentTarget.click();
+                }
+            }}
             {...(onClick ? { role: 'button', tabIndex: 0 } : {})}
             {...rest}
         />

--- a/src/fsd/5-shared/ui/icons/misc.icon.tsx
+++ b/src/fsd/5-shared/ui/icons/misc.icon.tsx
@@ -1,23 +1,28 @@
-﻿import { tacticusIcons } from './icon-list';
+﻿import { ImgHTMLAttributes, forwardRef } from 'react';
 
-export const MiscIcon = ({
-    icon,
-    width = 30,
-    height = 30,
-    className = '',
-    style = {},
-}: {
+import { tacticusIcons } from './icon-list';
+
+interface MiscIconProps extends Omit<ImgHTMLAttributes<HTMLImageElement>, 'src' | 'alt' | 'width' | 'height'> {
     icon: keyof typeof tacticusIcons;
     width?: number;
     height?: number;
-    className?: string;
-    style?: React.CSSProperties;
-}) => {
+}
+
+/**
+ * `pointer-events-none` is only dropped when an `onClick` is attached (e.g. by a tooltip wrapper
+ * injecting a tap handler) so the many call sites that sit inside a larger clickable row keep
+ * passing clicks through to their parent unchanged.
+ */
+export const MiscIcon = forwardRef<HTMLImageElement, MiscIconProps>(function MiscIcon(
+    { icon, width = 30, height = 30, className = '', style = {}, onClick, ...rest },
+    reference
+) {
     const details = tacticusIcons[icon] ?? { file: '', label: icon };
     return (
         <img
+            ref={reference}
             loading="lazy"
-            className={`pointer-events-none ${className}`}
+            className={`${onClick ? '' : 'pointer-events-none'} ${className}`}
             style={{
                 ...(height > 0 ? { height } : {}),
                 ...(width > 0 ? { width } : {}),
@@ -27,6 +32,9 @@ export const MiscIcon = ({
             width={width > 0 ? width : undefined}
             height={height > 0 ? height : undefined}
             alt={details.label}
+            onClick={onClick}
+            {...(onClick ? { role: 'button', tabIndex: 0 } : {})}
+            {...rest}
         />
     );
-};
+});

--- a/src/fsd/5-shared/ui/tooltip.tsx
+++ b/src/fsd/5-shared/ui/tooltip.tsx
@@ -119,14 +119,39 @@ export const LazyTooltip: FC<{ title: ReactNode; children: ReactElement<HTMLAttr
     );
 };
 
+/**
+ * Desktop path is a controlled `Tooltip` so a real click also opens/closes it, not just hover/focus
+ * — `isMobile` is a UA sniff and can miss touch-capable devices that land here instead of
+ * `TouchTooltip`, which otherwise had no click fallback at all.
+ */
 export const AccessibleTooltip: FC<Props> = ({ children, title }) => {
+    const [open, setOpen] = useState(false);
+    const close = useCallback(() => setOpen(false), []);
+
     if (isMobile) {
         return <TouchTooltip title={title}>{children}</TouchTooltip>;
     }
 
+    const childProps = children.props as HTMLAttributes<HTMLElement>;
+    const trigger = cloneElement(children, {
+        onClick: (event: MouseEvent<HTMLElement>) => {
+            childProps.onClick?.(event);
+            setOpen(value => !value);
+        },
+    } as Partial<HTMLAttributes<HTMLElement>>);
+
     return (
-        <Tooltip placement="top" title={title} arrow enterDelay={ENTER_DELAY_MS}>
-            {children}
-        </Tooltip>
+        <ClickAwayListener onClickAway={close} mouseEvent="onMouseUp">
+            <Tooltip
+                placement="top"
+                title={title}
+                arrow
+                enterDelay={ENTER_DELAY_MS}
+                open={open}
+                onOpen={() => setOpen(true)}
+                onClose={close}>
+                {trigger}
+            </Tooltip>
+        </ClickAwayListener>
     );
 };

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -266,6 +266,7 @@ export const defaultData: IPersonalData2 = {
         showGuildShop: true,
         showWarShop: true,
         showRogueTrader: true,
+        hideRandomShopDeals: false,
     },
     dailyRaidsPreferences: {
         dailyEnergy: 288,

--- a/src/routes/tables/crusade-shop-section.tsx
+++ b/src/routes/tables/crusade-shop-section.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo } from 'react';
+import { FC, ReactNode, useMemo } from 'react';
 
 import { snowprintIcons } from '@/fsd/5-shared/assets';
 import { Rarity, RarityMapper } from '@/fsd/5-shared/model';
@@ -14,6 +14,8 @@ import { ICharacterUpgradeEstimate } from '@/fsd/3-features/goals/goals.models';
 
 import { filterCrusadeShopItemsByType } from './crusade-shop-section.helpers';
 import { NeededByEntry } from './daily-raids.helpers';
+import { ShopAvailabilityGroups } from './shop-availability-groups';
+import { groupByAvailability } from './shop-availability.helpers';
 import { buildNeededByTooltip, resolveUnitName } from './shop-tooltip.helpers';
 import { parseForgeBadgeRarity } from './war-shop-section.helpers';
 
@@ -89,6 +91,7 @@ interface Props {
     forgeBadgeNeededBy: Record<Rarity, NeededByEntry[]>;
     userPL: number;
     hasBlueStarUnit: boolean;
+    hideRandomDeals: boolean;
 }
 
 export const CrusadeShopSection: FC<Props> = ({
@@ -98,6 +101,7 @@ export const CrusadeShopSection: FC<Props> = ({
     forgeBadgeNeededBy,
     userPL,
     hasBlueStarUnit,
+    hideRandomDeals,
 }) => {
     const today = CrusadeShopService.getTodayDow();
 
@@ -181,77 +185,75 @@ export const CrusadeShopSection: FC<Props> = ({
         [todayItems, shardsCountsMap, forgeBadgeCounts, materialCountsMap]
     );
 
-    if (visibleItems.length === 0) return;
+    const renderItem = (item: ResolvedShopItem): ReactNode => {
+        if (item.rewardType.startsWith('shards_')) {
+            const shardCounts = shardsCountsMap.get(item.rewardType) ?? { acquired: 0, required: 0 };
+            const charId = item.rewardType.slice(7);
+            const unit = CharactersService.getUnit(charId) ?? MowsService.resolveToStatic(charId);
+            const icon = unit ? (
+                <UnitShardIcon icon={unit.roundIcon} name={unit.name} height={ICON_SIZE} width={ICON_SIZE} />
+            ) : (
+                <UnitShardIcon icon="" name={item.rewardType} height={ICON_SIZE} width={ICON_SIZE} />
+            );
+            return (
+                <ShopItemCard
+                    key={item.rewardType}
+                    item={item}
+                    counts={shardCounts}
+                    icon={icon}
+                    name={unit?.name ?? charId}
+                    neededBy={shardsNeededByMap.get(item.rewardType) ?? []}
+                />
+            );
+        }
+
+        const badgeRarity = parseForgeBadgeRarity(item.rewardType);
+        if (badgeRarity !== undefined) {
+            const rarityLabel = RarityMapper.rarityToRarityString(badgeRarity);
+            return (
+                <ShopItemCard
+                    key={item.rewardType}
+                    item={item}
+                    counts={forgeBadgeCounts[badgeRarity]}
+                    icon={<ForgeBadgeImage rarity={badgeRarity} size="medium" />}
+                    name={`${rarityLabel} Forge Badge`}
+                    neededBy={forgeBadgeNeededBy[badgeRarity]}
+                />
+            );
+        }
+
+        const upgradeData = UpgradesService.recipeExpandedUpgradeData[item.rewardType];
+        const materialRarity = typeof upgradeData.rarity === 'number' ? upgradeData.rarity : Rarity.Common;
+        return (
+            <ShopItemCard
+                key={item.rewardType}
+                item={item}
+                counts={materialCountsMap.get(item.rewardType) ?? { acquired: 0, required: 0 }}
+                icon={
+                    <UpgradeImage
+                        material={upgradeData.label}
+                        iconPath={upgradeData.iconPath}
+                        rarity={RarityMapper.rarityToRarityString(materialRarity)}
+                        size={ICON_SIZE}
+                    />
+                }
+                name={upgradeData.label}
+                neededBy={materialNeededByMap.get(item.rewardType) ?? []}
+            />
+        );
+    };
+
+    const { guaranteed, possible } = useMemo(
+        () => groupByAvailability(visibleItems, hideRandomDeals),
+        [visibleItems, hideRandomDeals]
+    );
 
     return (
-        <div className="mt-4 border-t border-(--card-border) pt-3">
-            <p className="mb-2 text-xs font-semibold tracking-wide text-(--soft-fg) uppercase">
-                Available in Crusade Shop today
-            </p>
-            <div className="flex flex-wrap items-start justify-center gap-2">
-                {visibleItems.map(item => {
-                    if (item.rewardType.startsWith('shards_')) {
-                        const shardCounts = shardsCountsMap.get(item.rewardType) ?? { acquired: 0, required: 0 };
-                        const charId = item.rewardType.slice(7);
-                        const unit = CharactersService.getUnit(charId) ?? MowsService.resolveToStatic(charId);
-                        const icon = unit ? (
-                            <UnitShardIcon
-                                icon={unit.roundIcon}
-                                name={unit.name}
-                                height={ICON_SIZE}
-                                width={ICON_SIZE}
-                            />
-                        ) : (
-                            <UnitShardIcon icon="" name={item.rewardType} height={ICON_SIZE} width={ICON_SIZE} />
-                        );
-                        return (
-                            <ShopItemCard
-                                key={item.rewardType}
-                                item={item}
-                                counts={shardCounts}
-                                icon={icon}
-                                name={unit?.name ?? charId}
-                                neededBy={shardsNeededByMap.get(item.rewardType) ?? []}
-                            />
-                        );
-                    }
-
-                    const badgeRarity = parseForgeBadgeRarity(item.rewardType);
-                    if (badgeRarity !== undefined) {
-                        const rarityLabel = RarityMapper.rarityToRarityString(badgeRarity);
-                        return (
-                            <ShopItemCard
-                                key={item.rewardType}
-                                item={item}
-                                counts={forgeBadgeCounts[badgeRarity]}
-                                icon={<ForgeBadgeImage rarity={badgeRarity} size="medium" />}
-                                name={`${rarityLabel} Forge Badge`}
-                                neededBy={forgeBadgeNeededBy[badgeRarity]}
-                            />
-                        );
-                    }
-
-                    const upgradeData = UpgradesService.recipeExpandedUpgradeData[item.rewardType];
-                    const materialRarity = typeof upgradeData.rarity === 'number' ? upgradeData.rarity : Rarity.Common;
-                    return (
-                        <ShopItemCard
-                            key={item.rewardType}
-                            item={item}
-                            counts={materialCountsMap.get(item.rewardType) ?? { acquired: 0, required: 0 }}
-                            icon={
-                                <UpgradeImage
-                                    material={upgradeData.label}
-                                    iconPath={upgradeData.iconPath}
-                                    rarity={RarityMapper.rarityToRarityString(materialRarity)}
-                                    size={ICON_SIZE}
-                                />
-                            }
-                            name={upgradeData.label}
-                            neededBy={materialNeededByMap.get(item.rewardType) ?? []}
-                        />
-                    );
-                })}
-            </div>
-        </div>
+        <ShopAvailabilityGroups
+            shopName="Crusade Shop"
+            guaranteed={guaranteed}
+            possible={possible}
+            renderItem={renderItem}
+        />
     );
 };

--- a/src/routes/tables/daily-raids.tsx
+++ b/src/routes/tables/daily-raids.tsx
@@ -250,6 +250,7 @@ export const DailyRaids = () => {
                                 inProgressMaterials={estimatedRanks.inProgressMaterials}
                                 blockedMaterials={estimatedRanks.blockedMaterials}
                                 userPL={playerMetadata.powerLevel ?? 1}
+                                hideRandomDeals={viewPreferences.hideRandomShopDeals ?? false}
                             />
                         ) : undefined
                     }
@@ -263,6 +264,7 @@ export const DailyRaids = () => {
                                 componentNeededBy={mowCounts.componentNeededBy}
                                 forgeBadgeNeededBy={mowCounts.forgeBadgeNeededBy}
                                 userPL={playerMetadata.powerLevel ?? 1}
+                                hideRandomDeals={viewPreferences.hideRandomShopDeals ?? false}
                             />
                         ) : undefined
                     }
@@ -273,6 +275,7 @@ export const DailyRaids = () => {
                                 blockedMaterials={estimatedRanks.blockedMaterials}
                                 forgeBadgeCounts={mowCounts.forgeBadgeCounts}
                                 forgeBadgeNeededBy={mowCounts.forgeBadgeNeededBy}
+                                hideRandomDeals={viewPreferences.hideRandomShopDeals ?? false}
                             />
                         ) : undefined
                     }
@@ -285,6 +288,7 @@ export const DailyRaids = () => {
                                 forgeBadgeNeededBy={mowCounts.forgeBadgeNeededBy}
                                 userPL={playerMetadata.powerLevel ?? 1}
                                 hasBlueStarUnit={hasBlueStar}
+                                hideRandomDeals={viewPreferences.hideRandomShopDeals ?? false}
                             />
                         ) : undefined
                     }

--- a/src/routes/tables/guild-shop-section.tsx
+++ b/src/routes/tables/guild-shop-section.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo } from 'react';
+import { FC, ReactNode, useMemo } from 'react';
 
 import { snowprintIcons } from '@/fsd/5-shared/assets';
 import { Rarity, RarityMapper } from '@/fsd/5-shared/model';
@@ -13,6 +13,8 @@ import { UpgradeImage, UpgradesService } from '@/fsd/4-entities/upgrade';
 import { ICharacterUpgradeEstimate } from '@/fsd/3-features/goals/goals.models';
 
 import { NeededByEntry } from './daily-raids.helpers';
+import { ShopAvailabilityGroups } from './shop-availability-groups';
+import { groupByAvailability } from './shop-availability.helpers';
 import { buildNeededByTooltip, resolveUnitName } from './shop-tooltip.helpers';
 
 const MYTHIC_IDS = new Set(['upgHpM001', 'upgHpM002', 'upgHpM003', 'upgHpM004']);
@@ -100,9 +102,10 @@ interface Props {
     inProgressMaterials: ICharacterUpgradeEstimate[];
     blockedMaterials: ICharacterUpgradeEstimate[];
     userPL: number;
+    hideRandomDeals: boolean;
 }
 
-export const GuildShopSection: FC<Props> = ({ inProgressMaterials, blockedMaterials, userPL }) => {
+export const GuildShopSection: FC<Props> = ({ inProgressMaterials, blockedMaterials, userPL, hideRandomDeals }) => {
     const today = GuildShopService.getTodayDow();
 
     const todayItems = useMemo(
@@ -151,24 +154,27 @@ export const GuildShopSection: FC<Props> = ({ inProgressMaterials, blockedMateri
         [todayItems, countsMap]
     );
 
-    if (visibleItems.length === 0) return;
+    const renderItem = (item: ResolvedShopItem): ReactNode => (
+        <ShopItemCard
+            key={item.rewardType}
+            item={item}
+            acquired={countsMap.get(item.rewardType)?.acquired ?? 0}
+            required={countsMap.get(item.rewardType)?.required ?? 0}
+            neededBy={neededByMap.get(item.rewardType) ?? []}
+        />
+    );
+
+    const { guaranteed, possible } = useMemo(
+        () => groupByAvailability(visibleItems, hideRandomDeals),
+        [visibleItems, hideRandomDeals]
+    );
 
     return (
-        <div className="mt-4 border-t border-(--card-border) pt-3">
-            <p className="mb-2 text-xs font-semibold tracking-wide text-(--soft-fg) uppercase">
-                Available in Guild Shop today
-            </p>
-            <div className="flex flex-wrap items-start justify-center gap-2">
-                {visibleItems.map(item => (
-                    <ShopItemCard
-                        key={item.rewardType}
-                        item={item}
-                        acquired={countsMap.get(item.rewardType)?.acquired ?? 0}
-                        required={countsMap.get(item.rewardType)?.required ?? 0}
-                        neededBy={neededByMap.get(item.rewardType) ?? []}
-                    />
-                ))}
-            </div>
-        </div>
+        <ShopAvailabilityGroups
+            shopName="Guild Shop"
+            guaranteed={guaranteed}
+            possible={possible}
+            renderItem={renderItem}
+        />
     );
 };

--- a/src/routes/tables/rogue-trader-section.tsx
+++ b/src/routes/tables/rogue-trader-section.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo } from 'react';
+import { FC, ReactNode, useMemo } from 'react';
 
 import { snowprintIcons } from '@/fsd/5-shared/assets';
 import { Rarity, RarityMapper } from '@/fsd/5-shared/model';
@@ -11,6 +11,8 @@ import { UpgradeImage, UpgradesService } from '@/fsd/4-entities/upgrade';
 import { ICharacterUpgradeEstimate } from '@/fsd/3-features/goals/goals.models';
 
 import { NeededByEntry } from './daily-raids.helpers';
+import { ShopAvailabilityGroups } from './shop-availability-groups';
+import { groupByAvailability } from './shop-availability.helpers';
 import { buildNeededByTooltip, resolveUnitName } from './shop-tooltip.helpers';
 
 const MYTHIC_MAT_IDS = new Set(['upgHpM001', 'upgHpM002', 'upgHpM003', 'upgHpM004']);
@@ -101,6 +103,7 @@ interface Props {
     blockedMaterials: ICharacterUpgradeEstimate[];
     forgeBadgeCounts: Record<Rarity, Counts>;
     forgeBadgeNeededBy: Record<Rarity, NeededByEntry[]>;
+    hideRandomDeals: boolean;
 }
 
 export const RogueTraderSection: FC<Props> = ({
@@ -108,6 +111,7 @@ export const RogueTraderSection: FC<Props> = ({
     blockedMaterials,
     forgeBadgeCounts,
     forgeBadgeNeededBy,
+    hideRandomDeals,
 }) => {
     const today = RogueTraderService.getTodayDow();
 
@@ -159,34 +163,37 @@ export const RogueTraderSection: FC<Props> = ({
         [todayItems, forgeBadgeCounts, countsMap]
     );
 
-    if (visibleItems.length === 0) return;
+    const renderItem = (item: ResolvedShopItem): ReactNode => {
+        const c =
+            item.rewardType === MYTHIC_FORGE_BADGE
+                ? forgeBadgeCounts[Rarity.Mythic]
+                : (countsMap.get(item.rewardType) ?? { acquired: 0, required: 0 });
+        const neededBy =
+            item.rewardType === MYTHIC_FORGE_BADGE
+                ? forgeBadgeNeededBy[Rarity.Mythic]
+                : (neededByMap.get(item.rewardType) ?? []);
+        return (
+            <ShopItemCard
+                key={item.rewardType}
+                item={item}
+                acquired={c.acquired}
+                required={c.required}
+                neededBy={neededBy}
+            />
+        );
+    };
+
+    const { guaranteed, possible } = useMemo(
+        () => groupByAvailability(visibleItems, hideRandomDeals),
+        [visibleItems, hideRandomDeals]
+    );
 
     return (
-        <div className="mt-4 border-t border-(--card-border) pt-3">
-            <p className="mb-2 text-xs font-semibold tracking-wide text-(--soft-fg) uppercase">
-                Available in Rogue Trader today
-            </p>
-            <div className="flex flex-wrap items-start justify-center gap-2">
-                {visibleItems.map(item => {
-                    const c =
-                        item.rewardType === MYTHIC_FORGE_BADGE
-                            ? forgeBadgeCounts[Rarity.Mythic]
-                            : (countsMap.get(item.rewardType) ?? { acquired: 0, required: 0 });
-                    const neededBy =
-                        item.rewardType === MYTHIC_FORGE_BADGE
-                            ? forgeBadgeNeededBy[Rarity.Mythic]
-                            : (neededByMap.get(item.rewardType) ?? []);
-                    return (
-                        <ShopItemCard
-                            key={item.rewardType}
-                            item={item}
-                            acquired={c.acquired}
-                            required={c.required}
-                            neededBy={neededBy}
-                        />
-                    );
-                })}
-            </div>
-        </div>
+        <ShopAvailabilityGroups
+            shopName="Rogue Trader"
+            guaranteed={guaranteed}
+            possible={possible}
+            renderItem={renderItem}
+        />
     );
 };

--- a/src/routes/tables/shop-availability-groups.spec.tsx
+++ b/src/routes/tables/shop-availability-groups.spec.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import type { ResolvedShopItem } from '@/fsd/4-entities/shops';
+
+import { ShopAvailabilityGroups } from './shop-availability-groups';
+
+const makeItem = (rewardType: string): ResolvedShopItem => ({
+    rewardType,
+    rewardQty: 1,
+    costAmount: 100,
+    maxPerDay: 1,
+    isGuaranteed: true,
+});
+
+const renderItem = (item: ResolvedShopItem) => <span key={item.rewardType}>{item.rewardType}</span>;
+
+describe('ShopAvailabilityGroups', () => {
+    it('renders nothing when both groups are empty', () => {
+        const { container } = render(
+            <ShopAvailabilityGroups shopName="War Shop" guaranteed={[]} possible={[]} renderItem={renderItem} />
+        );
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders only the "Available" header/group when there are no random items', () => {
+        render(
+            <ShopAvailabilityGroups
+                shopName="War Shop"
+                guaranteed={[makeItem('a')]}
+                possible={[]}
+                renderItem={renderItem}
+            />
+        );
+        expect(screen.getByText('Available in War Shop today')).toBeInTheDocument();
+        expect(screen.queryByText(/Possibly in War Shop today/i)).not.toBeInTheDocument();
+        expect(screen.getByText('a')).toBeInTheDocument();
+    });
+
+    it('renders only the "Possibly" header/group when everything is random', () => {
+        render(
+            <ShopAvailabilityGroups
+                shopName="Guild Shop"
+                guaranteed={[]}
+                possible={[makeItem('b')]}
+                renderItem={renderItem}
+            />
+        );
+        expect(screen.getByText('Possibly in Guild Shop today')).toBeInTheDocument();
+        expect(screen.queryByText(/Available in Guild Shop today/i)).not.toBeInTheDocument();
+        expect(screen.getByText('b')).toBeInTheDocument();
+    });
+
+    it('renders both headers/groups for a mix of guaranteed and random items', () => {
+        render(
+            <ShopAvailabilityGroups
+                shopName="Crusade Shop"
+                guaranteed={[makeItem('a')]}
+                possible={[makeItem('b')]}
+                renderItem={renderItem}
+            />
+        );
+        expect(screen.getByText('Available in Crusade Shop today')).toBeInTheDocument();
+        expect(screen.getByText('Possibly in Crusade Shop today')).toBeInTheDocument();
+        expect(screen.getByText('a')).toBeInTheDocument();
+        expect(screen.getByText('b')).toBeInTheDocument();
+    });
+});

--- a/src/routes/tables/shop-availability-groups.tsx
+++ b/src/routes/tables/shop-availability-groups.tsx
@@ -1,0 +1,39 @@
+import { FC, ReactNode } from 'react';
+
+import { ResolvedShopItem } from '@/fsd/4-entities/shops';
+
+interface Props {
+    shopName: string;
+    guaranteed: ResolvedShopItem[];
+    possible: ResolvedShopItem[];
+    renderItem: (item: ResolvedShopItem) => ReactNode;
+}
+
+export const ShopAvailabilityGroups: FC<Props> = ({ shopName, guaranteed, possible, renderItem }) => {
+    if (guaranteed.length === 0 && possible.length === 0) return;
+
+    return (
+        <div className="mt-4 border-t border-(--card-border) pt-3">
+            {guaranteed.length > 0 && (
+                <section>
+                    <p className="mb-2 text-xs font-semibold tracking-wide text-(--soft-fg) uppercase">
+                        Available in {shopName} today
+                    </p>
+                    <div className="flex flex-wrap items-start justify-center gap-2">
+                        {guaranteed.map(item => renderItem(item))}
+                    </div>
+                </section>
+            )}
+            {possible.length > 0 && (
+                <section className={guaranteed.length > 0 ? 'mt-3' : undefined}>
+                    <p className="mb-2 text-xs font-semibold tracking-wide text-(--soft-fg) uppercase">
+                        Possibly in {shopName} today
+                    </p>
+                    <div className="flex flex-wrap items-start justify-center gap-2">
+                        {possible.map(item => renderItem(item))}
+                    </div>
+                </section>
+            )}
+        </div>
+    );
+};

--- a/src/routes/tables/shop-availability.helpers.spec.ts
+++ b/src/routes/tables/shop-availability.helpers.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ResolvedShopItem } from '@/fsd/4-entities/shops';
+
+import { groupByAvailability } from './shop-availability.helpers';
+
+const makeItem = (rewardType: string, isGuaranteed: boolean): ResolvedShopItem => ({
+    rewardType,
+    rewardQty: 1,
+    costAmount: 100,
+    maxPerDay: 1,
+    isGuaranteed,
+});
+
+describe('groupByAvailability', () => {
+    it('splits guaranteed and non-guaranteed items into separate groups', () => {
+        const items = [makeItem('a', true), makeItem('b', false), makeItem('c', true), makeItem('d', false)];
+
+        const { guaranteed, possible } = groupByAvailability(items, false);
+
+        expect(guaranteed.map(index => index.rewardType)).toEqual(['a', 'c']);
+        expect(possible.map(index => index.rewardType)).toEqual(['b', 'd']);
+    });
+
+    it('drops the possible group entirely when hideRandom is true', () => {
+        const items = [makeItem('a', true), makeItem('b', false)];
+
+        const { guaranteed, possible } = groupByAvailability(items, true);
+
+        expect(guaranteed.map(index => index.rewardType)).toEqual(['a']);
+        expect(possible).toEqual([]);
+    });
+
+    it('handles an all-guaranteed list', () => {
+        const items = [makeItem('a', true), makeItem('b', true)];
+
+        const { guaranteed, possible } = groupByAvailability(items, false);
+
+        expect(guaranteed).toHaveLength(2);
+        expect(possible).toHaveLength(0);
+    });
+
+    it('handles an all-random list', () => {
+        const items = [makeItem('a', false), makeItem('b', false)];
+
+        const { guaranteed, possible } = groupByAvailability(items, false);
+
+        expect(guaranteed).toHaveLength(0);
+        expect(possible).toHaveLength(2);
+    });
+
+    it('handles an empty list', () => {
+        expect(groupByAvailability([], false)).toEqual({ guaranteed: [], possible: [] });
+        expect(groupByAvailability([], true)).toEqual({ guaranteed: [], possible: [] });
+    });
+});

--- a/src/routes/tables/shop-availability.helpers.ts
+++ b/src/routes/tables/shop-availability.helpers.ts
@@ -1,0 +1,18 @@
+import { ResolvedShopItem } from '@/fsd/4-entities/shops';
+
+export interface ShopAvailabilityGroups {
+    guaranteed: ResolvedShopItem[];
+    possible: ResolvedShopItem[];
+}
+
+/**
+ * Splits already-filtered "visible" shop items into guaranteed-today vs. possibly-today (random
+ * slot). When `hideRandom` is true, the possible group is dropped entirely rather than shown under
+ * its own header.
+ */
+export function groupByAvailability(items: ResolvedShopItem[], hideRandom: boolean): ShopAvailabilityGroups {
+    return {
+        guaranteed: items.filter(item => item.isGuaranteed),
+        possible: hideRandom ? [] : items.filter(item => !item.isGuaranteed),
+    };
+}

--- a/src/routes/tables/war-shop-section.tsx
+++ b/src/routes/tables/war-shop-section.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo } from 'react';
+import { FC, ReactNode, useMemo } from 'react';
 
 import { snowprintIcons } from '@/fsd/5-shared/assets';
 import { Alliance, Rarity, RarityString } from '@/fsd/5-shared/model';
@@ -12,6 +12,8 @@ import { WarShopService, ResolvedShopItem } from '@/fsd/4-entities/shops';
 import { ICharacterUpgradeEstimate } from '@/fsd/3-features/goals/goals.models';
 
 import { NeededByEntry } from './daily-raids.helpers';
+import { ShopAvailabilityGroups } from './shop-availability-groups';
+import { groupByAvailability } from './shop-availability.helpers';
 import { buildNeededByTooltip, resolveUnitName } from './shop-tooltip.helpers';
 import {
     filterWarShopItemsByGoalNeed,
@@ -92,6 +94,7 @@ interface Props {
     componentNeededBy: Record<Alliance, NeededByEntry[]>;
     forgeBadgeNeededBy: Record<Rarity, NeededByEntry[]>;
     userPL: number;
+    hideRandomDeals: boolean;
 }
 
 export const WarShopSection: FC<Props> = ({
@@ -102,6 +105,7 @@ export const WarShopSection: FC<Props> = ({
     componentNeededBy,
     forgeBadgeNeededBy,
     userPL,
+    hideRandomDeals,
 }) => {
     const today = WarShopService.getTodayDow();
 
@@ -143,86 +147,84 @@ export const WarShopSection: FC<Props> = ({
         [todayItems, shardsCountsMap, componentsByAlliance, forgeBadgeCounts]
     );
 
-    if (visibleItems.length === 0) return;
+    const renderItem = (item: ResolvedShopItem): ReactNode => {
+        if (item.rewardType.startsWith('shards_')) {
+            const shardCounts = shardsCountsMap.get(item.rewardType);
+            const needsShard = shardCounts !== undefined && shardCounts.acquired < shardCounts.required;
+            if (!needsShard && item.freeOfferType === 'draft_machinesOfWarTokens') {
+                return (Object.values(Alliance) as Alliance[])
+                    .filter(a => componentsByAlliance[a].acquired < componentsByAlliance[a].required)
+                    .map(a => (
+                        <ShopItemCard
+                            key={`${item.rewardType}-${a}`}
+                            item={item}
+                            counts={componentsByAlliance[a]}
+                            icon={<ComponentImage alliance={a} size="medium" />}
+                            name={`${a} Components`}
+                            neededBy={componentNeededBy[a]}
+                        />
+                    ));
+            }
+            const charId = item.rewardType.slice(7);
+            const unit = CharactersService.getUnit(charId) ?? MowsService.resolveToStatic(charId);
+            const icon = unit ? (
+                <UnitShardIcon icon={unit.roundIcon} name={unit.name} height={ICON_SIZE} width={ICON_SIZE} />
+            ) : (
+                <UnitShardIcon icon="" name={item.rewardType} height={ICON_SIZE} width={ICON_SIZE} />
+            );
+            return (
+                <ShopItemCard
+                    key={item.rewardType}
+                    item={item}
+                    counts={shardCounts ?? { acquired: 0, required: 0 }}
+                    icon={icon}
+                    name={unit?.name ?? charId}
+                    neededBy={shardsNeededByMap.get(item.rewardType) ?? []}
+                />
+            );
+        }
+
+        if (item.rewardType === 'draft_machinesOfWarTokens') {
+            return (Object.values(Alliance) as Alliance[])
+                .filter(a => componentsByAlliance[a].acquired < componentsByAlliance[a].required)
+                .map(a => (
+                    <ShopItemCard
+                        key={`${item.rewardType}-${a}`}
+                        item={item}
+                        counts={componentsByAlliance[a]}
+                        icon={<ComponentImage alliance={a} size="medium" />}
+                        name={`${a} Components`}
+                        neededBy={componentNeededBy[a]}
+                    />
+                ));
+        }
+
+        const rarity = parseForgeBadgeRarity(item.rewardType);
+        if (rarity === undefined) return;
+        const rarityLabel = RarityString[rarity as unknown as keyof typeof RarityString] ?? 'Forge Badge';
+        return (
+            <ShopItemCard
+                key={item.rewardType}
+                item={item}
+                counts={forgeBadgeCounts[rarity]}
+                icon={<ForgeBadgeImage rarity={rarity} size="medium" />}
+                name={`${rarityLabel} Forge Badge`}
+                neededBy={forgeBadgeNeededBy[rarity]}
+            />
+        );
+    };
+
+    const { guaranteed, possible } = useMemo(
+        () => groupByAvailability(visibleItems, hideRandomDeals),
+        [visibleItems, hideRandomDeals]
+    );
 
     return (
-        <div className="mt-4 border-t border-(--card-border) pt-3">
-            <p className="mb-2 text-xs font-semibold tracking-wide text-(--soft-fg) uppercase">
-                Available in War Shop today
-            </p>
-            <div className="flex flex-wrap items-start justify-center gap-2">
-                {visibleItems.map(item => {
-                    if (item.rewardType.startsWith('shards_')) {
-                        const shardCounts = shardsCountsMap.get(item.rewardType);
-                        const needsShard = shardCounts !== undefined && shardCounts.acquired < shardCounts.required;
-                        if (!needsShard && item.freeOfferType === 'draft_machinesOfWarTokens') {
-                            return (Object.values(Alliance) as Alliance[])
-                                .filter(a => componentsByAlliance[a].acquired < componentsByAlliance[a].required)
-                                .map(a => (
-                                    <ShopItemCard
-                                        key={`${item.rewardType}-${a}`}
-                                        item={item}
-                                        counts={componentsByAlliance[a]}
-                                        icon={<ComponentImage alliance={a} size="medium" />}
-                                        name={`${a} Components`}
-                                        neededBy={componentNeededBy[a]}
-                                    />
-                                ));
-                        }
-                        const charId = item.rewardType.slice(7);
-                        const unit = CharactersService.getUnit(charId) ?? MowsService.resolveToStatic(charId);
-                        const icon = unit ? (
-                            <UnitShardIcon
-                                icon={unit.roundIcon}
-                                name={unit.name}
-                                height={ICON_SIZE}
-                                width={ICON_SIZE}
-                            />
-                        ) : (
-                            <UnitShardIcon icon="" name={item.rewardType} height={ICON_SIZE} width={ICON_SIZE} />
-                        );
-                        return (
-                            <ShopItemCard
-                                key={item.rewardType}
-                                item={item}
-                                counts={shardCounts ?? { acquired: 0, required: 0 }}
-                                icon={icon}
-                                name={unit?.name ?? charId}
-                                neededBy={shardsNeededByMap.get(item.rewardType) ?? []}
-                            />
-                        );
-                    }
-
-                    if (item.rewardType === 'draft_machinesOfWarTokens') {
-                        return (Object.values(Alliance) as Alliance[])
-                            .filter(a => componentsByAlliance[a].acquired < componentsByAlliance[a].required)
-                            .map(a => (
-                                <ShopItemCard
-                                    key={`${item.rewardType}-${a}`}
-                                    item={item}
-                                    counts={componentsByAlliance[a]}
-                                    icon={<ComponentImage alliance={a} size="medium" />}
-                                    name={`${a} Components`}
-                                    neededBy={componentNeededBy[a]}
-                                />
-                            ));
-                    }
-
-                    const rarity = parseForgeBadgeRarity(item.rewardType);
-                    if (rarity === undefined) return;
-                    const rarityLabel = RarityString[rarity as unknown as keyof typeof RarityString] ?? 'Forge Badge';
-                    return (
-                        <ShopItemCard
-                            key={item.rewardType}
-                            item={item}
-                            counts={forgeBadgeCounts[rarity]}
-                            icon={<ForgeBadgeImage rarity={rarity} size="medium" />}
-                            name={`${rarityLabel} Forge Badge`}
-                            neededBy={forgeBadgeNeededBy[rarity]}
-                        />
-                    );
-                })}
-            </div>
-        </div>
+        <ShopAvailabilityGroups
+            shopName="War Shop"
+            guaranteed={guaranteed}
+            possible={possible}
+            renderItem={renderItem}
+        />
     );
 };

--- a/src/shared-components/daily-raids-settings.tsx
+++ b/src/shared-components/daily-raids-settings.tsx
@@ -131,6 +131,7 @@ const DailyRaidsSettings: React.FC<Props> = ({ close, open }) => {
         showWarShop: viewPreferences.showWarShop ?? true,
         showRogueTrader: viewPreferences.showRogueTrader ?? true,
         showCrusadeShop: viewPreferences.showCrusadeShop ?? true,
+        hideRandomShopDeals: viewPreferences.hideRandomShopDeals ?? false,
     });
     const [dailyEnergy, setDailyEnergy] = React.useState(() => {
         const index = energyMarks.findIndex(x => x.value === dailyRaidsPreferences.dailyEnergy);
@@ -151,6 +152,7 @@ const DailyRaidsSettings: React.FC<Props> = ({ close, open }) => {
                 showWarShop: viewPreferences.showWarShop ?? true,
                 showRogueTrader: viewPreferences.showRogueTrader ?? true,
                 showCrusadeShop: viewPreferences.showCrusadeShop ?? true,
+                hideRandomShopDeals: viewPreferences.hideRandomShopDeals ?? false,
             });
         }
     }, [open, viewPreferences]);
@@ -174,6 +176,11 @@ const DailyRaidsSettings: React.FC<Props> = ({ close, open }) => {
         dispatch.viewPreferences({ type: 'Update', setting: 'showWarShop', value: shopVisibility.showWarShop });
         dispatch.viewPreferences({ type: 'Update', setting: 'showRogueTrader', value: shopVisibility.showRogueTrader });
         dispatch.viewPreferences({ type: 'Update', setting: 'showCrusadeShop', value: shopVisibility.showCrusadeShop });
+        dispatch.viewPreferences({
+            type: 'Update',
+            setting: 'hideRandomShopDeals',
+            value: shopVisibility.hideRandomShopDeals,
+        });
         close();
     };
 
@@ -345,6 +352,19 @@ const DailyRaidsSettings: React.FC<Props> = ({ close, open }) => {
                             }>
                             Crusade Shop
                         </Switch>
+                        <div className="my-1 border-t border-(--card-border)" />
+                        <div className="flex items-center gap-1">
+                            <Switch
+                                isSelected={shopVisibility.hideRandomShopDeals}
+                                onChange={checked =>
+                                    setShopVisibility(current => ({ ...current, hideRandomShopDeals: checked }))
+                                }>
+                                Hide non-guaranteed items
+                            </Switch>
+                            <AccessibleTooltip title="Some shop slots can roll one of several different rewards — only one will actually appear in-game. When enabled, items that aren't guaranteed to show up today are hidden instead of shown separately.">
+                                <Info className="size-4 text-(--primary)" />
+                            </AccessibleTooltip>
+                        </div>
                     </div>
                 </fieldset>
             </PortalDialog.Body>


### PR DESCRIPTION
<img width="449" height="92" alt="image" src="https://github.com/user-attachments/assets/fe777001-f78b-47e5-95ba-6b6d0f4e02bd" />
<img width="693" height="327" alt="image" src="https://github.com/user-attachments/assets/f2ffbe37-ddce-4fa9-b48a-3cf0deeddfb5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Daily Raids setting to hide non-guaranteed shop deals, with the preference saved between sessions.
  - Shop sections now separate guaranteed and possible rewards for clearer browsing.
  - Added accessible tooltip interactions and improved keyboard/click behavior for interactive icons.

- **Bug Fixes**
  - Improved tooltip dismissal and click handling on desktop.

- **Tests**
  - Added coverage for shop grouping, filtering, and empty-state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->