### PR TITLE
Add Survival and Product Calendar menu items to mobile navigation

### DIFF
--- a/src/mobile-routes/events/plan-routes.tsx
+++ b/src/mobile-routes/events/plan-routes.tsx
@@ -32,6 +32,7 @@ export const PlanRoutes = () => {
     const questsMenuItem = menuItemById['quests'];
     const cesMenuItem = menuItemById['ces'];
     const hsesMenuItem = menuItemById['hses'];
+    const survivalMenuItem = menuItemById['survival'];
 
     const [selectedRoutes, setSelectedRoutes] = useState<SelectedRoutes>(SelectedRoutes.all);
 
@@ -49,6 +50,7 @@ export const PlanRoutes = () => {
                         hsesMenuItem,
                         shopEventsMenuItem,
                         bulkGoalCreatorMenuItem,
+                        survivalMenuItem,
                     ].map(menuItem => (
                         <MobileNavCard
                             key={menuItem.label}

--- a/src/models/menu-items.tsx
+++ b/src/models/menu-items.tsx
@@ -174,6 +174,7 @@ export const learnSubMenuMobile: MenuItemTP[] = [
     menuItemById['dirtyDozen'],
     menuItemById['insights'],
     menuItemById['guildPerformance'],
+    menuItemById['productCalendar'],
 ];
 
 export const learnSubMenu: MenuItemTP[] = [


### PR DESCRIPTION
## Summary
- Mobile navigation is built from lists separate from desktop: the mobile Plan page uses a hardcoded array in `src/mobile-routes/events/plan-routes.tsx`, and the mobile Learn page maps `learnSubMenuMobile`. As a result **Survival** (`/plan/survival`) and **Product Calendar** (`/learn/productCalendar`) were reachable by route but had no mobile menu link.
- Added `survivalMenuItem` to the mobile Plan nav-card list (last entry, above the Guild War / LRE category cards) — matches desktop ordering.
- Added `productCalendar` to `learnSubMenuMobile` (last entry) — matches `learnSubMenu` ordering.
- Desktop sidebar and hamburger menus are unchanged.

Still out of sync (not addressed here): LRE Archive / inactive LREs (mobile-only sidebar item, needs mobile LRE drill-down work), Contacts and Thank You (hamburger Misc only, no mobile Misc surface).

## Test plan
- [ ] `/mobile/plan` shows a Survival card that navigates to `/mobile/plan/survival`.
- [ ] `/mobile/learn` shows a Product Calendar card that navigates to `/mobile/learn/productCalendar`.
- [ ] Desktop sidebar + hamburger menus unchanged.
- [ ] `npm run tsc`, `npm run lint`, `npm test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Survival option to the mobile navigation routes.
  * Added Product Calendar to the mobile Learn submenu for easier access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->