### PR TITLE
Allow ignoring the unlock status when setting ascend goals

### DIFF
--- a/src/shared-components/goals/set-goal-dialog.tsx
+++ b/src/shared-components/goals/set-goal-dialog.tsx
@@ -366,6 +366,7 @@ export const SetGoalDialog = ({ onClose }: { onClose?: (goal?: IPersonalGoal) =>
                 <PortalDialog.Body>
                     <Conditional
                         condition={[
+                            PersonalGoalType.Ascend,
                             PersonalGoalType.UpgradeRank,
                             PersonalGoalType.MowAbilities,
                             PersonalGoalType.CharacterAbilities,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the rank and rarity restriction toggle to Ascend goals in the goal-setting dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->