### PR TITLE
Fix HSE raid-points detection for trackers restricted to non-raid modes

### DIFF
--- a/src/fsd/4-entities/homescreen_events/homescreen-event.utils.spec.ts
+++ b/src/fsd/4-entities/homescreen_events/homescreen-event.utils.spec.ts
@@ -207,4 +207,9 @@ describe('hseEarnsRaidPoints', () => {
         const resolved = resolveHseTier(findEvent('arsenal_of_war'), 'high');
         expect(hseEarnsRaidPoints(resolved!.tier, 'arsenal_of_war')).toBe(false);
     });
+
+    it('is false for an event whose killUnits tracker is restricted to non-raid modes (Arena/Onslaught/Salvage Run)', () => {
+        const resolved = resolveHseTier(findEvent('hse_trait_boost_terminator_armour'), 'high');
+        expect(hseEarnsRaidPoints(resolved!.tier, 'hse_trait_boost_terminator_armour')).toBe(false);
+    });
 });

--- a/src/fsd/4-entities/homescreen_events/homescreen-event.utils.ts
+++ b/src/fsd/4-entities/homescreen_events/homescreen-event.utils.ts
@@ -68,14 +68,30 @@ export function getHseTierKeyForRoster(pl: number, hasBlueStarUnit: boolean): Ho
     return tier === 'medium' ? 'mid' : tier;
 }
 
+// Mirrors UpgradesService.getBattleGameModeId in upgrades.service.ts — the mode ids a real raid
+// location can resolve to. Kept in sync manually; if that mapping changes, update this too.
+const CAMPAIGN_BATTLE_MODE_IDS = [
+    'Campaign',
+    'MirrorCampaign',
+    'EliteCampaign',
+    'MirrorEliteCampaign',
+    'CampaignEvent',
+];
+
 /**
- * True if this resolved tier has a `killUnits` tracker, or a manual override — i.e. it earns
- * points via campaign-battle raiding at all. Deliberately mirrors `getGenericHsePoints` in
- * upgrades.service.ts at a coarser grain (existence check only, no per-battle scoring).
+ * True if this resolved tier has a `killUnits` tracker whose restrictions actually permit at
+ * least one real campaign-battle mode id, or has a manual override — i.e. it earns points via
+ * campaign-battle raiding at all. A tracker restricted to only PvP/Waves/TreasureBeach/etc.
+ * (Arena/Onslaught/Salvage Run) doesn't count, even though it's still a `killUnits` tracker.
+ * Deliberately mirrors `getGenericHsePoints` in upgrades.service.ts, checking abstractly across
+ * every possible campaign mode id instead of one concrete battle's.
  */
 export function hseEarnsRaidPoints(tier: HomescreenEventTier, eventName: string): boolean {
-    const hasKillUnitsTracker = tier.liveEventConfig?.trackers?.some(t => t.type === 'killUnits') ?? false;
-    return hasKillUnitsTracker || Boolean(hseRaidPointsOverrides[eventName]);
+    const killUnitsTrackers = tier.liveEventConfig?.trackers?.filter(t => t.type === 'killUnits') ?? [];
+    const earnsFromRaiding = killUnitsTrackers.some(tracker =>
+        CAMPAIGN_BATTLE_MODE_IDS.some(modeId => matchesRestriction(tracker.gameModeRestrictions, tag => tag === modeId))
+    );
+    return earnsFromRaiding || Boolean(hseRaidPointsOverrides[eventName]);
 }
 
 /**


### PR DESCRIPTION
## Summary
- `hseEarnsRaidPoints` only checked whether a `killUnits` tracker existed, not whether its `gameModeRestrictions` actually permitted a real campaign-battle mode id.
- Events like Terminator Armour Boost only earn points from Arena/Onslaught/Salvage Run (`PvP`/`Waves`/`TreasureBeach` tags), never from raiding — but the Daily Raids page's upcoming-HSE banner was telling players to "plan your energy" for them anyway.
- Now checks each tracker against the real campaign-battle mode ids (mirroring `UpgradesService.getGenericHsePoints`'s actual scoring logic), fixing the same false positive on 17 other events (`hse-trait-boost-rapid-assault`, `trait-boost-flying`, `trait-boost-psyker`, `squig-smash`, the three `faction-boost-*` events, `for-the-dark-gods`/`for-the-emperor`, and the six `hse-11th-edition-week*` files).

## Test plan
- [x] Added a regression test asserting `hseEarnsRaidPoints` is `false` for `hse_trait_boost_terminator_armour`
- [x] `npx vitest run src/fsd/4-entities/homescreen_events/homescreen-event.utils.spec.ts` — all 24 tests pass
- [x] `npm run tsc` clean
- [x] `npx eslint` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected raid point eligibility for events with restricted kill-unit tracking.
  - Events limited to non-campaign modes, such as PvP or Waves, no longer incorrectly award raid points.
  - Campaign, Mirror Campaign, Elite Campaign, Mirror Elite Campaign, and Campaign Event modes continue to qualify appropriately.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->