### PR TITLE
Derive LE event ID from character snowprintId instead of hardcoded switch

### DIFF
--- a/src/fsd/1-pages/plan-lre/le-progress.service.ts
+++ b/src/fsd/1-pages/plan-lre/le-progress.service.ts
@@ -1,10 +1,9 @@
 /* eslint-disable import-x/no-internal-modules */
-/* eslint-disable boundaries/element-types */
 import { cloneDeep, sum } from 'lodash';
 
 import { TacticusLegendaryEventLane, TacticusLegendaryEventProgress } from '@/fsd/5-shared/lib';
 
-import { LegendaryEventEnum } from '@/fsd/4-entities/lre/@x/character';
+import { LegendaryEventEnum, LegendaryEventService } from '@/fsd/4-entities/lre';
 
 import { ILegendaryEventTrack, RequirementStatus } from '@/fsd/3-features/lre';
 import { LegendaryEventBase } from '@/fsd/3-features/lre/model/base.le';
@@ -301,26 +300,7 @@ export class LeProgressService {
 
     /** Maps a unit's snowprintId to the planner internal ID for legendary events. */
     public static mapEventId(charId: string): LegendaryEventEnum | undefined {
-        switch (charId) {
-            case 'bloodDante': {
-                return LegendaryEventEnum.Dante;
-            }
-            case 'custoTrajann': {
-                return LegendaryEventEnum.Trajann;
-            }
-            case 'emperLucius': {
-                return LegendaryEventEnum.Lucius;
-            }
-            case 'tauFarsight': {
-                return LegendaryEventEnum.Farsight;
-            }
-            case 'votanUthar': {
-                return LegendaryEventEnum.Uthar;
-            }
-            default: {
-                return undefined;
-            }
-        }
+        return LegendaryEventService.getEventByCharacterSnowprintId(charId)?.id;
     }
 
     /**


### PR DESCRIPTION
## Summary
- `mapEventId` in `le-progress.service.ts` required a manual switch-case update every time a new Legendary Event shipped; a forgotten update caused sync errors.
- Now delegates to `LegendaryEventService.getEventByCharacterSnowprintId`, which is already built from each LE's data file, so new events are picked up automatically.

## Test plan
- [x] `npm run tsc` clean
- [x] `npx eslint` clean on the changed file
- [x] `npx vitest run` — all 1274 tests pass, including `le-progress.service.spec.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved event identification and character resolution for LRE progress tracking.
  * Removed hardcoded event mappings, helping keep results accurate as events change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->