### PR TITLE
Guild performance: highlight selected line, fix oval boss-icon rings, sortable Overview columns

### DIFF
--- a/src/fsd/1-pages/learn-guild-performance/guild-performance.components.tsx
+++ b/src/fsd/1-pages/learn-guild-performance/guild-performance.components.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure */
-import { Camera, ChevronDown, Minus, Plus } from 'lucide-react';
+import { Camera, ChevronDown, ChevronsUpDown, ChevronUp, Minus, Plus } from 'lucide-react';
 import { type ReactNode } from 'react';
 
 import { CAPTURE_EXPAND_ATTRIBUTE, CAPTURE_IGNORE_ATTRIBUTE, cn } from '@/fsd/5-shared/lib';
@@ -240,10 +240,14 @@ export const TableCardHeader = ({ children, className }: { children: ReactNode; 
     </div>
 );
 
-export type ColumnLabel = string | { text: string; align?: 'center' | 'right'; span?: 2 | 3 };
+export type ColumnLabel = string | { text: string; align?: 'center' | 'right'; span?: 2 | 3; sortKey?: string };
+
+export type ColumnSort = { key: string; direction: 'asc' | 'desc' };
 
 /** Literal so Tailwind's JIT can see them; `span` values are constrained to match. */
 const COL_SPAN = { 2: 'col-span-2', 3: 'col-span-3' } as const;
+
+const ARIA_SORT = { asc: 'ascending', desc: 'descending' } as const;
 
 /**
  * Header row for a CSS-grid table. Every table on this page gets one — several had none.
@@ -253,7 +257,19 @@ const COL_SPAN = { 2: 'col-span-2', 3: 'col-span-3' } as const;
  * from a real table has to be restored with roles. Every consumer must therefore sit inside an
  * element with `role="table"`.
  */
-export const ColumnHeader = ({ cols, labels }: { cols: string; labels: ColumnLabel[] }) => (
+export const ColumnHeader = ({
+    cols,
+    labels,
+    sort,
+    onSort,
+}: {
+    cols: string;
+    labels: ColumnLabel[];
+    /** Active sort, when the table is sortable. */
+    sort?: ColumnSort;
+    /** Provided to make columns whose label carries a `sortKey` clickable. */
+    onSort?: (key: string) => void;
+}) => (
     <div
         role="row"
         className={cn(
@@ -263,11 +279,15 @@ export const ColumnHeader = ({ cols, labels }: { cols: string; labels: ColumnLab
             'items-center gap-x-2.5 border-b border-(--border) bg-(--soft) px-2.5 py-1.5 [&>*]:min-w-0'
         )}>
         {labels.map((label, index) => {
-            const { text, align, span } = typeof label === 'string' ? { text: label } : label;
+            const { text, align, span, sortKey } = typeof label === 'string' ? { text: label } : label;
+            const sortable = sortKey !== undefined && onSort !== undefined;
+            const activeDirection = sortable && sort && sort.key === sortKey ? sort.direction : undefined;
+            const ariaSort = sortable ? (activeDirection ? ARIA_SORT[activeDirection] : 'none') : undefined;
             return (
                 <span
                     role="columnheader"
                     key={index}
+                    aria-sort={ariaSort}
                     className={cn(
                         'truncate text-xs font-bold tracking-widest text-(--soft-fg) uppercase',
                         align === 'right' && 'text-right',
@@ -276,7 +296,26 @@ export const ColumnHeader = ({ cols, labels }: { cols: string; labels: ColumnLab
                         // a single label rather than each getting an unreadable, clipped one.
                         span !== undefined && COL_SPAN[span]
                     )}>
-                    {text}
+                    {sortKey !== undefined && onSort !== undefined ? (
+                        <button
+                            type="button"
+                            onClick={() => onSort(sortKey)}
+                            className={cn(
+                                'inline-flex max-w-full cursor-pointer items-center gap-0.5 hover:text-(--fg)',
+                                activeDirection !== undefined && 'text-(--fg)'
+                            )}>
+                            <span className="truncate">{text}</span>
+                            {activeDirection === 'asc' ? (
+                                <ChevronUp className="size-3 shrink-0" aria-hidden />
+                            ) : activeDirection === 'desc' ? (
+                                <ChevronDown className="size-3 shrink-0" aria-hidden />
+                            ) : (
+                                <ChevronsUpDown className="size-3 shrink-0 opacity-40" aria-hidden />
+                            )}
+                        </button>
+                    ) : (
+                        text
+                    )}
                 </span>
             );
         })}
@@ -407,6 +446,15 @@ const RARITY_RING_CLASS: Record<Rarity, string> = {
 };
 
 /**
+ * The rarity ring around a boss/prime portrait. `inline-flex items-center justify-center` is
+ * load-bearing, not decoration: the child (`UnitShardIcon`) is `inline-block`, so without a flex
+ * context this span's box is the line box — taller than wide from the baseline strut — and
+ * `rounded-full` then paints an ellipse with the art sitting high. Same fix as `guild-performance.styles.ts`.
+ */
+const rarityRingClass = (rarity: Rarity) =>
+    `inline-flex items-center justify-center rounded-full ring-2 ${RARITY_RING_CLASS[rarity]}`;
+
+/**
  * Portrait toggles for a list of boss/prime options. Generic over the option type: bosses pass a
  * `BossFilterOption` (keyed by its `key`, distinct per boss slot), primes pass their bare unitId
  * string (keyed by itself).
@@ -444,7 +492,7 @@ export const PrefixFilter = <T,>({
                 const isActive = selected.includes(key);
                 const { icon, name } = iconFor(option);
                 const rarity = getRarity?.(option);
-                const ringClass = rarity === undefined ? undefined : `rounded-full ring-2 ${RARITY_RING_CLASS[rarity]}`;
+                const ringClass = rarity === undefined ? undefined : rarityRingClass(rarity);
                 return (
                     <button
                         key={key}
@@ -534,7 +582,7 @@ export const EncounterIcon = ({
     if (unitId === undefined) return <div style={{ width: size, height: size }} />;
 
     const label = tooltip ?? unitDisplayLabel(unitId);
-    const ringClass = rarity === undefined ? undefined : `rounded-full ring-2 ${RARITY_RING_CLASS[rarity]}`;
+    const ringClass = rarity === undefined ? undefined : rarityRingClass(rarity);
 
     const mappedIcon = unitRoundIconMap[unitId];
     if (mappedIcon !== undefined) {

--- a/src/fsd/1-pages/learn-guild-performance/guild-performance.utils.spec.ts
+++ b/src/fsd/1-pages/learn-guild-performance/guild-performance.utils.spec.ts
@@ -16,7 +16,9 @@ import {
     getBossPrefix,
     getBossSlotKey,
     resolveBossOverviewDisplay,
+    sortTokenEntriesBy,
     unitDisplayLabel,
+    type GuildTokenEntryWithDisplay,
 } from './guild-performance.utils';
 
 // Bosses rotate between ladder positions as Snowprint updates the season config, so these are
@@ -191,5 +193,76 @@ describe('bossIconFor', () => {
         // shown alongside it) needs to disambiguate them.
         expect(leviathan.name).toBe('Hive Tyrant');
         expect(kronos.name).toBe('Hive Tyrant');
+    });
+});
+
+describe('sortTokenEntriesBy', () => {
+    const ann: GuildTokenEntryWithDisplay = {
+        userId: 'ann',
+        displayName: 'Ann',
+        tokens: 1,
+        nextTokenAtUtc: 300,
+        bombAvailableAtUtc: 900, // bomb on cooldown → "used"
+    };
+    const bob: GuildTokenEntryWithDisplay = {
+        userId: 'bob',
+        displayName: 'Bob',
+        tokens: 3,
+        nextTokenAtUtc: undefined, // "Full"
+        bombAvailableAtUtc: undefined, // bomb ready now
+    };
+    const cid: GuildTokenEntryWithDisplay = {
+        userId: 'cid',
+        displayName: 'Cid',
+        tokens: 1,
+        nextTokenAtUtc: 100,
+        bombAvailableAtUtc: undefined, // bomb ready now
+    };
+    const dan: GuildTokenEntryWithDisplay = {
+        userId: 'dan',
+        displayName: 'Dan',
+        tokens: undefined, // no readiness data at all
+        nextTokenAtUtc: undefined,
+        bombAvailableAtUtc: undefined,
+    };
+    const all = [dan, cid, bob, ann];
+    const order = (column: 'tokens' | 'nextToken' | 'bomb' | 'bombReady', direction: 'asc' | 'desc') =>
+        sortTokenEntriesBy(all, column, direction).map(entry => entry.displayName);
+
+    it('sorts by token count ascending, no-data rows last, ties broken by name A→Z', () => {
+        expect(order('tokens', 'asc')).toEqual(['Ann', 'Cid', 'Bob', 'Dan']);
+    });
+
+    it('sorts by token count descending, no-data rows still last, ties still A→Z', () => {
+        expect(order('tokens', 'desc')).toEqual(['Bob', 'Ann', 'Cid', 'Dan']);
+    });
+
+    it('sorts by next-token time, treating "Full" (undefined) as zero wait', () => {
+        expect(order('nextToken', 'asc')).toEqual(['Bob', 'Cid', 'Ann', 'Dan']);
+        expect(order('nextToken', 'desc')).toEqual(['Ann', 'Cid', 'Bob', 'Dan']);
+    });
+
+    it('sorts by bomb-ready time, treating ready-now (undefined) as zero', () => {
+        expect(order('bombReady', 'asc')).toEqual(['Bob', 'Cid', 'Ann', 'Dan']);
+        expect(order('bombReady', 'desc')).toEqual(['Ann', 'Bob', 'Cid', 'Dan']);
+    });
+
+    it('sorts by bomb readiness — used before ready ascending, ready before used descending', () => {
+        expect(order('bomb', 'asc')).toEqual(['Ann', 'Bob', 'Cid', 'Dan']);
+        expect(order('bomb', 'desc')).toEqual(['Bob', 'Cid', 'Ann', 'Dan']);
+    });
+
+    it('keeps rows with no readiness data at the bottom for every column and direction', () => {
+        for (const column of ['tokens', 'nextToken', 'bomb', 'bombReady'] as const) {
+            for (const direction of ['asc', 'desc'] as const) {
+                expect(order(column, direction).at(-1)).toBe('Dan');
+            }
+        }
+    });
+
+    it('does not mutate its input', () => {
+        const input = [...all];
+        sortTokenEntriesBy(input, 'tokens', 'desc');
+        expect(input).toEqual(all);
     });
 });

--- a/src/fsd/1-pages/learn-guild-performance/guild-performance.utils.ts
+++ b/src/fsd/1-pages/learn-guild-performance/guild-performance.utils.ts
@@ -160,17 +160,48 @@ export function sortTokenEntries(entries: GuildTokenEntryWithDisplay[]): GuildTo
     });
 }
 
-export function sortBombEntries(entries: GuildTokenEntryWithDisplay[]): GuildTokenEntryWithDisplay[] {
-    // "has bomb" (bombAvailableAtUtc null = bomb ready) sorts above "no bomb"
+export type TokenSortColumn = 'tokens' | 'nextToken' | 'bomb' | 'bombReady';
+export type SortDirection = 'asc' | 'desc';
+
+/**
+ * Single-column sort for the roster readiness table. Rows with no readiness data
+ * (`tokens == undefined`) always sink to the bottom regardless of direction; equal values
+ * tie-break by display name A→Z. `?? 0` on the time columns matches `sortTokenEntries`'
+ * treatment of "Full" / "ready now" as zero wait.
+ */
+export function sortTokenEntriesBy(
+    entries: GuildTokenEntryWithDisplay[],
+    column: TokenSortColumn,
+    direction: SortDirection
+): GuildTokenEntryWithDisplay[] {
+    const sign = direction === 'asc' ? 1 : -1;
     return entries.toSorted((a, b) => {
-        const aHas = a.tokens != undefined && a.bombAvailableAtUtc == undefined ? 1 : 0;
-        const bHas = b.tokens != undefined && b.bombAvailableAtUtc == undefined ? 1 : 0;
-        if (bHas !== aHas) return bHas - aHas;
+        const aHas = a.tokens != undefined;
+        const bHas = b.tokens != undefined;
+        if (aHas !== bHas) return aHas ? -1 : 1;
 
-        const aNext = a.bombAvailableAtUtc ?? 0;
-        const bNext = b.bombAvailableAtUtc ?? 0;
-        if (bNext !== aNext) return bNext - aNext;
+        let cmp = 0;
+        switch (column) {
+            case 'tokens': {
+                cmp = (a.tokens ?? 0) - (b.tokens ?? 0);
+                break;
+            }
+            case 'nextToken': {
+                cmp = (a.nextTokenAtUtc ?? 0) - (b.nextTokenAtUtc ?? 0);
+                break;
+            }
+            case 'bombReady': {
+                cmp = (a.bombAvailableAtUtc ?? 0) - (b.bombAvailableAtUtc ?? 0);
+                break;
+            }
+            case 'bomb': {
+                // A null cooldown means the bomb is ready now, which sorts as the higher value.
+                cmp = (a.bombAvailableAtUtc == undefined ? 1 : 0) - (b.bombAvailableAtUtc == undefined ? 1 : 0);
+                break;
+            }
+        }
 
+        if (cmp !== 0) return sign * cmp;
         return a.displayName.localeCompare(b.displayName);
     });
 }

--- a/src/fsd/1-pages/learn-guild-performance/tabs/historical-performance-tab.tsx
+++ b/src/fsd/1-pages/learn-guild-performance/tabs/historical-performance-tab.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure */
 import { useTheme } from '@mui/material';
-import { ResponsiveLine } from '@nivo/line';
+import { ResponsiveLine, type LineCustomSvgLayerProps } from '@nivo/line';
 import { type PartialTheme } from '@nivo/theming';
 import { useMemo, useState } from 'react';
 
@@ -28,6 +28,8 @@ const CHART_THEME: PartialTheme = {
     },
     grid: { line: { stroke: 'var(--hairline)' } },
 };
+
+type ChartSeries = { id: string; data: { x: number; y: number }[] };
 
 const LegendLine = ({ className, dashed, label }: { className: string; dashed?: boolean; label: string }) => (
     <span className="flex items-center gap-1.5">
@@ -106,6 +108,33 @@ export const HistoricalPerformanceTab = ({
     const [hoveredId, setHoveredId] = useState<string | undefined>();
     const activeId = hoveredId ?? selectedPlayerId;
 
+    // Replaces nivo's built-in `lines` layer: paints the active line last (on top) and
+    // thicker, and fades the rest while any line is active.
+    // eslint-disable-next-line react/no-unstable-nested-components -- closes over activeId; mirrors the tooltip layer below
+    const HighlightingLines = ({ series, lineGenerator }: LineCustomSvgLayerProps<ChartSeries>) => {
+        const ordered = series.toSorted(
+            (a, b) => Number(String(a.id) === activeId) - Number(String(b.id) === activeId)
+        );
+        return (
+            <g>
+                {ordered.map(serie => {
+                    const isActive = String(serie.id) === activeId;
+                    const dimmed = activeId !== undefined && !isActive;
+                    return (
+                        <path
+                            key={serie.id}
+                            d={lineGenerator(serie.data.map(d => d.position)) ?? undefined}
+                            fill="none"
+                            stroke={serie.color}
+                            strokeWidth={isActive ? 3 : 1.5}
+                            strokeOpacity={dimmed ? 0.2 : 1}
+                        />
+                    );
+                })}
+            </g>
+        );
+    };
+
     const allSeasons = useMemo(
         () => [...new Set(lines.flatMap(l => l.points.map(p => p.season)))].toSorted((a, b) => a - b),
         [lines]
@@ -156,7 +185,18 @@ export const HistoricalPerformanceTab = ({
                     yScale={{ type: 'linear', min: 0, max: 'auto' }}
                     curve="monotoneX"
                     enablePoints={false}
-                    lineWidth={1.5}
+                    layers={[
+                        'grid',
+                        'markers',
+                        'axes',
+                        'areas',
+                        'crosshair',
+                        HighlightingLines,
+                        'points',
+                        'slices',
+                        'mesh',
+                        'legends',
+                    ]}
                     useMesh
                     colors={(serie: { id: string | number }) =>
                         String(serie.id) === activeId ? activeLineColor : fadedLineColor

--- a/src/fsd/1-pages/learn-guild-performance/tabs/overview-tab.tsx
+++ b/src/fsd/1-pages/learn-guild-performance/tabs/overview-tab.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure */
 /* eslint-disable boundaries/element-types -- cross-page import for shared guild data */
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { snowprintIcons } from '@/fsd/5-shared/assets';
 import { obfuscateUserId } from '@/fsd/5-shared/lib';
@@ -39,8 +39,10 @@ import {
     formatTime,
     resolveBossOverviewDisplay,
     sortTokenEntries,
+    sortTokenEntriesBy,
     type BossDisplayHp,
     type PrimeDisplay,
+    type TokenSortColumn,
 } from '../guild-performance.utils';
 
 /** `boss` renders a thicker bar than `prime`, so the boss reads as the dominant encounter. */
@@ -273,7 +275,14 @@ const MAX_TOKENS = 3;
  */
 const ROSTER_COLS =
     'grid-cols-[minmax(150px,1.7fr)_minmax(86px,0.9fr)_minmax(92px,1fr)_minmax(74px,0.8fr)_minmax(92px,1fr)_minmax(76px,0.9fr)]';
-const ROSTER_LABELS: ColumnLabel[] = ['Player', 'Tokens', 'Next token', 'Bomb', 'Bomb ready', 'Teams'];
+const ROSTER_LABELS: ColumnLabel[] = [
+    'Player',
+    { text: 'Tokens', sortKey: 'tokens' },
+    { text: 'Next token', sortKey: 'nextToken' },
+    { text: 'Bomb', sortKey: 'bomb' },
+    { text: 'Bomb ready', sortKey: 'bombReady' },
+    'Teams',
+];
 
 /**
  * Three token icons plus `n/3`. Colour is never the only signal — the count is always spelled out.
@@ -319,23 +328,36 @@ const RosterReadinessTable = ({
     raidCompsMap: Map<string, RaidComp[]> | undefined;
     selectedComp: RaidComp | undefined;
 }) => {
-    const rows = entries.map(entry => ({
-        userId: entry.userId,
-        displayName: names.get(entry.userId) ?? entry.name ?? obfuscateUserId(entry.userId),
-        tokens: entry.tokens,
-        nextTokenAtUtc: entry.nextTokenAtUtc,
-        bombAvailableAtUtc: entry.bombAvailableAtUtc,
-    }));
-    const filtered =
-        selectedComp === undefined
-            ? rows
-            : rows.filter(row => (raidCompsMap?.get(row.userId) ?? []).includes(selectedComp));
-    const sorted = sortTokenEntries(filtered);
+    // undefined → the default composite order (`sortTokenEntries`). Clicking a header
+    // cycles asc → desc → back to the default.
+    const [sort, setSort] = useState<{ key: TokenSortColumn; direction: 'asc' | 'desc' } | undefined>();
+    const toggleSort = (key: string) =>
+        setSort(current => {
+            if (current?.key === key) {
+                return current.direction === 'asc' ? { key: current.key, direction: 'desc' } : undefined;
+            }
+            return { key: key as TokenSortColumn, direction: 'asc' };
+        });
+
+    const sorted = useMemo(() => {
+        const rows = entries.map(entry => ({
+            userId: entry.userId,
+            displayName: names.get(entry.userId) ?? entry.name ?? obfuscateUserId(entry.userId),
+            tokens: entry.tokens,
+            nextTokenAtUtc: entry.nextTokenAtUtc,
+            bombAvailableAtUtc: entry.bombAvailableAtUtc,
+        }));
+        const filtered =
+            selectedComp === undefined
+                ? rows
+                : rows.filter(row => (raidCompsMap?.get(row.userId) ?? []).includes(selectedComp));
+        return sort ? sortTokenEntriesBy(filtered, sort.key, sort.direction) : sortTokenEntries(filtered);
+    }, [entries, names, raidCompsMap, selectedComp, sort]);
 
     return (
         <ScrollX minWidth={620}>
             <div role="table" aria-label="Roster readiness">
-                <ColumnHeader cols={ROSTER_COLS} labels={ROSTER_LABELS} />
+                <ColumnHeader cols={ROSTER_COLS} labels={ROSTER_LABELS} sort={sort} onSort={toggleSort} />
                 {sorted.map(row => {
                     const hasData = row.tokens != undefined;
                     // A null bombAvailableAtUtc means the bomb is off cooldown, i.e. ready now.


### PR DESCRIPTION
Three guild-performance changes (two commits).

## Historical performance chart — emphasize the selected line
- Replaced nivo's built-in `lines` layer with a custom SVG layer: the active line (hovered, or picked in the header dropdown) is painted last (on top) and thicker; every other line fades to 20% opacity while a line is active. Resting state is unchanged.

## Boss-icon rings rendered as ovals
- The rarity ring around a boss/prime portrait (`EncounterIcon`, `PrefixFilter`) was drawn on a bare `display:inline` span, so its box followed the line box (taller than wide, baseline-heavy) and `rounded-full` painted an ellipse with the art riding high — worst in the Damage tab's Target column.
- New `rarityRingClass()` helper wraps the ring in an `inline-flex items-center justify-center` context (the fix already documented in `guild-performance.styles.ts`), so the ring is a true circle around the square icon. Shared `UnitShardIcon` is intentionally left alone (≈60 consumers app-wide).

## Sortable Overview roster columns
- The Overview tab's per-player table can now be sorted by **Tokens**, **Next token**, **Bomb**, and **Bomb ready** by clicking the column header. Each click cycles ascending → descending → back to the default composite order. Rows with no readiness data always stay at the bottom; ties break by player name.
- `ColumnHeader` gained optional `sort` / `onSort` props and a `sortKey` on `ColumnLabel` — purely additive, so the other CSS-grid tables that use it are unchanged. Sortable headers render a `<button>` with a chevron and `aria-sort`.
- New `sortTokenEntriesBy()` in `guild-performance.utils.ts` (replaces the dead `sortBombEntries`), with 8 unit tests.

## Test plan
- [ ] `npm run tsc`, `npm run lint`, `npm test` — all green (75 files / 1365 tests locally).
- [ ] Historical performance tab: hover a line / pick a player — it thickens and comes to the front, others fade.
- [ ] Damage tab Target column: rarity ring is a circle, boss art centered; spot-check Leaderboards / Performance / boss-filter toggles.
- [ ] Overview tab: click Tokens / Next token / Bomb / Bomb ready headers — asc, desc, then default; no-data players stay last; Player and Teams headers inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sortable columns to the guild performance roster for Tokens, Next token, Bomb, and Bomb ready.
  * Sorting cycles between ascending, descending, and the default order while keeping unavailable values at the bottom.
  * Added visual sorting indicators and accessibility labels to sortable column headers.
  * Improved historical performance charts by highlighting the selected series and dimming others.

* **Tests**
  * Added coverage for sorting directions, unavailable values, tie-breaking, and input preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->