### PR TITLE
Add dark mode support to prevent FOUC on reload

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -225,6 +225,8 @@ New tokens go in `src/fsd/0-app/index.css`:
 | `bg-(--card-fg)/60` as a progress fill                       | Pick a semantic fill: `bg-(--primary)` or the relevant domain token                                                                          |
 | `hover:bg-(--neutral)` on buttons inside cards/tables        | `--neutral` = card surface in dark mode — invisible hover. Use `hover:bg-(--primary)/15` (neutral) or `hover:bg-(--danger)/10` (destructive) |
 
+**Exception:** `index.html`'s pre-CSS theme bootstrap script may hardcode hex (tokens aren't loaded yet). Keep it mirroring `--bg`/`--fg`.
+
 ### Shade-picking guide
 
 **Tokens for identity. Tailwind for variation.** If changing the colour would change what the app _is_ (brand, intent, semantic meaning), it's a token. If it's just picking a lighter or darker shade of something that already has a token, use Tailwind's scale with explicit `dark:` variants.

--- a/index.html
+++ b/index.html
@@ -26,16 +26,21 @@
         </style>
         <script>
             (function () {
+                var stored = null;
                 try {
-                    var stored = localStorage.getItem('tp-theme');
-                    var isDark =
-                        stored === 'DARK' ||
-                        (stored !== 'LIGHT' && matchMedia('(prefers-color-scheme: dark)').matches);
-                    if (isDark) {
-                        document.documentElement.classList.add('dark');
-                        document.documentElement.dataset.agThemeMode = 'dark';
-                    }
+                    stored = localStorage.getItem('tp-theme');
                 } catch (e) {}
+                var isDark;
+                try {
+                    isDark =
+                        stored === 'DARK' || (stored !== 'LIGHT' && matchMedia('(prefers-color-scheme: dark)').matches);
+                } catch (e) {
+                    isDark = stored === 'DARK';
+                }
+                if (isDark) {
+                    document.documentElement.classList.add('dark');
+                    document.documentElement.dataset.agThemeMode = 'dark';
+                }
             })();
         </script>
 

--- a/index.html
+++ b/index.html
@@ -13,6 +13,32 @@
         <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
         <meta name="theme-color" content="rgb(18, 18, 18)" media="(prefers-color-scheme: dark)" />
 
+        <!--
+      Prevents dark-mode FOUC on reload: sets .dark + bg/fg before index.css loads.
+      Keep localStorage key ('tp-theme') in sync with theme.provider.tsx, and these
+      hex values in sync with --color-zinc-900/--color-zinc-300 in index.css.
+    -->
+        <style>
+            html.dark {
+                background-color: #18181b;
+                color: #d4d4d8;
+            }
+        </style>
+        <script>
+            (function () {
+                try {
+                    var stored = localStorage.getItem('tp-theme');
+                    var isDark =
+                        stored === 'DARK' ||
+                        (stored !== 'LIGHT' && matchMedia('(prefers-color-scheme: dark)').matches);
+                    if (isDark) {
+                        document.documentElement.classList.add('dark');
+                        document.documentElement.dataset.agThemeMode = 'dark';
+                    }
+                } catch (e) {}
+            })();
+        </script>
+
         <!--        Preconnect-->
         <link rel="preconnect" href="https://www.googletagmanager.com" />
         <link rel="preconnect" href="https://tacticucplannerstorage.blob.core.windows.net" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dark-mode initialization before styles load, reducing flashes of unstyled content.
  * Dark mode now respects the saved theme preference and system color scheme.
  * Applies the appropriate theme immediately for a smoother page experience.

* **Documentation**
  * Updated styling conventions to allow required theme colors in the early initialization script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->