### PR TITLE
fix: resolve onslaught shards calculation and remove unused properties

### DIFF
--- a/src/fsd/3-features/goals/goals.service.ts
+++ b/src/fsd/3-features/goals/goals.service.ts
@@ -482,7 +482,7 @@ export class GoalsService {
                               unit.alliance as Alliance,
                               onslaughtPreferences
                           )
-                        : 1,
+                        : 0,
                     campaignsUsage: g.campaignsUsage ?? CampaignsLocationsUsage.LeastEnergy,
                     mythicCampaignsUsage: g.mythicCampaignsUsage ?? CampaignsLocationsUsage.LeastEnergy,
                     farmType: g.shardFarmType ?? 'both',

--- a/src/fsd/3-features/goals/goals.service.ts
+++ b/src/fsd/3-features/goals/goals.service.ts
@@ -467,26 +467,22 @@ export class GoalsService {
                     mythicShards: useActualProgress ? (unit.mythicShards ?? 0) : 0,
                     starsStart,
                     starsEnd: g.targetStars ?? rarityToStars[g.targetRarity!],
-                    onslaughtShards:
-                        (g.shardsPerToken || undefined) ??
-                        (unit.alliance
-                            ? getOnslaughtMidpointForCharacter(
-                                  unit.rarity,
-                                  unit.stars,
-                                  unit.alliance as Alliance,
-                                  onslaughtPreferences
-                              )
-                            : 0),
-                    onslaughtMythicShards:
-                        (g.mythicShardsPerToken || undefined) ??
-                        (unit.alliance
-                            ? getOnslaughtMidpointForCharacter(
-                                  Math.max(unit.rarity, Rarity.Legendary) as Rarity,
-                                  Math.max(unit.stars, RarityStars.OneBlueStar) as RarityStars,
-                                  unit.alliance as Alliance,
-                                  onslaughtPreferences
-                              )
-                            : 1),
+                    onslaughtShards: unit.alliance
+                        ? getOnslaughtMidpointForCharacter(
+                              unit.rarity,
+                              unit.stars,
+                              unit.alliance as Alliance,
+                              onslaughtPreferences
+                          )
+                        : 0,
+                    onslaughtMythicShards: unit.alliance
+                        ? getOnslaughtMidpointForCharacter(
+                              Math.max(unit.rarity, Rarity.Legendary) as Rarity,
+                              Math.max(unit.stars, RarityStars.OneBlueStar) as RarityStars,
+                              unit.alliance as Alliance,
+                              onslaughtPreferences
+                          )
+                        : 1,
                     campaignsUsage: g.campaignsUsage ?? CampaignsLocationsUsage.LeastEnergy,
                     mythicCampaignsUsage: g.mythicCampaignsUsage ?? CampaignsLocationsUsage.LeastEnergy,
                     farmType: g.shardFarmType ?? 'both',
@@ -539,17 +535,10 @@ export class GoalsService {
                     mythicShards: useActualProgress ? (unit.mythicShards ?? 0) : 0,
                     starsStart,
                     starsEnd: targetStars,
-                    onslaughtShards:
-                        (g.shardsPerToken || undefined) ??
-                        (unit.alliance
-                            ? getOnslaughtMidpointForCharacter(
-                                  unit.rarity,
-                                  unit.stars,
-                                  unit.alliance,
-                                  onslaughtPreferences
-                              )
-                            : 0),
-                    onslaughtMythicShards: (g.mythicShardsPerToken || undefined) ?? defaultMythicShards,
+                    onslaughtShards: unit.alliance
+                        ? getOnslaughtMidpointForCharacter(unit.rarity, unit.stars, unit.alliance, onslaughtPreferences)
+                        : 0,
+                    onslaughtMythicShards: defaultMythicShards,
                     campaignsUsage: g.campaignsUsage ?? CampaignsLocationsUsage.LeastEnergy,
                     mythicCampaignsUsage: g.mythicCampaignsUsage ?? CampaignsLocationsUsage.LeastEnergy,
                     farmType: g.shardFarmType ?? 'both',
@@ -656,8 +645,6 @@ export class GoalsService {
                     targetStars: goal.starsEnd,
                     campaignsUsage: goal.campaignsUsage,
                     mythicCampaignsUsage: goal.mythicCampaignsUsage,
-                    shardsPerToken: goal.onslaughtShards,
-                    mythicShardsPerToken: goal.onslaughtMythicShards,
                     shardFarmType: goal.farmType,
                 };
             }

--- a/src/models/interfaces.ts
+++ b/src/models/interfaces.ts
@@ -397,8 +397,6 @@ export interface IPersonalGoal {
     startingStars?: RarityStars;
     targetRarity?: Rarity;
     targetStars?: RarityStars;
-    shardsPerToken?: number;
-    mythicShardsPerToken?: number;
     manuallyFarmXp?: boolean;
     shardFarmType?: ShardFarmType;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ascend goal shard values are now consistently calculated from current character state and preferences.
  - Generic, Master of Weapons, and character Ascend goals no longer use outdated per-goal shard overrides.
- **Improvements**
  - Removed support for configuring shard-per-token overrides on personal goals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->