### PR TITLE
feat: add account purge UI

### DIFF
--- a/src/fsd/2-widgets/sidebar/account-dock/account-dock.tsx
+++ b/src/fsd/2-widgets/sidebar/account-dock/account-dock.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable import-x/no-internal-modules */
 import { Computer as ComputerIcon, Smartphone as PhoneIcon } from '@mui/icons-material';
+import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
 import DownloadIcon from '@mui/icons-material/Download';
 import GroupWorkIcon from '@mui/icons-material/GroupWork';
 import LoginIcon from '@mui/icons-material/Login';
@@ -23,6 +24,7 @@ import { convertData, PersonalDataLocalStorage } from 'src/services';
 import { AdminToolsDialog } from 'src/shared-components/user-menu/admin-tools-dialog';
 import { LoginUserDialog } from 'src/shared-components/user-menu/login-user-dialog';
 import { OverrideDataDialog } from 'src/shared-components/user-menu/override-data-dialog';
+import { PurgeUserDataDialog } from 'src/shared-components/user-menu/purge-user-data-dialog';
 import { RegisterUserDialog } from 'src/shared-components/user-menu/register-user-dialog';
 import { RestoreBackupDialog } from 'src/shared-components/user-menu/restore-backup-dialog';
 
@@ -115,6 +117,7 @@ export const AccountDock = ({ collapsed = false }: AccountDockProps) => {
     const [showLoginUser, setShowLoginUser] = useState(false);
     const [showRestoreBackup, setShowRestoreBackup] = useState(false);
     const [showOverrideDataWarning, setShowOverrideDataWarning] = useState(false);
+    const [showPurgeUserData, setShowPurgeUserData] = useState(false);
 
     const lastSyncSec = store.gameModeTokens?.tokens?.lastSetAtSecondsUtc;
     const syncMeta = getSyncMeta(lastSyncSec);
@@ -384,16 +387,28 @@ export const AccountDock = ({ collapsed = false }: AccountDockProps) => {
             {/* Auth */}
             <hr className="mx-2 my-1 border-(--border)" />
             {isAuthenticated ? (
-                <button
-                    className={dangerItemClass}
-                    role="menuitem"
-                    onClick={() => {
-                        logout();
-                        closeMenu();
-                    }}>
-                    <LogoutIcon className="flex-shrink-0 !text-[16px]" />
-                    <span>Logout</span>
-                </button>
+                <>
+                    <button
+                        className={dangerItemClass}
+                        role="menuitem"
+                        onClick={() => {
+                            logout();
+                            closeMenu();
+                        }}>
+                        <LogoutIcon className={iconClass} />
+                        <span>Logout</span>
+                    </button>
+                    <button
+                        className={dangerItemClass}
+                        role="menuitem"
+                        onClick={() => {
+                            setShowPurgeUserData(true);
+                            closeMenu();
+                        }}>
+                        <DeleteForeverIcon className={iconClass} />
+                        <span>Delete account</span>
+                    </button>
+                </>
             ) : (
                 <>
                     <button
@@ -521,6 +536,7 @@ export const AccountDock = ({ collapsed = false }: AccountDockProps) => {
                 }}
             />
             <AdminToolsDialog isOpen={showAdminTools} onClose={() => setShowAdminTools(false)} />
+            <PurgeUserDataDialog isOpen={showPurgeUserData} onClose={() => setShowPurgeUserData(false)} />
         </>
     );
 };

--- a/src/shared-components/user-menu/auth.endpoints.ts
+++ b/src/shared-components/user-menu/auth.endpoints.ts
@@ -27,3 +27,6 @@ export const loginUser = async (username: string, password: string) => {
     if (error) throw error;
     return { data, error: undefined };
 };
+
+/** Permanently removes the currently authenticated user's account and owned server data. */
+export const purgeUserData = () => makeApiCall<void>('DELETE', 'users/me');

--- a/src/shared-components/user-menu/purge-user-data-dialog.spec.tsx
+++ b/src/shared-components/user-menu/purge-user-data-dialog.spec.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { SnackbarProvider } from 'notistack';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AuthContext } from '@/fsd/5-shared/model/auth';
+import { IUserInfo } from '@/fsd/5-shared/model/user-info.model';
+import { UserRole } from '@/fsd/5-shared/model/user-role.enum';
+
+import { purgeUserData } from './auth.endpoints';
+import { PurgeUserDataDialog } from './purge-user-data-dialog';
+
+vi.mock('./auth.endpoints', () => ({ purgeUserData: vi.fn() }));
+
+const purgeUserDataMock = vi.mocked(purgeUserData);
+const logoutMock = vi.fn();
+const onCloseMock = vi.fn();
+const userInfo: IUserInfo = {
+    username: 'Tactician',
+    userId: 1,
+    role: UserRole.user,
+    pendingTeamsCount: 0,
+    rejectedTeamsCount: 0,
+    tacticusApiKey: '',
+    tacticusUserId: '',
+    tacticusGuildApiKey: '',
+};
+
+const renderDialog = () =>
+    render(
+        <SnackbarProvider>
+            <AuthContext.Provider
+                value={{
+                    username: 'Tactician',
+                    isAuthenticated: true,
+                    token: 'token',
+                    userInfo,
+                    login: vi.fn(),
+                    logout: logoutMock,
+                    setUser: vi.fn(),
+                    setUserInfo: vi.fn(),
+                }}>
+                <PurgeUserDataDialog isOpen onClose={onCloseMock} />
+            </AuthContext.Provider>
+        </SnackbarProvider>
+    );
+
+describe('PurgeUserDataDialog', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('purges the server account and logs out after a successful deletion', async () => {
+        purgeUserDataMock.mockResolvedValue({ data: undefined, error: undefined });
+        renderDialog();
+
+        const deleteButton = screen.getByRole('button', { name: 'Delete account' });
+        expect(deleteButton).toBeDisabled();
+        fireEvent.change(screen.getByLabelText('Type DELETE to confirm'), { target: { value: 'DELETE' } });
+        fireEvent.click(deleteButton);
+
+        await waitFor(() => expect(purgeUserDataMock).toHaveBeenCalledOnce());
+        expect(logoutMock).toHaveBeenCalledOnce();
+        expect(onCloseMock).toHaveBeenCalledOnce();
+    });
+
+    it('keeps the user signed in when the deletion request fails', async () => {
+        purgeUserDataMock.mockResolvedValue({ data: undefined, error: 'Network error' });
+        renderDialog();
+
+        fireEvent.change(screen.getByLabelText('Type DELETE to confirm'), { target: { value: 'DELETE' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Delete account' }));
+
+        await waitFor(() => expect(purgeUserDataMock).toHaveBeenCalledOnce());
+        expect(logoutMock).not.toHaveBeenCalled();
+        expect(onCloseMock).not.toHaveBeenCalled();
+    });
+});

--- a/src/shared-components/user-menu/purge-user-data-dialog.tsx
+++ b/src/shared-components/user-menu/purge-user-data-dialog.tsx
@@ -1,0 +1,77 @@
+import { DialogActions, DialogContent, DialogContentText, DialogTitle } from '@mui/material';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import TextField from '@mui/material/TextField';
+import { enqueueSnackbar } from 'notistack';
+import { useEffect, useState } from 'react';
+
+import { useAuth } from '@/fsd/5-shared/model';
+
+import { purgeUserData } from './auth.endpoints';
+
+interface PurgeUserDataDialogProps {
+    isOpen: boolean;
+    onClose: () => void;
+}
+
+/** Confirms and performs the irreversible deletion of the signed-in user's server account. */
+export const PurgeUserDataDialog = ({ isOpen, onClose }: PurgeUserDataDialogProps) => {
+    const { logout } = useAuth();
+    const [isPurging, setIsPurging] = useState(false);
+    const [confirmation, setConfirmation] = useState('');
+
+    useEffect(() => {
+        if (!isOpen) setConfirmation('');
+    }, [isOpen]);
+
+    const handlePurge = async () => {
+        setIsPurging(true);
+        const { error } = await purgeUserData();
+        setIsPurging(false);
+
+        if (error) {
+            enqueueSnackbar('Could not delete your account. Please try again.', { variant: 'error' });
+            return;
+        }
+
+        logout();
+        enqueueSnackbar('Your account has been deleted.', { variant: 'success' });
+        onClose();
+    };
+
+    return (
+        <Dialog open={isOpen} onClose={isPurging ? undefined : onClose} fullWidth maxWidth="sm">
+            <DialogTitle>Delete account?</DialogTitle>
+            <DialogContent>
+                <DialogContentText>
+                    This permanently deletes your account, likes, saved planner data, and linked guild roster data. It
+                    cannot be undone.
+                </DialogContentText>
+                <DialogContentText className="mt-3">
+                    Guides you authored or moderated remain available as community content, but no longer identify you.
+                </DialogContentText>
+                <TextField
+                    autoComplete="off"
+                    autoFocus
+                    fullWidth
+                    label="Type DELETE to confirm"
+                    margin="normal"
+                    onChange={event_ => setConfirmation(event_.target.value)}
+                    value={confirmation}
+                />
+            </DialogContent>
+            <DialogActions>
+                <Button disabled={isPurging} onClick={onClose}>
+                    Cancel
+                </Button>
+                <Button
+                    color="error"
+                    disabled={isPurging || confirmation !== 'DELETE'}
+                    variant="contained"
+                    onClick={handlePurge}>
+                    {isPurging ? 'Deleting…' : 'Delete account'}
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+};

--- a/src/shared-components/user-menu/user-menu.tsx
+++ b/src/shared-components/user-menu/user-menu.tsx
@@ -1,4 +1,5 @@
 import { Computer as ComputerIcon, Smartphone as PhoneIcon } from '@mui/icons-material';
+import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
 import DownloadIcon from '@mui/icons-material/Download';
 import GroupWorkIcon from '@mui/icons-material/GroupWork';
 import LoginIcon from '@mui/icons-material/Login';
@@ -30,6 +31,7 @@ import { TacticusIntegrationDialog } from '@/fsd/3-features/tacticus-integration
 
 import { LoginUserDialog } from './login-user-dialog';
 import { OverrideDataDialog } from './override-data-dialog';
+import { PurgeUserDataDialog } from './purge-user-data-dialog';
 import { RegisterUserDialog } from './register-user-dialog';
 import { RestoreBackupDialog } from './restore-backup-dialog';
 
@@ -77,6 +79,7 @@ export const UserMenu = ({ compact = false }: UserMenuProps) => {
     const [showRestoreBackup, setShowRestoreBackup] = useState(false);
     const [debugMode, setDebugMode] = useState(() => localStorage.getItem('debugMode') === 'true');
     const [showOverrideDataWarning, setShowOverrideDataWarning] = useState(false);
+    const [showPurgeUserData, setShowPurgeUserData] = useState(false);
     const userMenuControls = usePopUpControls();
     const navigate = useNavigate();
     const location = useLocation();
@@ -266,15 +269,26 @@ export const UserMenu = ({ compact = false }: UserMenuProps) => {
                 anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}>
                 {/* Auth */}
                 {isAuthenticated ? (
-                    <button
-                        className="flex w-full cursor-pointer items-center gap-2.5 rounded-lg border-none bg-transparent px-2 py-1.5 text-left text-[13px] text-(--danger) transition-colors hover:bg-(--danger)/14 hover:text-red-500 focus-visible:ring-2 focus-visible:ring-(--ring) focus-visible:ring-inset dark:hover:text-red-400"
-                        onClick={() => {
-                            logout();
-                            close();
-                        }}>
-                        <LogoutIcon className={iconClass} />
-                        <span>Logout</span>
-                    </button>
+                    <>
+                        <button
+                            className="flex w-full cursor-pointer items-center gap-2.5 rounded-lg border-none bg-transparent px-2 py-1.5 text-left text-[13px] text-(--danger) transition-colors hover:bg-(--danger)/14 hover:text-red-500 focus-visible:ring-2 focus-visible:ring-(--ring) focus-visible:ring-inset dark:hover:text-red-400"
+                            onClick={() => {
+                                logout();
+                                close();
+                            }}>
+                            <LogoutIcon className={iconClass} />
+                            <span>Logout</span>
+                        </button>
+                        <button
+                            className="flex w-full cursor-pointer items-center gap-2.5 rounded-lg border-none bg-transparent px-2 py-1.5 text-left text-[13px] text-(--danger) transition-colors hover:bg-(--danger)/14 hover:text-red-500 focus-visible:ring-2 focus-visible:ring-(--ring) focus-visible:ring-inset dark:hover:text-red-400"
+                            onClick={() => {
+                                setShowPurgeUserData(true);
+                                close();
+                            }}>
+                            <DeleteForeverIcon className={iconClass} />
+                            <span>Delete account</span>
+                        </button>
+                    </>
                 ) : (
                     <>
                         <button
@@ -430,6 +444,7 @@ export const UserMenu = ({ compact = false }: UserMenuProps) => {
                     setShowAdminTools(false);
                 }}
             />
+            <PurgeUserDataDialog isOpen={showPurgeUserData} onClose={() => setShowPurgeUserData(false)} />
         </div>
     );
 };


### PR DESCRIPTION
## Summary
- add a Delete account action to both V1 account menus
- require typing DELETE before calling DELETE users/me
- log out only after a successful purge and retain the session on failure

## Verification
- npm test -- --run src/shared-components/user-menu/purge-user-data-dialog.spec.tsx
- npx eslint src/shared-components/user-menu/auth.endpoints.ts src/shared-components/user-menu/purge-user-data-dialog.tsx src/shared-components/user-menu/purge-user-data-dialog.spec.tsx src/shared-components/user-menu/user-menu.tsx src/fsd/2-widgets/sidebar/account-dock/account-dock.tsx
- npm run tsc *(fails on existing unrelated TypeScript configuration/source errors)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Delete account” option to the authenticated user menu.
  * Added a confirmation dialog requiring users to type “DELETE” before permanently deleting their account and associated data.
  * Successful deletion signs the user out and displays a confirmation message.

* **Bug Fixes**
  * Failed account deletion attempts keep the user signed in and leave the dialog open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->