### PR TITLE
Stack radar chart and ability graphs on their own rows on mobile

### DIFF
--- a/src/fsd/1-pages/who-you-own/unit-details-page.tsx
+++ b/src/fsd/1-pages/who-you-own/unit-details-page.tsx
@@ -86,7 +86,7 @@ const AbilityPanel = ({
     const scaledVariableNames = disableScaling ? [] : (ability?.variablesAffectedByRarityBonus ?? []);
 
     return (
-        <div className="flex w-full max-w-xl min-w-0 flex-1 flex-col gap-1 sm:min-w-80">
+        <div className="flex w-full max-w-xl min-w-0 basis-full flex-col gap-1 lg:min-w-80 lg:flex-1 lg:basis-auto">
             <span className="text-xs text-(--soft-fg)">{label}</span>
             {ability ? (
                 <div className="rounded-md bg-(--ability-panel)">
@@ -575,7 +575,7 @@ export const UnitDetailsPage = ({ unit, prevUnit, nextUnit, onNavigate, onClose 
                             unitName={unit.name}
                             factionId={unit.faction}
                         />
-                        <div className="flex w-full max-w-[320px] min-w-64 flex-1 flex-col items-center gap-1">
+                        <div className="flex w-full basis-full flex-col items-center gap-1 lg:max-w-[320px] lg:min-w-64 lg:flex-1 lg:basis-auto">
                             <span className="self-start text-xs text-(--soft-fg)">Stat percentiles</span>
                             <UnitStatRadarChart snowprintId={char.snowprintId} />
                         </div>


### PR DESCRIPTION
## Summary
- On the unit details page, the abilities row placed the Active/Passive ability graphs and the "Stat percentiles" radar chart in one `flex flex-wrap` row. Below `lg`, ability panels were allowed to shrink (`min-w-0`) while the radar wrapper kept a hard `min-w-64` floor, so the radar never wrapped to its own line and squished the ability graph next to it.
- Each child of that row now goes full width (`basis-full`) below `lg`; the multi-across layout is restored at `lg` via `lg:` variants, so desktop is unchanged.
- Same change applies to `AbilityPanel`, which the MoW branch also uses — its 3 ability graphs now stack one-per-line on mobile instead of cramming across.

## Test plan
- [ ] Open a character unit details page, narrow viewport below `lg` (~390px, ~800px): Active graph, Passive graph, and radar chart each on their own full-width row; radar centered; nothing squished.
- [ ] At `lg`+ width: layout identical to before (growth chart + Active + Passive + radar across the row).
- [ ] Open a MoW unit details page: 3 ability graphs stack one-per-line on mobile; across the row at `lg`.
- [ ] `npm run tsc`, `npm run lint`, `npm test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved responsive layout for ability and stat percentile panels.
  - Panels now occupy the full width on smaller screens and use flexible sizing on larger displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->