### PR TITLE
Ready to Rank Up filter, accurate power calc, ability/radar UI, and bulk-goal button

### DIFF
--- a/src/fsd/1-pages/plan-bulk-goals/add-ready-to-rank-up-dialog.tsx
+++ b/src/fsd/1-pages/plan-bulk-goals/add-ready-to-rank-up-dialog.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import { Rank } from '@/fsd/5-shared/model';
+import { Button, PortalDialog, RankSelect, Switch } from '@/fsd/5-shared/ui';
+
+import { ALL_RANK_VALUES } from '@/fsd/2-widgets/unit-threshold-picker';
+
+import type { ReadyToRankUpOptions } from './bulk-goal-creator.service';
+
+const VIABLE_RANKS = ALL_RANK_VALUES.filter(rank => rank > Rank.Locked);
+
+interface Props {
+    open: boolean;
+    /** One entry per ready-to-rank-up character in the roster: that character's target rank. */
+    targetRanks: Rank[];
+    onClose: (result?: ReadyToRankUpOptions) => void;
+}
+
+export function AddReadyToRankUpDialog({ open, targetRanks, onClose }: Props) {
+    const [raiseActiveAbility, setRaiseActiveAbility] = useState(false);
+    const [raisePassiveAbility, setRaisePassiveAbility] = useState(false);
+    const [minRank, setMinRank] = useState<Rank>(Rank.Stone1);
+    const [maxRank, setMaxRank] = useState<Rank>(Rank.Adamantine2);
+
+    useEffect(() => {
+        if (open) {
+            setRaiseActiveAbility(false);
+            setRaisePassiveAbility(false);
+            setMinRank(Rank.Stone1);
+            setMaxRank(Rank.Adamantine2);
+        }
+    }, [open]);
+
+    const matchingCount = useMemo(
+        () => targetRanks.filter(rank => rank >= minRank && rank <= maxRank).length,
+        [targetRanks, minRank, maxRank]
+    );
+
+    return (
+        <PortalDialog open={open} onClose={() => onClose()} aria-label="Add Units Ready to Rank Up" size="sm">
+            <PortalDialog.Header>Add Units Ready to Rank Up</PortalDialog.Header>
+            <PortalDialog.Body>
+                <Switch isSelected={raiseActiveAbility} onChange={setRaiseActiveAbility}>
+                    Also raise Active Ability to XP level
+                </Switch>
+                <Switch isSelected={raisePassiveAbility} onChange={setRaisePassiveAbility}>
+                    Also raise Passive Ability to XP level
+                </Switch>
+                <div className="flex items-end gap-2">
+                    <RankSelect
+                        label="Minimum Viable Rank"
+                        rankValues={VIABLE_RANKS.filter(rank => rank <= maxRank)}
+                        value={minRank}
+                        valueChanges={value => setMinRank(value as Rank)}
+                    />
+                    <RankSelect
+                        label="Maximum Viable Rank"
+                        rankValues={VIABLE_RANKS.filter(rank => rank >= minRank)}
+                        value={maxRank}
+                        valueChanges={value => setMaxRank(value as Rank)}
+                    />
+                </div>
+                {matchingCount === 0 ? (
+                    <span className="text-sm text-red-600 dark:text-red-400">No units match the rank constraints</span>
+                ) : (
+                    <span className="text-sm text-zinc-500 dark:text-zinc-400">
+                        {matchingCount} unit{matchingCount === 1 ? '' : 's'}
+                    </span>
+                )}
+            </PortalDialog.Body>
+            <PortalDialog.Footer>
+                <Button intent="secondary" appearance="plain" onPress={() => onClose()}>
+                    Cancel
+                </Button>
+                <Button
+                    isDisabled={matchingCount === 0}
+                    onPress={() => onClose({ raiseActiveAbility, raisePassiveAbility, minRank, maxRank })}>
+                    Add
+                </Button>
+            </PortalDialog.Footer>
+        </PortalDialog>
+    );
+}

--- a/src/fsd/1-pages/plan-bulk-goals/bulk-goal-creator.service.spec.ts
+++ b/src/fsd/1-pages/plan-bulk-goals/bulk-goal-creator.service.spec.ts
@@ -2,7 +2,31 @@ import { describe, expect, it } from 'vitest';
 
 import { Rank, Rarity, RarityStars } from '@/fsd/5-shared/model';
 
-import { buildBulkPlannedGoals, type BulkUnitEntry, getBulkRankGoalPlans } from './bulk-goal-creator.service';
+import { ICharacter2 } from '@/fsd/4-entities/character';
+
+import {
+    buildBulkPlannedGoals,
+    buildReadyToRankUpEntries,
+    type BulkUnitEntry,
+    getBulkRankGoalPlans,
+} from './bulk-goal-creator.service';
+
+/** A character with just the fields `getRankUpTarget`/`getBulkUnitEntryFromUnit` read. */
+const makeCharacter = (overrides: Partial<ICharacter2> = {}): ICharacter2 =>
+    ({
+        snowprintId: 'test-character',
+        rank: Rank.Stone1,
+        rarity: Rarity.Common,
+        stars: RarityStars.OneStar,
+        level: 1,
+        activeAbilityLevel: 1,
+        passiveAbilityLevel: 1,
+        name: 'Test Character',
+        shortName: 'Test',
+        icon: '',
+        roundIcon: '',
+        ...overrides,
+    }) as unknown as ICharacter2;
 
 const makeCharacterEntry = (overrides: Partial<BulkUnitEntry> = {}): BulkUnitEntry => ({
     unit: {
@@ -218,5 +242,70 @@ describe('bulk-goal-creator.service', () => {
             createId: () => 'id',
         });
         expect(tierGoals.map(goal => goal.character)).toEqual(['charB', 'charA']);
+    });
+});
+
+describe('buildReadyToRankUpEntries', () => {
+    // level 50 -> Diamond3 (rankToLevel), Legendary caps at Diamond3 (RarityMapper.toMaxRank)
+    const highTarget = makeCharacter({
+        snowprintId: 'highTarget',
+        rank: Rank.Gold3,
+        rarity: Rarity.Legendary,
+        level: 50,
+        activeAbilityLevel: 5,
+        passiveAbilityLevel: 5,
+    });
+    // level 26 -> Silver1 (rankToLevel), Rare caps at Silver1 (RarityMapper.toMaxRank)
+    const midTarget = makeCharacter({
+        snowprintId: 'midTarget',
+        rank: Rank.Bronze2,
+        rarity: Rarity.Rare,
+        level: 26,
+    });
+    // level 1 -> Stone1, already at Stone1: no rank above current is reachable yet
+    const notReady = makeCharacter({ snowprintId: 'notReady', rank: Rank.Stone1, rarity: Rarity.Common, level: 1 });
+
+    const defaultOptions = {
+        raiseActiveAbility: false,
+        raisePassiveAbility: false,
+        minRank: Rank.Stone1,
+        maxRank: Rank.Adamantine3,
+    };
+
+    it('stages only ready-to-rank-up characters, sorted descending by target rank', () => {
+        const entries = buildReadyToRankUpEntries([highTarget, midTarget, notReady], new Set(), defaultOptions);
+
+        expect(entries.map(entry => entry.unit?.snowprintId)).toEqual(['highTarget', 'midTarget']);
+        expect(entries[0].rank).toBe(Rank.Diamond3);
+        expect(entries[1].rank).toBe(Rank.Silver1);
+    });
+
+    it('excludes a character whose target rank falls outside the given range', () => {
+        const entries = buildReadyToRankUpEntries([highTarget, midTarget], new Set(), {
+            ...defaultOptions,
+            minRank: Rank.Bronze1,
+            maxRank: Rank.Bronze3,
+        });
+
+        expect(entries).toEqual([]);
+    });
+
+    it('excludes a character already present in existingUnitIds', () => {
+        const entries = buildReadyToRankUpEntries([highTarget, midTarget], new Set(['highTarget']), defaultOptions);
+
+        expect(entries.map(entry => entry.unit?.snowprintId)).toEqual(['midTarget']);
+    });
+
+    it('raises active/passive ability level to the XP level only when the corresponding option is enabled', () => {
+        const [activeOnly] = buildReadyToRankUpEntries([highTarget], new Set(), {
+            ...defaultOptions,
+            raiseActiveAbility: true,
+        });
+        expect(activeOnly.activeAbilityLevel).toBe(50);
+        expect(activeOnly.passiveAbilityLevel).toBe(5);
+
+        const [neither] = buildReadyToRankUpEntries([highTarget], new Set(), defaultOptions);
+        expect(neither.activeAbilityLevel).toBe(5);
+        expect(neither.passiveAbilityLevel).toBe(5);
     });
 });

--- a/src/fsd/1-pages/plan-bulk-goals/bulk-goal-creator.service.ts
+++ b/src/fsd/1-pages/plan-bulk-goals/bulk-goal-creator.service.ts
@@ -2,10 +2,14 @@
 import { CampaignsLocationsUsage, PersonalGoalType } from 'src/models/enums';
 import { IPersonalGoal } from 'src/models/interfaces';
 
+import { filterMap } from '@/fsd/5-shared/lib';
 import { Rank, Rarity, RarityStars } from '@/fsd/5-shared/model';
 
+import { ICharacter2 } from '@/fsd/4-entities/character';
 import type { GoalCategory, RankStep } from '@/fsd/4-entities/goal';
 import { IUnit } from '@/fsd/4-entities/unit';
+
+import { getRankUpTarget } from '@/fsd/3-features/characters/functions/ready-to-rank-up';
 
 export type { GoalCategory, RankStep } from '@/fsd/4-entities/goal';
 export type IncrementalGoalMode = 'milestones' | 'full' | 'macro';
@@ -23,6 +27,77 @@ export type BulkUnitEntry = {
     preFarmLegendaryMythic: boolean;
     useIncrementalGoals: boolean;
     incrementalGoalMode: IncrementalGoalMode;
+};
+
+export const createBulkUnitEntry = (): BulkUnitEntry => ({
+    unit: undefined,
+    rank: Rank.Stone1,
+    rarity: Rarity.Common,
+    stars: 1,
+    activeAbilityLevel: 1,
+    passiveAbilityLevel: 1,
+    unlockMow: false,
+    preFarmLegendaryMythic: false,
+    useIncrementalGoals: false,
+    incrementalGoalMode: 'milestones',
+});
+
+export const getBulkUnitEntryFromUnit = (unit: IUnit | undefined): BulkUnitEntry => {
+    if (!unit) {
+        return createBulkUnitEntry();
+    }
+
+    const activeAbilityLevel = 'activeAbilityLevel' in unit ? unit.activeAbilityLevel : unit.primaryAbilityLevel;
+    const passiveAbilityLevel = 'passiveAbilityLevel' in unit ? unit.passiveAbilityLevel : unit.secondaryAbilityLevel;
+    const rank = 'rank' in unit ? unit.rank : Rank.Locked;
+
+    return {
+        unit,
+        rank,
+        rarity: unit.rarity ?? Rarity.Common,
+        stars: unit.stars ?? 1,
+        activeAbilityLevel,
+        passiveAbilityLevel,
+        unlockMow: false,
+        preFarmLegendaryMythic: false,
+        useIncrementalGoals: false,
+        incrementalGoalMode: 'milestones',
+    };
+};
+
+export interface ReadyToRankUpOptions {
+    raiseActiveAbility: boolean;
+    raisePassiveAbility: boolean;
+    minRank: Rank;
+    maxRank: Rank;
+}
+
+/**
+ * Stages one bulk-unit entry per ready-to-rank-up character whose target rank falls within
+ * `[minRank, maxRank]`, sorted descending by target rank. Characters already staged
+ * (`existingUnitIds`) or outside the rank range are skipped entirely.
+ */
+export const buildReadyToRankUpEntries = (
+    characters: ICharacter2[],
+    existingUnitIds: ReadonlySet<string | undefined>,
+    options: ReadyToRankUpOptions
+): BulkUnitEntry[] => {
+    const candidates = filterMap(characters, character => {
+        if (existingUnitIds.has(character.snowprintId)) return;
+        const target = getRankUpTarget(character);
+        if (target === undefined || target < options.minRank || target > options.maxRank) return;
+        return { unit: character, target };
+    }).toSorted((first, second) => second.target - first.target);
+
+    return candidates.map(({ unit, target }) => {
+        const entry = getBulkUnitEntryFromUnit(unit);
+        return {
+            ...entry,
+            rank: target,
+            activeAbilityLevel: options.raiseActiveAbility ? unit.level : entry.activeAbilityLevel,
+            passiveAbilityLevel: options.raisePassiveAbility ? unit.level : entry.passiveAbilityLevel,
+        };
+    });
 };
 
 type PlannedGoalItem = { category: GoalCategory; unitIndex: number; goal: IPersonalGoal; rankSubOrder: number };

--- a/src/fsd/1-pages/plan-bulk-goals/bulk-goal-creator.tsx
+++ b/src/fsd/1-pages/plan-bulk-goals/bulk-goal-creator.tsx
@@ -30,6 +30,7 @@ import { AbilitiesChangeText, AscendChangeArrow, RankChangeArrow } from '@/fsd/4
 import { MowsService } from '@/fsd/4-entities/mow';
 import { IUnit } from '@/fsd/4-entities/unit';
 
+import { getRankUpTarget } from '@/fsd/3-features/characters/functions/ready-to-rank-up';
 import { GoalSummaryTable } from '@/fsd/3-features/goals';
 import { RosterSnapshotShowVariableSettings } from '@/fsd/3-features/view-settings/model';
 
@@ -44,30 +45,22 @@ import { RosterSnapshotsAssetsProvider } from '../input-roster-snapshots/roster-
 import { ITeam2 } from '../plan-teams2/models';
 import { TeamFlow } from '../plan-teams2/team-flow';
 
+import { AddReadyToRankUpDialog } from './add-ready-to-rank-up-dialog';
 import { BulkGoalCreatorUnitCard } from './bulk-goal-creator-unit-card';
 import {
     buildBulkPlannedGoals,
+    buildReadyToRankUpEntries,
+    createBulkUnitEntry,
     getBulkRankGoalPlans,
+    getBulkUnitEntryFromUnit,
     getRankGoalSubOrder,
     getTierValue,
     type CharacterPriorityMode,
     type GoalCategory,
     type IncrementalGoalMode,
     type RankStep,
+    type ReadyToRankUpOptions,
 } from './bulk-goal-creator.service';
-
-const createBulkUnitEntry = () => ({
-    unit: undefined,
-    rank: Rank.Stone1,
-    rarity: Rarity.Common,
-    stars: 1,
-    activeAbilityLevel: 1,
-    passiveAbilityLevel: 1,
-    unlockMow: false,
-    preFarmLegendaryMythic: false,
-    useIncrementalGoals: false,
-    incrementalGoalMode: 'milestones' as IncrementalGoalMode,
-});
 
 const rankValues = ALL_RANK_VALUES;
 const allStarValues = ALL_STAR_VALUES;
@@ -95,29 +88,6 @@ const enforceMinimums = <
     ...entry,
     ...enforceUnitThresholdMinimums(entry),
 });
-
-const getBulkUnitEntryFromUnit = (unit: IUnit | undefined) => {
-    if (!unit) {
-        return createBulkUnitEntry();
-    }
-
-    const activeAbilityLevel = 'activeAbilityLevel' in unit ? unit.activeAbilityLevel : unit.primaryAbilityLevel;
-    const passiveAbilityLevel = 'passiveAbilityLevel' in unit ? unit.passiveAbilityLevel : unit.secondaryAbilityLevel;
-    const rank = 'rank' in unit ? unit.rank : Rank.Locked;
-
-    return {
-        unit,
-        rank,
-        rarity: unit.rarity ?? Rarity.Common,
-        stars: unit.stars ?? 1,
-        activeAbilityLevel,
-        passiveAbilityLevel,
-        unlockMow: false,
-        preFarmLegendaryMythic: false,
-        useIncrementalGoals: false,
-        incrementalGoalMode: 'milestones' as IncrementalGoalMode,
-    };
-};
 
 export const BulkGoalCreator = () => {
     const { characters: charactersDefault, goals, mows, teams2 } = useContext(StoreContext);
@@ -235,6 +205,22 @@ export const BulkGoalCreator = () => {
             }
         },
         [bulkUnits, resolvedCharacters, resolvedMows]
+    );
+
+    const [rankUpDialogOpen, setRankUpDialogOpen] = useState(false);
+
+    const readyToRankUpTargets = useMemo(() => filterMap(resolvedCharacters, getRankUpTarget), [resolvedCharacters]);
+
+    const addReadyToRankUpUnits = useCallback(
+        (options: ReadyToRankUpOptions) => {
+            const existingIds = new Set(bulkUnits.map(entry => entry.unit?.snowprintId));
+            const newEntries = buildReadyToRankUpEntries(resolvedCharacters, existingIds, options);
+
+            if (newEntries.length > 0) {
+                setBulkUnits(previous => [...previous, ...newEntries]);
+            }
+        },
+        [bulkUnits, resolvedCharacters]
     );
 
     const bulkTeamCharacters = useMemo(
@@ -545,6 +531,18 @@ export const BulkGoalCreator = () => {
                             </Menu>
                         </div>
                     )}
+                    {readyToRankUpTargets.length > 0 && (
+                        <div className="mr-4">
+                            <Button
+                                size="small"
+                                variant="outlined"
+                                color="primary"
+                                onClick={() => setRankUpDialogOpen(true)}
+                                sx={{ textTransform: 'none' }}>
+                                Add Ready to Rank Up
+                            </Button>
+                        </div>
+                    )}
                     <div className="mr-4">
                         <Button
                             variant="contained"
@@ -556,6 +554,14 @@ export const BulkGoalCreator = () => {
                         </Button>
                     </div>
                 </div>
+                <AddReadyToRankUpDialog
+                    open={rankUpDialogOpen}
+                    targetRanks={readyToRankUpTargets}
+                    onClose={result => {
+                        setRankUpDialogOpen(false);
+                        if (result) addReadyToRankUpUnits(result);
+                    }}
+                />
                 <div className="mb-4 grid grid-cols-[repeat(auto-fill,minmax(300px,1fr))] gap-4">
                     {bulkUnits.map((entry, index) => (
                         <div key={index}>

--- a/src/fsd/1-pages/who-you-own/unit-details-page.tsx
+++ b/src/fsd/1-pages/who-you-own/unit-details-page.tsx
@@ -87,7 +87,10 @@ const AbilityPanel = ({
 
     return (
         <div className="flex w-full max-w-xl min-w-0 basis-full flex-col gap-1 lg:min-w-80 lg:flex-1 lg:basis-auto">
-            <span className="text-xs text-(--soft-fg)">{label}</span>
+            <div className="flex items-baseline gap-2">
+                <span className="text-xs text-(--soft-fg)">{label}</span>
+                {ability?.text.name && <span className="text-sm font-semibold text-(--fg)">{ability.text.name}</span>}
+            </div>
             {ability ? (
                 <div className="rounded-md bg-(--ability-panel)">
                     {/* Description text */}

--- a/src/fsd/1-pages/who-you-own/who-you-own.tsx
+++ b/src/fsd/1-pages/who-you-own/who-you-own.tsx
@@ -74,15 +74,24 @@ export const WhoYouOwn = () => {
         }
     }, [teams2, viewControls.filterBy, dispatch]);
 
+    const useRankUpPower = viewControls.filterBy === CharactersFilterBy.ReadyToRankUp;
+
     const factions = useMemo(
         () =>
             CharactersService.orderByFaction(
                 charactersFiltered,
                 viewControls.orderBy,
                 viewPreferences.showBsValue,
-                viewPreferences.showPower
+                viewPreferences.showPower,
+                useRankUpPower
             ),
-        [charactersFiltered, viewControls.orderBy, viewPreferences.showBsValue, viewPreferences.showPower]
+        [
+            charactersFiltered,
+            viewControls.orderBy,
+            viewPreferences.showBsValue,
+            viewPreferences.showPower,
+            useRankUpPower,
+        ]
     );
 
     const totalPower = useMemo(() => sum(factions.map(faction => faction.power)), [factions]);
@@ -92,9 +101,10 @@ export const WhoYouOwn = () => {
         () =>
             CharactersService.orderUnits(
                 factions.flatMap(f => f.units),
-                viewControls.orderBy
+                viewControls.orderBy,
+                useRankUpPower
             ),
-        [factions, viewControls.orderBy]
+        [factions, viewControls.orderBy, useRankUpPower]
     );
 
     const unitId = searchParams.get('unit');
@@ -212,13 +222,20 @@ export const WhoYouOwn = () => {
                     />
                     <div className="min-h-[10px]" />
 
-                    {factionsView && <FactionsGrid factions={factions} onCharacterClick={handleUnitClick} />}
+                    {factionsView && (
+                        <FactionsGrid
+                            factions={factions}
+                            onCharacterClick={handleUnitClick}
+                            showRankUpTarget={useRankUpPower}
+                        />
+                    )}
 
                     {charactersView && (
                         <CharactersGrid
                             characters={units}
                             onAvailableCharacterClick={handleUnitClick}
                             onLockedCharacterClick={handleUnitClick}
+                            showRankUpTarget={useRankUpPower}
                         />
                     )}
 

--- a/src/fsd/3-features/character-details/unit-stat-radar-chart.tsx
+++ b/src/fsd/3-features/character-details/unit-stat-radar-chart.tsx
@@ -2,7 +2,7 @@ import { Copy } from 'lucide-react';
 import { enqueueSnackbar } from 'notistack';
 import { useRef } from 'react';
 
-import { tacticusIcons } from '@/fsd/5-shared/ui/icons';
+import { MiscIcon, tacticusIcons } from '@/fsd/5-shared/ui/icons';
 import { AccessibleTooltip } from '@/fsd/5-shared/ui/tooltip';
 
 import { buildRadarStats, RadarAxisId } from './unit-stat-radar.utils';
@@ -290,10 +290,15 @@ export const UnitStatRadarChart = ({ snowprintId }: Props) => {
             <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-(--soft-fg)">
                 {stats.map(stat => {
                     const axis = AXES.find(candidate => candidate.id === stat.axis);
+                    if (!axis) return;
                     return (
-                        <span key={stat.axis}>
-                            {axis?.description}: <span className="text-(--fg)">{Math.round(stat.percentile)}%</span>
-                        </span>
+                        <AccessibleTooltip key={stat.axis} title={axis.description}>
+                            <span className="flex items-center gap-1">
+                                <MiscIcon icon={axis.icon} width={16} height={16} />
+                                {axis.symbol && <span className="text-(--soft-fg)">{axis.symbol}</span>}
+                                <span className="text-(--fg)">{Math.round(stat.percentile)}%</span>
+                            </span>
+                        </AccessibleTooltip>
                     );
                 })}
             </div>

--- a/src/fsd/3-features/characters/characters.service.ts
+++ b/src/fsd/3-features/characters/characters.service.ts
@@ -17,6 +17,12 @@ import { CharactersFilterBy } from '@/fsd/4-entities/character/characters-filter
 import { CharactersOrderBy } from '@/fsd/4-entities/character/characters-order-by.enum';
 import { IMow2 } from '@/fsd/4-entities/mow';
 import { IUnit } from '@/fsd/4-entities/unit';
+import {
+    getProjectedRankUpPower,
+    getRosterCharacterPower,
+    getRosterMowPower,
+    // eslint-disable-next-line import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure
+} from '@/fsd/4-entities/unit/character-power';
 // eslint-disable-next-line import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure
 import { CharactersPowerService } from '@/fsd/4-entities/unit/characters-power.service';
 // eslint-disable-next-line import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure
@@ -45,6 +51,8 @@ import { filterXenos } from './functions/filter-by-xenos';
 import { needToAscendCharacter } from './functions/need-to-ascend';
 // eslint-disable-next-line import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure
 import { needToLevelCharacter } from './functions/need-to-level';
+// eslint-disable-next-line import-x/no-internal-modules -- FYI: Ported from `v2` module; doesn't comply with `fsd` structure
+import { getRankUpTarget, readyToRankUp } from './functions/ready-to-rank-up';
 
 export class CharactersService {
     static filterUnits(
@@ -92,6 +100,9 @@ export class CharactersService {
             case CharactersFilterBy.MoW: {
                 return filteredCharactersByName.filter(character => isMow(character));
             }
+            case CharactersFilterBy.ReadyToRankUp: {
+                return filteredCharactersByName.filter(character => readyToRankUp(character));
+            }
             case CharactersFilterBy.None: {
                 return filteredCharactersByName;
             }
@@ -106,7 +117,42 @@ export class CharactersService {
         return this.getFaction(unit1) === this.getFaction(unit2);
     }
 
-    static orderUnits(units: IUnit[], charactersOrderBy: CharactersOrderBy): IUnit[] {
+    /**
+     * Current unit power using the accurate GameConfig-based formula (equipment, relics, traits,
+     * MoW ability/mythic-ability power and all) rather than the coarse rank/stars/ability-level
+     * heuristic. If the accurate formula throws (its bundled GameConfig slice predates a unit/item
+     * on the roster), falls back to the heuristic so callers never break.
+     */
+    static getDisplayPower(unit: IUnit): number {
+        try {
+            return isCharacter(unit) ? getRosterCharacterPower(unit) : getRosterMowPower(unit);
+        } catch (error) {
+            console.warn(`Accurate power failed for ${unit.snowprintId}; using heuristic`, error);
+            return CharactersPowerService.getCharacterPower(unit);
+        }
+    }
+
+    /**
+     * Character power for sorting/summing. When `useRankUpTargetPower` is set (the who-you-own
+     * "Ready to Rank Up" filter), characters are scored at the rank they could rank up into rather
+     * than their current rank. MoWs and characters with no rank-up target fall back to their
+     * normal (accurate) power. If the accurate formula throws (its bundled GameConfig slice
+     * predates a unit/item on the roster), fall back to the heuristic so the page still renders.
+     */
+    private static powerForUnit(unit: IUnit, useRankUpTargetPower: boolean): number {
+        if (!useRankUpTargetPower || !isCharacter(unit)) {
+            return CharactersService.getDisplayPower(unit);
+        }
+        try {
+            const target = getRankUpTarget(unit);
+            return target ? getProjectedRankUpPower(unit, target) : getRosterCharacterPower(unit);
+        } catch (error) {
+            console.warn(`Accurate rank-up power failed for ${unit.snowprintId}; using heuristic`, error);
+            return CharactersPowerService.getCharacterPower(unit);
+        }
+    }
+
+    static orderUnits(units: IUnit[], charactersOrderBy: CharactersOrderBy, useRankUpTargetPower = false): IUnit[] {
         switch (charactersOrderBy) {
             case CharactersOrderBy.CharacterValue: {
                 return orderBy(
@@ -117,7 +163,7 @@ export class CharactersService {
             }
             case CharactersOrderBy.CharacterPower: {
                 return orderBy(
-                    units.map(x => ({ ...x, characterPower: CharactersPowerService.getCharacterPower(x) })),
+                    units.map(x => ({ ...x, characterPower: CharactersService.powerForUnit(x, useRankUpTargetPower) })),
                     ['characterPower'],
                     ['desc']
                 );
@@ -196,7 +242,8 @@ export class CharactersService {
         units: IUnit[],
         charactersOrderBy: CharactersOrderBy,
         includeBsValue = true,
-        includePower = true
+        includePower = true,
+        useRankUpTargetPower = false
     ): IFaction[] {
         const factionCharacters = groupBy(units, 'faction');
 
@@ -214,7 +261,7 @@ export class CharactersService {
                         : 0,
                 power:
                     includePower || charactersOrderBy === CharactersOrderBy.FactionPower
-                        ? sum(units.map(character => CharactersPowerService.getCharacterPower(character)))
+                        ? sum(units.map(character => CharactersService.powerForUnit(character, useRankUpTargetPower)))
                         : 0,
                 unlockedCharacters: units.filter(character => isUnlocked(character)).length,
             };

--- a/src/fsd/3-features/characters/components/characters-grid.tsx
+++ b/src/fsd/3-features/characters/components/characters-grid.tsx
@@ -15,6 +15,8 @@ import { RosterSnapshotsService } from '@/fsd/1-pages/input-roster-snapshots/ros
 
 import { RosterSnapshotShowVariableSettings } from '../../view-settings/model';
 import { CharactersViewContext } from '../characters-view.context';
+import { CharactersService } from '../characters.service';
+import { getRankUpTarget } from '../functions/ready-to-rank-up';
 
 export const CharactersGrid = ({
     characters,
@@ -22,12 +24,14 @@ export const CharactersGrid = ({
     onAvailableCharacterClick,
     onLockedCharacterClick,
     onlyBlocked,
+    showRankUpTarget,
 }: {
     characters: IUnit[];
     blockedCharacters?: string[];
     onAvailableCharacterClick?: (character: IUnit) => void;
     onLockedCharacterClick?: (character: IUnit) => void;
     onlyBlocked?: boolean;
+    showRankUpTarget?: boolean;
 }) => {
     const viewContext = useContext(CharactersViewContext);
     const unlockedCharacters = characters
@@ -39,7 +43,7 @@ export const CharactersGrid = ({
                     key={unit.snowprintId}
                     onClick={() => onAvailableCharacterClick?.(unit)}
                     className="flex-shrink-0 cursor-pointer rounded-md transition-shadow duration-200 hover:ring-2 hover:ring-(--primary)"
-                    title={`Select ${unit.name || 'Unit'}`}>
+                    title={`Select ${unit.name || 'Unit'} (${CharactersService.getDisplayPower(unit).toLocaleString()} power)`}>
                     <RosterSnapshotCharacter
                         key={unit.snowprintId}
                         char={isCharacter ? RosterSnapshotsService.snapshotCharacter(unit) : undefined}
@@ -73,6 +77,7 @@ export const CharactersGrid = ({
                         }
                         showTooltip={true}
                         isDisabled={false}
+                        targetRank={showRankUpTarget && isCharacter ? getRankUpTarget(unit) : undefined}
                     />
                 </div>
             );

--- a/src/fsd/3-features/characters/components/faction-tile.tsx
+++ b/src/fsd/3-features/characters/components/faction-tile.tsx
@@ -18,13 +18,17 @@ import { RosterSnapshotsService } from '@/fsd/1-pages/input-roster-snapshots/ros
 
 import { RosterSnapshotShowVariableSettings } from '../../view-settings/model';
 import { IFaction } from '../characters.models';
+import { CharactersService } from '../characters.service';
+import { getRankUpTarget } from '../functions/ready-to-rank-up';
 
 export const FactionsTile = ({
     faction,
     onCharacterClick,
+    showRankUpTarget,
 }: {
     faction: IFaction;
     onCharacterClick?: (character: IUnit) => void;
+    showRankUpTarget?: boolean;
 }) => {
     const viewContext = useContext(CharactersViewContext);
     const factionPower = numberToThousandsString(faction.power);
@@ -93,7 +97,7 @@ export const FactionsTile = ({
                             key={unit.snowprintId}
                             onClick={() => onCharacterClick?.(unit)}
                             className="shrink-0 cursor-pointer rounded-md transition-shadow duration-200 hover:ring-2 hover:ring-(--primary)"
-                            title={`Select ${unit.name || 'Unit'}`}>
+                            title={`Select ${unit.name || 'Unit'} (${CharactersService.getDisplayPower(unit).toLocaleString()} power)`}>
                             <RosterSnapshotCharacter
                                 char={isCharacter ? RosterSnapshotsService.snapshotCharacter(unit) : undefined}
                                 charData={isCharacter ? unit : undefined}
@@ -126,6 +130,7 @@ export const FactionsTile = ({
                                 }
                                 showTooltip={true}
                                 isDisabled={isCharacter ? unit.rank === Rank.Locked : !unit.unlocked}
+                                targetRank={showRankUpTarget && isCharacter ? getRankUpTarget(unit) : undefined}
                             />
                         </div>
                     );

--- a/src/fsd/3-features/characters/components/factions-grid.tsx
+++ b/src/fsd/3-features/characters/components/factions-grid.tsx
@@ -5,14 +5,21 @@ import { FactionsTile } from './faction-tile';
 export const FactionsGrid = ({
     factions,
     onCharacterClick,
+    showRankUpTarget,
 }: {
     factions: IFaction[];
     onCharacterClick?: (character: IUnit) => void;
+    showRankUpTarget?: boolean;
 }) => {
     return (
         <div className="grid grid-cols-[repeat(auto-fill,minmax(375px,720px))] place-content-around gap-4 gap-x-6">
             {factions.map(x => (
-                <FactionsTile key={x.name} faction={x} onCharacterClick={onCharacterClick} />
+                <FactionsTile
+                    key={x.name}
+                    faction={x}
+                    onCharacterClick={onCharacterClick}
+                    showRankUpTarget={showRankUpTarget}
+                />
             ))}
         </div>
     );

--- a/src/fsd/3-features/characters/functions/ready-to-rank-up.ts
+++ b/src/fsd/3-features/characters/functions/ready-to-rank-up.ts
@@ -1,0 +1,37 @@
+/* eslint-disable import-x/no-internal-modules */
+import { rankToLevel } from 'src/models/constants';
+
+import { getEnumValues } from '@/fsd/5-shared/lib';
+import { Rank, RarityMapper, UnitType } from '@/fsd/5-shared/model';
+
+import { IUnit } from '@/fsd/4-entities/unit';
+
+import { needToAscendCharacter } from './need-to-ascend';
+
+/**
+ * The highest rank this character could rank up into right now: the largest rank its current XP
+ * level satisfies, capped at the rank ceiling of its current rarity. Returns `undefined` when the
+ * character is a MoW, locked, already blocked by its rarity cap (needs to ascend first), or has no
+ * rank above its current one available.
+ */
+export const getRankUpTarget = (unit: IUnit): Rank | undefined => {
+    if (unit.unitType === UnitType.mow || unit.rank <= Rank.Locked) {
+        return undefined;
+    }
+    if (needToAscendCharacter(unit)) {
+        return undefined;
+    }
+
+    const rarityCeiling = RarityMapper.toMaxRank[unit.rarity];
+    let levelRank = Rank.Locked;
+    for (const rank of getEnumValues(Rank)) {
+        if (rank > Rank.Locked && unit.level >= rankToLevel[rank as Rank]) {
+            levelRank = rank as Rank;
+        }
+    }
+
+    const target = Math.min(levelRank, rarityCeiling) as Rank;
+    return target > unit.rank ? target : undefined;
+};
+
+export const readyToRankUp = (unit: IUnit): boolean => getRankUpTarget(unit) !== undefined;

--- a/src/fsd/3-features/view-settings/view-controls.tsx
+++ b/src/fsd/3-features/view-settings/view-controls.tsx
@@ -99,6 +99,9 @@ export const CharactersViewControls = ({
             case CharactersFilterBy.MoW: {
                 return 'MoW only';
             }
+            case CharactersFilterBy.ReadyToRankUp: {
+                return 'Ready to Rank Up';
+            }
             case CharactersFilterBy.None: {
                 return 'None';
             }

--- a/src/fsd/4-entities/character/characters-filter-by.enum.ts
+++ b/src/fsd/4-entities/character/characters-filter-by.enum.ts
@@ -8,4 +8,5 @@
     Imperial,
     Xenos,
     MoW,
+    ReadyToRankUp,
 }

--- a/src/fsd/4-entities/unit/character-power/character-power.data.ts
+++ b/src/fsd/4-entities/unit/character-power/character-power.data.ts
@@ -1,0 +1,18 @@
+/* eslint-disable import-x/no-internal-modules */
+import items from './data/character-power-items.json';
+import units from './data/character-power-units.json';
+import upgrades from './data/character-power-upgrades.json';
+
+/**
+ * The trimmed slice of Snowprint's `clientGameConfig` the power formula needs, bundled at build
+ * time (see `scripts`/README of the sibling `tacops` repo for how it is re-extracted each patch).
+ * `units` is `clientGameConfig.units` picked down to the power-relevant keys; `items` and
+ * `upgrades` are `clientGameConfig.items` / `.upgrades` verbatim.
+ */
+export interface PowerConfig {
+    units: unknown;
+    items: unknown;
+    upgrades: unknown;
+}
+
+export const bundledPowerConfig: PowerConfig = { units, items, upgrades };

--- a/src/fsd/4-entities/unit/character-power/character-power.test.ts
+++ b/src/fsd/4-entities/unit/character-power/character-power.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from 'vitest';
+
+import { Rarity, RarityStars } from '@/fsd/5-shared/model';
+
+import {
+    calculateRosterCharacterPower,
+    calculateRosterMowPower,
+    RosterMowPowerInput,
+    RosterPowerInput,
+} from './character-power';
+import { bundledPowerConfig, PowerConfig } from './character-power.data';
+import { progressionIndexFromRarityStars } from './progression-index';
+
+const config = (unitOverrides: Record<string, unknown> = {}): PowerConfig => ({
+    units: {
+        lineup: {
+            testUnit: {
+                name: 'Test Unit',
+                traits: [],
+                weapons: [{ hits: 1, DamageProfile: 'Bolter' }],
+                activeAbilities: ['activeA'],
+                passiveAbilities: ['passiveA'],
+                Movement: 16,
+                stats: { Health: 100, Damage: 10 },
+                upgrades: [],
+                upgradesStatIncrease: [],
+                ...unitOverrides,
+            },
+        },
+        heroProgressionSteps: [{ unitStatMultiplierPct: 100, abilityPowerMultiplier: 100 }],
+        heroProgressionStepsPerUnit: {},
+        damageProfileModifiers: { Bolter: 100 },
+        abilityPowerCurve: { active: [10, 20], passive: [5, 15], relic: [1000, 2000, 3000] },
+        abilityPowerModifiers: {},
+        traitPowerModifiers: {},
+    },
+    items: {
+        relicItem: { abilityId: 'someRelicAbility', levels: [{ stats: {} }, { stats: {} }, { stats: {} }] },
+    },
+    upgrades: {},
+});
+
+const input = (overrides: Partial<RosterPowerInput> = {}): RosterPowerInput => ({
+    unitId: 'testUnit',
+    progressionIndex: 0,
+    rank: 0,
+    activeLevel: 2,
+    passiveLevel: 2,
+    appliedUpgradeIndices: [],
+    equipment: [],
+    ...overrides,
+});
+
+describe('calculateRosterCharacterPower', () => {
+    it('reproduces the reference implementation output for a hand-built fixture', () => {
+        expect(calculateRosterCharacterPower(input(), config())).toBe(3514);
+    });
+
+    it('gives a higher-rank character more power than an otherwise-identical lower-rank one', () => {
+        const rankedConfig = config({ upgrades: [['hpUpgrade']], upgradesStatIncrease: [[50]] });
+        const withUpgrades: PowerConfig = { ...rankedConfig, upgrades: { hpUpgrade: { statType: 'hp' } } };
+
+        const low = calculateRosterCharacterPower(input({ rank: 0 }), withUpgrades);
+        const high = calculateRosterCharacterPower(input({ rank: 1 }), withUpgrades);
+
+        expect(high).toBeGreaterThan(low);
+    });
+
+    it('returns 0 for a locked character (negative game rank)', () => {
+        expect(calculateRosterCharacterPower(input({ rank: -1 }), config())).toBe(0);
+    });
+
+    it('adds relic ability power for an equipped relic', () => {
+        const withoutRelic = calculateRosterCharacterPower(input(), config());
+        const withRelic = calculateRosterCharacterPower(
+            input({ equipment: [{ itemId: 'relicItem', level: 2 }] }),
+            config()
+        );
+        expect(withRelic).toBeGreaterThan(withoutRelic);
+    });
+
+    it('throws when the unit is missing from the bundled config', () => {
+        expect(() => calculateRosterCharacterPower(input({ unitId: 'unknownUnit' }), config())).toThrow(/unknownUnit/);
+    });
+
+    it('applies sqrt(0.9), not a bare 0.9, as the range modifier for a weapon with no Range', () => {
+        // A regression guard for a bug where a melee (no-`Range`) weapon's power was multiplied by
+        // a flat 0.9 instead of sqrt(0.9) — a ~5% undercount that only shows up for weapons without
+        // a Range, and is invisible in ability-power-dominated fixtures like the one above.
+        const bigStatsConfig = config({ stats: { Health: 100_000, Damage: 10_000 } });
+        const noAbilityInput = input({ activeLevel: 0, passiveLevel: 0 });
+
+        const actual = calculateRosterCharacterPower(noAbilityInput, bigStatsConfig);
+
+        const durability = 100_000;
+        const weaponPower = 10_000 * Math.sqrt(0.9);
+        const statsPower = Math.pow(durability * weaponPower, 2 / 3);
+        const expected = Math.round(10 + (statsPower * Math.sqrt(16)) / 100);
+
+        expect(actual).toBe(expected);
+    });
+
+    it('reproduces real, in-game-verified power for two equipped characters (Kharn and Gulgortz)', () => {
+        // Values confirmed against the live game for these exact roster records. Kharn's single
+        // weapon has no `Range` (100% of its weapon power went through the buggy range-modifier
+        // path above); Gulgortz has one melee + one ranged weapon, diluting that same bug's effect.
+        const kharn = calculateRosterCharacterPower(
+            {
+                unitId: 'worldKharn',
+                progressionIndex: 18,
+                rank: 19,
+                activeLevel: 60,
+                passiveLevel: 60,
+                appliedUpgradeIndices: [],
+                equipment: [
+                    { itemId: 'I_Crit_M006', level: 1 },
+                    { itemId: 'I_Booster_Crit_M003', level: 1 },
+                    { itemId: 'I_Block_M003', level: 1 },
+                ],
+            },
+            bundledPowerConfig
+        );
+        const gulgortz = calculateRosterCharacterPower(
+            {
+                unitId: 'orksWarboss',
+                progressionIndex: 16,
+                rank: 19,
+                activeLevel: 60,
+                passiveLevel: 60,
+                appliedUpgradeIndices: [],
+                equipment: [
+                    { itemId: 'R_Crit_HeadwoppasKillchoppa', level: 6 },
+                    { itemId: 'I_Block_L003', level: 11 },
+                    { itemId: 'I_Booster_Block_M002', level: 1 },
+                ],
+            },
+            bundledPowerConfig
+        );
+
+        expect(kharn).toBe(936_827);
+        expect(gulgortz).toBe(954_786);
+    });
+});
+
+const mowConfig = (): PowerConfig => ({
+    units: {
+        lineup: {
+            testMachine: {
+                name: 'Test Machine',
+                traits: ['MachineOfWar'],
+                activeAbilities: ['primaryA', 'secondaryA'],
+            },
+        },
+        heroProgressionStepsMoW: [
+            { abilityPowerMultiplier: 2 },
+            { abilityPowerMultiplier: 3, mythicAbilityPower: 5000 },
+        ],
+        abilityPowerCurve: { active: [10, 20], passive: [5, 15] },
+        abilityPowerModifiers: {},
+        traitPowerModifiers: { MachineOfWar: 100 },
+    },
+    items: {},
+    upgrades: {},
+});
+
+const mowInput = (overrides: Partial<RosterMowPowerInput> = {}): RosterMowPowerInput => ({
+    unitId: 'testMachine',
+    progressionIndex: 0,
+    primaryAbilityLevel: 2,
+    secondaryAbilityLevel: 2,
+    ...overrides,
+});
+
+describe('calculateRosterMowPower', () => {
+    it('reproduces the reference implementation output for a maxed Biovore', () => {
+        // Documented in the reference characterPower.mjs README as the known-good value for this
+        // exact input against a matching GameConfig snapshot.
+        const power = calculateRosterMowPower(
+            {
+                unitId: 'tyranBiovore',
+                progressionIndex: 19,
+                primaryAbilityLevel: 60,
+                secondaryAbilityLevel: 60,
+            },
+            bundledPowerConfig
+        );
+        expect(power).toBe(1_040_687);
+    });
+
+    it('adds the flat mythic-ability bonus once the progression step unlocks one', () => {
+        const withoutMythic = calculateRosterMowPower(mowInput({ progressionIndex: 0 }), mowConfig());
+        const withMythic = calculateRosterMowPower(mowInput({ progressionIndex: 1 }), mowConfig());
+        expect(withMythic).toBeGreaterThan(withoutMythic);
+    });
+
+    it('throws when the MoW is missing from the bundled config', () => {
+        expect(() => calculateRosterMowPower(mowInput({ unitId: 'unknownMachine' }), mowConfig())).toThrow(
+            /unknownMachine/
+        );
+    });
+});
+
+describe('progressionIndexFromRarityStars', () => {
+    it('inverts the known progression-index table', () => {
+        expect(progressionIndexFromRarityStars(Rarity.Common, RarityStars.None)).toBe(0);
+        expect(progressionIndexFromRarityStars(Rarity.Uncommon, RarityStars.TwoStars)).toBe(3);
+        expect(progressionIndexFromRarityStars(Rarity.Rare, RarityStars.FourStars)).toBe(6);
+        expect(progressionIndexFromRarityStars(Rarity.Epic, RarityStars.RedOneStar)).toBe(9);
+        expect(progressionIndexFromRarityStars(Rarity.Legendary, RarityStars.RedThreeStars)).toBe(12);
+        expect(progressionIndexFromRarityStars(Rarity.Mythic, RarityStars.OneBlueStar)).toBe(16);
+        expect(progressionIndexFromRarityStars(Rarity.Mythic, RarityStars.MythicWings)).toBe(19);
+    });
+
+    it('clamps out-of-range combinations', () => {
+        expect(progressionIndexFromRarityStars(Rarity.Mythic, RarityStars.ThreeBlueStars + 10)).toBe(19);
+    });
+});

--- a/src/fsd/4-entities/unit/character-power/character-power.ts
+++ b/src/fsd/4-entities/unit/character-power/character-power.ts
@@ -1,0 +1,488 @@
+// Ported from tacops' `src/characters/character-power.ts` / the original `characterPower.mjs`, just
+// fed from the app's roster model instead of a raw CONNECT response. The validation is a feature:
+// it throws loudly when the bundled GameConfig slice doesn't know a unit/item/upgrade the roster
+// references (e.g. a character released after the last extraction) rather than returning a
+// believable-but-wrong number.
+
+import { bundledPowerConfig, PowerConfig } from './character-power.data';
+
+/** One roster character reduced to exactly what the power formula reads. */
+export interface RosterPowerInput {
+    /** Snowprint id; must equal a key of `GameConfig.units.lineup`. */
+    unitId: string;
+    /** 0..19 — see `progressionIndexFromRarityStars`. */
+    progressionIndex: number;
+    /** 0-based game rank (app `Rank` enum value minus 1). */
+    rank: number;
+    activeLevel: number;
+    passiveLevel: number;
+    /** Indices into `lineup[unitId].upgrades[rank]` of the current-rank upgrades already applied. */
+    appliedUpgradeIndices: number[];
+    equipment: Array<{ itemId: string; level: number }>;
+}
+
+/** One roster Machine of War reduced to exactly what the power formula reads. MoWs have no rank,
+ * upgrades, or equipment — only ability levels and progression (rarity/stars). */
+export interface RosterMowPowerInput {
+    /** Snowprint id; must equal a key of `GameConfig.units.lineup`. */
+    unitId: string;
+    /** 0..19 — see `progressionIndexFromRarityStars`. */
+    progressionIndex: number;
+    primaryAbilityLevel: number;
+    secondaryAbilityLevel: number;
+}
+
+interface Stats {
+    health: number;
+    damage: number;
+    fixedArmor: number;
+    critChance: number;
+    critDamage: number;
+    blockChance: number;
+    blockDamage: number;
+    critChanceBonus: number;
+    critDamageBonus: number;
+    blockChanceBonus: number;
+    blockDamageBonus: number;
+}
+
+type JsonObject = Record<string, unknown>;
+
+/**
+ * Real in-game power for a single roster character, matching the game's own formula (health,
+ * damage, crit/block, ability power, trait/movement modifiers).
+ *
+ * Throws when `config` (the bundled GameConfig slice by default) is missing the unit, one of its
+ * equipped items, or one of its upgrades — most often because `config` predates a freshly released
+ * character.
+ */
+export function calculateRosterCharacterPower(
+    input: RosterPowerInput,
+    config: PowerConfig = bundledPowerConfig
+): number {
+    if (input.rank < 0) {
+        return 0;
+    }
+
+    const unitsConfig = requireObject(config.units, 'GameConfig.units');
+    const lineup = objectAt(unitsConfig, 'lineup');
+    const itemConfigs = requireObject(config.items, 'GameConfig.items');
+    const upgradeConfigs = requireObject(config.upgrades, 'GameConfig.upgrades');
+
+    const unit = requireObject(lineup[input.unitId], `GameConfig.units.lineup.${input.unitId}`);
+    const progressionStep = getProgressionStep(unitsConfig, input.unitId, input.progressionIndex);
+    const stats = calculateStats(input, unit, progressionStep, itemConfigs, upgradeConfigs);
+    const relicAbilityLevel = relicAbilityLevelOf(input.equipment, itemConfigs);
+    return calculatePower(input, unit, progressionStep, stats, relicAbilityLevel, unitsConfig);
+}
+
+/**
+ * Real in-game power for a single roster Machine of War: primary/secondary ability power plus a
+ * flat mythic-ability bonus once its progression step unlocks one, scaled by trait and unit power
+ * multipliers. MoWs have no health/damage/armor stats, so none of the character stat math applies.
+ */
+export function calculateRosterMowPower(input: RosterMowPowerInput, config: PowerConfig = bundledPowerConfig): number {
+    const unitsConfig = requireObject(config.units, 'GameConfig.units');
+    const lineup = objectAt(unitsConfig, 'lineup');
+    const unit = requireObject(lineup[input.unitId], `GameConfig.units.lineup.${input.unitId}`);
+    const progressionStep = getMachineProgressionStep(unitsConfig, input.unitId, input.progressionIndex);
+    return calculateMachinePower(input, unit, progressionStep, unitsConfig);
+}
+
+/**
+ * Level of the equipped relic (the one item whose config carries a non-empty `abilityId`), or 0
+ * when no relic is equipped. Its power is added via the `abilityPowerCurve.relic` curve.
+ */
+function relicAbilityLevelOf(equipment: RosterPowerInput['equipment'], itemConfigs: JsonObject): number {
+    let level = 0;
+    for (const item of equipment) {
+        const config = optionalObject(itemConfigs[item.itemId]);
+        if (config && typeof config.abilityId === 'string' && config.abilityId.length > 0) {
+            level = item.level;
+        }
+    }
+    return level;
+}
+
+function calculateItemStats(equipment: RosterPowerInput['equipment'], itemConfigs: JsonObject): Stats {
+    const result = emptyStats();
+    for (const { itemId, level } of equipment) {
+        const item = requireObject(itemConfigs[itemId], `GameConfig.items.${itemId}`);
+        if (!Array.isArray(item.levels)) {
+            throw new TypeError(`GameConfig item ${itemId} has no levels`);
+        }
+        const levelConfig = requireObject(item.levels[level - 1], `GameConfig.items.${itemId}.levels[${level - 1}]`);
+        const rawStats = objectAt(levelConfig, 'stats');
+        result.health += numberOrZero(rawStats.hp);
+        result.damage += numberOrZero(rawStats.dmg);
+        result.fixedArmor += numberOrZero(rawStats.fixedArmor);
+        result.critChance = stackChance(result.critChance, numberOrZero(rawStats.critChance));
+        result.critDamage += numberOrZero(rawStats.critDmg);
+        result.blockChance = stackChance(result.blockChance, numberOrZero(rawStats.blockChance));
+        result.blockDamage += numberOrZero(rawStats.blockDmg);
+        result.critChanceBonus = stackChance(result.critChanceBonus, numberOrZero(rawStats.critChanceBonus));
+        result.critDamageBonus += numberOrZero(rawStats.critDmgBonus);
+        result.blockChanceBonus = stackChance(result.blockChanceBonus, numberOrZero(rawStats.blockChanceBonus));
+        result.blockDamageBonus += numberOrZero(rawStats.blockDmgBonus);
+    }
+    if (result.critChance > 0) result.critChance += result.critChanceBonus;
+    if (result.critDamage > 0) result.critDamage += result.critDamageBonus;
+    if (result.blockChance > 0) result.blockChance += result.blockChanceBonus;
+    if (result.blockDamage > 0) result.blockDamage += result.blockDamageBonus;
+    return result;
+}
+
+function calculateStats(
+    input: RosterPowerInput,
+    unit: JsonObject,
+    progressionStep: JsonObject,
+    itemConfigs: JsonObject,
+    upgradeConfigs: JsonObject
+): Stats {
+    const unitId = input.unitId;
+    const base = objectAt(unit, 'stats');
+    const stats = emptyStats();
+    stats.health = numberOrZero(base.Health);
+    stats.damage = numberOrZero(base.Damage);
+    stats.fixedArmor = numberOrZero(base.FixedArmor);
+    stats.critChance = numberOrZero(base.CritChance);
+    stats.critDamage = numberOrZero(base.CritDamage);
+    stats.blockChance = numberOrZero(base.BlockChance);
+    stats.blockDamage = numberOrZero(base.BlockDamage);
+
+    const rank = input.rank;
+    const upgradeRows = nestedStringArrays(unit.upgrades, `${unitId}.upgrades`);
+    const increaseRows = nestedNumberArrays(unit.upgradesStatIncrease, `${unitId}.upgradesStatIncrease`);
+    for (let completedRank = 0; completedRank < rank; completedRank += 1) {
+        addUpgradeRow(stats, upgradeRows[completedRank], increaseRows[completedRank], upgradeConfigs, unitId);
+    }
+
+    const multiplier = integerAt(progressionStep, 'unitStatMultiplierPct', `${unitId}.progressionStep`);
+    stats.health = Math.trunc((stats.health * multiplier) / 100);
+    stats.damage = Math.trunc((stats.damage * multiplier) / 100);
+    stats.fixedArmor = Math.trunc((stats.fixedArmor * multiplier) / 100);
+
+    for (const index of input.appliedUpgradeIndices) {
+        const upgradeId = upgradeRows[rank]?.[index];
+        const increase = increaseRows[rank]?.[index];
+        if (upgradeId === undefined || increase === undefined) {
+            throw new TypeError(`Invalid current-rank upgrade ${index} for ${unitId}`);
+        }
+        addUpgrade(stats, upgradeId, increase, upgradeConfigs, unitId);
+    }
+
+    mergeStats(stats, calculateItemStats(input.equipment, itemConfigs));
+    return stats;
+}
+
+function calculatePower(
+    input: RosterPowerInput,
+    unit: JsonObject,
+    progressionStep: JsonObject,
+    stats: Stats,
+    relicAbilityLevel: number,
+    unitsConfig: JsonObject
+): number {
+    const damageModifiers = objectAt(unitsConfig, 'damageProfileModifiers');
+    const weapons = arrayOfObjects(unit.weapons, 'unit.weapons');
+    let squaredWeaponPower = 0;
+    for (const weapon of weapons) {
+        const hits = integerAt(weapon, 'hits', 'unit.weapon');
+        const profile = stringAt(weapon, 'DamageProfile', 'unit.weapon');
+        const baseDamage = hits * stats.damage;
+        const criticalDamage = stats.critDamage * geometricPartial(stats.critChance / 100, hits);
+        const profileModifier = numberAt(damageModifiers, profile, 'units.damageProfileModifiers');
+        const rangeModifier = Math.sqrt(weapon.Range === undefined ? 0.9 : numberOrZero(weapon.Range));
+        const weaponPower = (baseDamage + criticalDamage) * (profileModifier / 100) * rangeModifier;
+        squaredWeaponPower += weaponPower * weaponPower;
+    }
+    const weaponsPower = Math.sqrt(squaredWeaponPower);
+
+    const expectedBlock = 3 * stats.blockDamage * geometricPartial(stats.blockChance / 100, 3);
+    const durability = (stats.health + expectedBlock) * (1 + stats.fixedArmor / 2);
+    const statsPower = Math.pow(durability * weaponsPower, 2 / 3);
+
+    const abilityPowerCurve = objectAt(unitsConfig, 'abilityPowerCurve');
+    const activeCurve = numberArrayAt(abilityPowerCurve, 'active', 'units.abilityPowerCurve');
+    const passiveCurve = numberArrayAt(abilityPowerCurve, 'passive', 'units.abilityPowerCurve');
+    const relicCurve = numberArrayAt(abilityPowerCurve, 'relic', 'units.abilityPowerCurve');
+    const abilityModifiers = objectAt(unitsConfig, 'abilityPowerModifiers');
+    const activeId = stringArray(unit.activeAbilities, 'unit.activeAbilities')[0];
+    const passiveId = stringArray(unit.passiveAbilities, 'unit.passiveAbilities')[0];
+    if (!activeId || !passiveId) {
+        throw new TypeError(`${input.unitId} must have one active and one passive ability`);
+    }
+    const activePower = abilityPower(activeId, input.activeLevel, activeCurve, abilityModifiers);
+    const passivePower = abilityPower(passiveId, input.passiveLevel, passiveCurve, abilityModifiers);
+    const abilityMultiplier = integerAt(progressionStep, 'abilityPowerMultiplier', 'unit.progressionStep');
+    const abilitiesPower = (activePower + passivePower) * abilityMultiplier;
+
+    let relicPower = 0;
+    if (relicAbilityLevel >= 1) {
+        const curveValue = relicCurve[relicAbilityLevel - 1];
+        if (curveValue === undefined) {
+            throw new TypeError(`Relic ability level ${relicAbilityLevel} is outside the power curve`);
+        }
+        relicPower = curveValue;
+    }
+
+    const traitMultiplier = traitMultiplierOf(unit, unitsConfig);
+    const movement = numberAt(unit, 'Movement', 'unit');
+    const unitPowerMultiplier = typeof unit.powerMultiplier === 'number' ? unit.powerMultiplier : 100;
+    const rawPower =
+        (10 + traitMultiplier * ((statsPower * Math.sqrt(movement)) / 100 + abilitiesPower + relicPower)) *
+        (unitPowerMultiplier / 100);
+    return Math.round(rawPower);
+}
+
+function calculateMachinePower(
+    input: RosterMowPowerInput,
+    unit: JsonObject,
+    progressionStep: JsonObject,
+    unitsConfig: JsonObject
+): number {
+    const abilityPowerCurve = objectAt(unitsConfig, 'abilityPowerCurve');
+    const activeCurve = numberArrayAt(abilityPowerCurve, 'active', 'units.abilityPowerCurve');
+    const passiveCurve = numberArrayAt(abilityPowerCurve, 'passive', 'units.abilityPowerCurve');
+    const abilityModifiers = objectAt(unitsConfig, 'abilityPowerModifiers');
+    const ids = stringArray(unit.activeAbilities, 'machine.activeAbilities');
+    const primaryId = ids[0];
+    const secondaryId = ids[1];
+    if (!primaryId || !secondaryId) {
+        throw new TypeError(`${input.unitId} must have two active abilities`);
+    }
+    const primaryPower = abilityPower(primaryId, input.primaryAbilityLevel, activeCurve, abilityModifiers);
+    const secondaryPower = abilityPower(secondaryId, input.secondaryAbilityLevel, passiveCurve, abilityModifiers);
+    const abilityMultiplier = integerAt(progressionStep, 'abilityPowerMultiplier', 'machine.progressionStep');
+    const mythicAbilityPower = numberOrZero(progressionStep.mythicAbilityPower);
+
+    const traitMultiplier = traitMultiplierOf(unit, unitsConfig);
+    const unitPowerMultiplier = typeof unit.powerMultiplier === 'number' ? unit.powerMultiplier : 100;
+    const rawPower =
+        (10 + traitMultiplier * ((primaryPower + secondaryPower) * abilityMultiplier + mythicAbilityPower)) *
+        (unitPowerMultiplier / 100);
+    return Math.round(rawPower);
+}
+
+function traitMultiplierOf(unit: JsonObject, unitsConfig: JsonObject): number {
+    const traitModifiers = objectAt(unitsConfig, 'traitPowerModifiers');
+    let traitMultiplier = 1;
+    for (const trait of stringArray(unit.traits, 'unit.traits')) {
+        const modifier = traitModifiers[trait];
+        if (typeof modifier === 'number') {
+            traitMultiplier *= modifier / 100;
+        }
+    }
+    return traitMultiplier;
+}
+
+function abilityPower(abilityId: string, level: number, curve: number[], modifiers: JsonObject): number {
+    if (level < 1) return 0;
+    const base = curve[level - 1];
+    if (base === undefined) {
+        throw new TypeError(`Ability level ${level} is outside the power curve`);
+    }
+    const modifier = optionalObject(modifiers[abilityId]);
+    return base * (modifier ? numberOrDefault(modifier.baseMultiplier, 100) / 100 : 1);
+}
+
+function getProgressionStep(unitsConfig: JsonObject, unitId: string, progressionIndex: number): JsonObject {
+    const perUnit = objectAt(unitsConfig, 'heroProgressionStepsPerUnit');
+    const defaults = (perUnit.default as unknown) ?? unitsConfig.heroProgressionSteps;
+    if (!Array.isArray(defaults)) {
+        throw new TypeError(`GameConfig has no progression steps for ${unitId}`);
+    }
+    const defaultStep = requireObject(defaults[progressionIndex], `${unitId}.defaultProgressionStep`);
+    const overrides = perUnit[unitId];
+    if (overrides === undefined) {
+        return defaultStep;
+    }
+    if (!Array.isArray(overrides)) {
+        throw new TypeError(`GameConfig progression override for ${unitId} must be an array`);
+    }
+    const override = requireObject(overrides[progressionIndex], `${unitId}.progressionStepOverride`);
+    return { ...defaultStep, ...override };
+}
+
+function getMachineProgressionStep(unitsConfig: JsonObject, unitId: string, progressionIndex: number): JsonObject {
+    const steps = unitsConfig.heroProgressionStepsMoW;
+    if (!Array.isArray(steps)) {
+        throw new TypeError(`GameConfig has no MoW progression steps for ${unitId}`);
+    }
+    return requireObject(steps[progressionIndex], `${unitId}.machineProgressionStep`);
+}
+
+function addUpgradeRow(
+    stats: Stats,
+    ids: string[] | undefined,
+    increases: number[] | undefined,
+    upgradeConfigs: JsonObject,
+    unitId: string
+): void {
+    if (!ids || !increases || ids.length !== increases.length) {
+        throw new TypeError(`Invalid upgrade row for ${unitId}`);
+    }
+    for (const [index, id] of ids.entries()) {
+        const increase = increases[index];
+        if (increase === undefined) {
+            throw new TypeError(`Missing upgrade stat increase for ${unitId}`);
+        }
+        addUpgrade(stats, id, increase, upgradeConfigs, unitId);
+    }
+}
+
+function addUpgrade(
+    stats: Stats,
+    upgradeId: string,
+    increase: number,
+    upgradeConfigs: JsonObject,
+    unitId: string
+): void {
+    const config = requireObject(upgradeConfigs[upgradeId], `GameConfig.upgrades.${upgradeId}`);
+    switch (stringAt(config, 'statType', `upgrade ${upgradeId}`)) {
+        case 'hp': {
+            stats.health += increase;
+            break;
+        }
+        case 'dmg': {
+            stats.damage += increase;
+            break;
+        }
+        case 'fixedArmor': {
+            stats.fixedArmor += increase;
+            break;
+        }
+        default: {
+            throw new TypeError(`Unsupported upgrade stat on ${upgradeId} for ${unitId}`);
+        }
+    }
+}
+
+function mergeStats(target: Stats, source: Stats): void {
+    target.health += source.health;
+    target.damage += source.damage;
+    target.fixedArmor += source.fixedArmor;
+    target.critChance += source.critChance;
+    target.critDamage += source.critDamage;
+    target.blockChance += source.blockChance;
+    target.blockDamage += source.blockDamage;
+}
+
+function stackChance(current: number, added: number): number {
+    return current + Math.trunc((1 - current / 100) * added);
+}
+
+function geometricPartial(ratio: number, terms: number): number {
+    let sum = 0;
+    let term = ratio;
+    for (let index = 0; index < terms; index += 1) {
+        sum += term;
+        term *= ratio;
+    }
+    return sum;
+}
+
+function emptyStats(): Stats {
+    return {
+        health: 0,
+        damage: 0,
+        fixedArmor: 0,
+        critChance: 0,
+        critDamage: 0,
+        blockChance: 0,
+        blockDamage: 0,
+        critChanceBonus: 0,
+        critDamageBonus: 0,
+        blockChanceBonus: 0,
+        blockDamageBonus: 0,
+    };
+}
+
+function objectAt(value: JsonObject, key: string): JsonObject {
+    return requireObject(value[key], key);
+}
+
+function optionalObject(value: unknown): JsonObject | undefined {
+    return value !== null && typeof value === 'object' && !Array.isArray(value) ? (value as JsonObject) : undefined;
+}
+
+function requireObject(value: unknown, field: string): JsonObject {
+    const object = optionalObject(value);
+    if (!object) {
+        throw new TypeError(`${field} must be an object`);
+    }
+    return object;
+}
+
+function integerAt(value: JsonObject, key: string, field: string): number {
+    const number = numberAt(value, key, field);
+    if (!Number.isInteger(number)) {
+        throw new TypeError(`${field}.${key} must be an integer`);
+    }
+    return number;
+}
+
+function numberAt(value: JsonObject, key: string, field: string): number {
+    const number = value[key];
+    if (typeof number !== 'number' || !Number.isFinite(number)) {
+        throw new TypeError(`${field}.${key} must be a finite number`);
+    }
+    return number;
+}
+
+function stringAt(value: JsonObject, key: string, field: string): string {
+    const string = value[key];
+    if (typeof string !== 'string') {
+        throw new TypeError(`${field}.${key} must be a string`);
+    }
+    return string;
+}
+
+function numberOrZero(value: unknown): number {
+    return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
+function numberOrDefault(value: unknown, fallback: number): number {
+    return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+function stringArray(value: unknown, field: string): string[] {
+    if (!Array.isArray(value) || !value.every(item => typeof item === 'string')) {
+        throw new TypeError(`${field} must be a string array`);
+    }
+    return value;
+}
+
+function numberArrayAt(value: JsonObject, key: string, field: string): number[] {
+    const array = value[key];
+    if (!Array.isArray(array) || !array.every(item => typeof item === 'number')) {
+        throw new TypeError(`${field}.${key} must be a number array`);
+    }
+    return array;
+}
+
+function nestedStringArrays(value: unknown, field: string): string[][] {
+    if (!Array.isArray(value)) {
+        throw new TypeError(`${field} must be an array`);
+    }
+    return value.map((row, index) => stringArray(row, `${field}[${index}]`));
+}
+
+function nestedNumberArrays(value: unknown, field: string): number[][] {
+    if (!Array.isArray(value)) {
+        throw new TypeError(`${field} must be an array`);
+    }
+    return value.map((row, index) => {
+        if (!Array.isArray(row) || !row.every(item => typeof item === 'number')) {
+            throw new TypeError(`${field}[${index}] must be a number array`);
+        }
+        return row;
+    });
+}
+
+function arrayOfObjects(value: unknown, field: string): JsonObject[] {
+    if (!Array.isArray(value)) {
+        throw new TypeError(`${field} must be an array`);
+    }
+    return value.map((item, index) => requireObject(item, `${field}[${index}]`));
+}

--- a/src/fsd/4-entities/unit/character-power/data/character-power-items.json
+++ b/src/fsd/4-entities/unit/character-power/data/character-power-items.json
@@ -1,0 +1,15644 @@
+{
+    "I_Crit_C001": {
+        "name": "Combat Knife",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_U001",
+        "rarity": "Common",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 22
+                },
+                "dustCost": 10
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 36
+                },
+                "dustCost": 5,
+                "goldCost": 50
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 50
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "Sisterhood",
+            "AstraMilitarum",
+            "BlackLegion",
+            "DeathGuard",
+            "Orks",
+            "BlackTemplars",
+            "SpaceWolves",
+            "ThousandSons",
+            "DarkAngels",
+            "AdeptusMechanicus",
+            "WorldEaters",
+            "BloodAngels",
+            "Genestealers",
+            "EmperorsChildren",
+            "LeaguesOfVotann",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Crit_U001": {
+        "name": "Balanced Combat Knife",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_R001",
+        "rarity": "Uncommon",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 55
+                },
+                "dustCost": 25
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 73
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 91
+                },
+                "dustCost": 15,
+                "goldCost": 150
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 109
+                },
+                "dustCost": 20,
+                "goldCost": 200
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 126
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "Sisterhood",
+            "AstraMilitarum",
+            "BlackLegion",
+            "DeathGuard",
+            "Orks",
+            "BlackTemplars",
+            "SpaceWolves",
+            "ThousandSons",
+            "DarkAngels",
+            "AdeptusMechanicus",
+            "WorldEaters",
+            "BloodAngels",
+            "Genestealers",
+            "EmperorsChildren",
+            "LeaguesOfVotann",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Crit_R001": {
+        "name": "Powered Combat Knife",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_E001",
+        "rarity": "Rare",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 138
+                },
+                "dustCost": 60
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 168
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 197
+                },
+                "dustCost": 40,
+                "goldCost": 350
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 227
+                },
+                "dustCost": 60,
+                "goldCost": 450
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 256
+                },
+                "dustCost": 90,
+                "goldCost": 550
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 286
+                },
+                "dustCost": 120,
+                "goldCost": 650
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 315
+                },
+                "dustCost": 150,
+                "goldCost": 750
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "Sisterhood",
+            "AstraMilitarum",
+            "BlackLegion",
+            "DeathGuard",
+            "Orks",
+            "BlackTemplars",
+            "SpaceWolves",
+            "ThousandSons",
+            "DarkAngels",
+            "AdeptusMechanicus",
+            "WorldEaters",
+            "BloodAngels",
+            "Genestealers",
+            "EmperorsChildren",
+            "LeaguesOfVotann",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Crit_E001": {
+        "name": "Advanced Combat Knife",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_L001",
+        "rarity": "Epic",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 352
+                },
+                "dustCost": 150
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 440
+                },
+                "dustCost": 90,
+                "goldCost": 750
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 527
+                },
+                "dustCost": 120,
+                "goldCost": 1000
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 615
+                },
+                "dustCost": 150,
+                "goldCost": 1250
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 702
+                },
+                "dustCost": 200,
+                "goldCost": 1500
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 789
+                },
+                "dustCost": 250,
+                "goldCost": 1750
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 877
+                },
+                "dustCost": 300,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 964
+                },
+                "dustCost": 350,
+                "goldCost": 2250
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 1052
+                },
+                "dustCost": 400,
+                "goldCost": 2500
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "Sisterhood",
+            "AstraMilitarum",
+            "BlackLegion",
+            "DeathGuard",
+            "Orks",
+            "BlackTemplars",
+            "SpaceWolves",
+            "ThousandSons",
+            "DarkAngels",
+            "AdeptusMechanicus",
+            "WorldEaters",
+            "BloodAngels",
+            "Genestealers",
+            "EmperorsChildren",
+            "LeaguesOfVotann",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Crit_L001": {
+        "name": "Grand Combat Knife",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_M001",
+        "rarity": "Legendary",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 1144
+                },
+                "dustCost": 400
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 1211
+                },
+                "dustCost": 250,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 1277
+                },
+                "dustCost": 350,
+                "goldCost": 3000
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 1344
+                },
+                "dustCost": 450,
+                "goldCost": 4000
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 1410
+                },
+                "dustCost": 600,
+                "goldCost": 6000
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 1476
+                },
+                "dustCost": 800,
+                "goldCost": 8000
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 1543
+                },
+                "dustCost": 1000,
+                "goldCost": 10000
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 1609
+                },
+                "dustCost": 1250,
+                "goldCost": 15000
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 1675
+                },
+                "dustCost": 1500,
+                "goldCost": 20000
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 1742
+                },
+                "dustCost": 2000,
+                "goldCost": 30000
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 1808
+                },
+                "dustCost": 3000,
+                "goldCost": 50000
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "Sisterhood",
+            "AstraMilitarum",
+            "BlackLegion",
+            "DeathGuard",
+            "Orks",
+            "BlackTemplars",
+            "SpaceWolves",
+            "ThousandSons",
+            "DarkAngels",
+            "AdeptusMechanicus",
+            "WorldEaters",
+            "BloodAngels",
+            "Genestealers",
+            "EmperorsChildren",
+            "LeaguesOfVotann",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Crit_M001": {
+        "name": "Ancient Combat Knife",
+        "itemType": "I_Crit",
+        "rarity": "Mythic",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 1835
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 1935
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 2034
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 2133
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 2232
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 2331
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 2430
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 2529
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 2628
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 2727
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "Sisterhood",
+            "AstraMilitarum",
+            "BlackLegion",
+            "DeathGuard",
+            "Orks",
+            "BlackTemplars",
+            "SpaceWolves",
+            "ThousandSons",
+            "DarkAngels",
+            "AdeptusMechanicus",
+            "WorldEaters",
+            "BloodAngels",
+            "Genestealers",
+            "EmperorsChildren",
+            "LeaguesOfVotann",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Crit_C002": {
+        "name": "Standard-Issue Bolt Pistol",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_U002",
+        "rarity": "Common",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 13
+                },
+                "dustCost": 10
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 22
+                },
+                "dustCost": 5,
+                "goldCost": 50
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 30
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "Sisterhood",
+            "AstraMilitarum",
+            "BlackTemplars",
+            "SpaceWolves",
+            "DarkAngels",
+            "AdeptusMechanicus",
+            "BloodAngels",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Crit_U002": {
+        "name": "Battle-Hardened Bolt Pistol",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_R002",
+        "rarity": "Uncommon",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 32
+                },
+                "dustCost": 25
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 43
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 53
+                },
+                "dustCost": 15,
+                "goldCost": 150
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 63
+                },
+                "dustCost": 20,
+                "goldCost": 200
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 74
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "Sisterhood",
+            "AstraMilitarum",
+            "BlackTemplars",
+            "SpaceWolves",
+            "DarkAngels",
+            "AdeptusMechanicus",
+            "BloodAngels",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Crit_R002": {
+        "name": "Sanctified Bolt Pistol",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_E002",
+        "rarity": "Rare",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 80
+                },
+                "dustCost": 60
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 98
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 115
+                },
+                "dustCost": 40,
+                "goldCost": 350
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 132
+                },
+                "dustCost": 60,
+                "goldCost": 450
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 149
+                },
+                "dustCost": 90,
+                "goldCost": 550
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 166
+                },
+                "dustCost": 120,
+                "goldCost": 650
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 183
+                },
+                "dustCost": 150,
+                "goldCost": 750
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "Sisterhood",
+            "AstraMilitarum",
+            "BlackTemplars",
+            "SpaceWolves",
+            "DarkAngels",
+            "AdeptusMechanicus",
+            "BloodAngels",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Crit_E002": {
+        "name": "Master-Crafted Bolt Pistol",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_L002",
+        "rarity": "Epic",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 202
+                },
+                "dustCost": 150
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 253
+                },
+                "dustCost": 90,
+                "goldCost": 750
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 303
+                },
+                "dustCost": 120,
+                "goldCost": 1000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 353
+                },
+                "dustCost": 150,
+                "goldCost": 1250
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 403
+                },
+                "dustCost": 200,
+                "goldCost": 1500
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 453
+                },
+                "dustCost": 250,
+                "goldCost": 1750
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 503
+                },
+                "dustCost": 300,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 554
+                },
+                "dustCost": 350,
+                "goldCost": 2250
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 604
+                },
+                "dustCost": 400,
+                "goldCost": 2500
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "Sisterhood",
+            "AstraMilitarum",
+            "BlackTemplars",
+            "SpaceWolves",
+            "DarkAngels",
+            "AdeptusMechanicus",
+            "BloodAngels",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Crit_L002": {
+        "name": "Artificer Bolt Pistol",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_M002",
+        "rarity": "Legendary",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 648
+                },
+                "dustCost": 400
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 686
+                },
+                "dustCost": 250,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 724
+                },
+                "dustCost": 350,
+                "goldCost": 3000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 761
+                },
+                "dustCost": 450,
+                "goldCost": 4000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 799
+                },
+                "dustCost": 600,
+                "goldCost": 6000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 836
+                },
+                "dustCost": 800,
+                "goldCost": 8000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 874
+                },
+                "dustCost": 1000,
+                "goldCost": 10000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 912
+                },
+                "dustCost": 1250,
+                "goldCost": 15000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 949
+                },
+                "dustCost": 1500,
+                "goldCost": 20000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 987
+                },
+                "dustCost": 2000,
+                "goldCost": 30000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1024
+                },
+                "dustCost": 3000,
+                "goldCost": 50000
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "Sisterhood",
+            "AstraMilitarum",
+            "BlackTemplars",
+            "SpaceWolves",
+            "DarkAngels",
+            "AdeptusMechanicus",
+            "BloodAngels",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Crit_M002": {
+        "name": "Archeotech Bolt Pistol",
+        "itemType": "I_Crit",
+        "rarity": "Mythic",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1050
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1107
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1164
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1221
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1277
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1334
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1391
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1447
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1504
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1561
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "Sisterhood",
+            "AstraMilitarum",
+            "BlackTemplars",
+            "SpaceWolves",
+            "DarkAngels",
+            "AdeptusMechanicus",
+            "BloodAngels",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Crit_C003": {
+        "name": "Void Blade",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_U003",
+        "rarity": "Common",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 22
+                },
+                "dustCost": 10
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 36
+                },
+                "dustCost": 5,
+                "goldCost": 50
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 50
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            }
+        ],
+        "allowedFactions": ["Necrons"]
+    },
+    "I_Crit_U003": {
+        "name": "Subjugating Void Blade",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_R003",
+        "rarity": "Uncommon",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 55
+                },
+                "dustCost": 25
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 73
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 91
+                },
+                "dustCost": 15,
+                "goldCost": 150
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 109
+                },
+                "dustCost": 20,
+                "goldCost": 200
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 126
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            }
+        ],
+        "allowedFactions": ["Necrons"]
+    },
+    "I_Crit_R003": {
+        "name": "Royal Void Blade",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_E003",
+        "rarity": "Rare",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 138
+                },
+                "dustCost": 60
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 168
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 197
+                },
+                "dustCost": 40,
+                "goldCost": 350
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 227
+                },
+                "dustCost": 60,
+                "goldCost": 450
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 256
+                },
+                "dustCost": 90,
+                "goldCost": 550
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 286
+                },
+                "dustCost": 120,
+                "goldCost": 650
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 315
+                },
+                "dustCost": 150,
+                "goldCost": 750
+            }
+        ],
+        "allowedFactions": ["Necrons"]
+    },
+    "I_Crit_E003": {
+        "name": "Hyperphasing Void Blade",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_L003",
+        "rarity": "Epic",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 352
+                },
+                "dustCost": 150
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 440
+                },
+                "dustCost": 90,
+                "goldCost": 750
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 527
+                },
+                "dustCost": 120,
+                "goldCost": 1000
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 615
+                },
+                "dustCost": 150,
+                "goldCost": 1250
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 702
+                },
+                "dustCost": 200,
+                "goldCost": 1500
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 789
+                },
+                "dustCost": 250,
+                "goldCost": 1750
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 877
+                },
+                "dustCost": 300,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 964
+                },
+                "dustCost": 350,
+                "goldCost": 2250
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 1052
+                },
+                "dustCost": 400,
+                "goldCost": 2500
+            }
+        ],
+        "allowedFactions": ["Necrons"]
+    },
+    "I_Crit_L003": {
+        "name": "Transdimensional Void Blade",
+        "itemType": "I_Crit",
+        "rarity": "Legendary",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 1144
+                },
+                "dustCost": 400
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 1211
+                },
+                "dustCost": 250,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 1277
+                },
+                "dustCost": 350,
+                "goldCost": 3000
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 1344
+                },
+                "dustCost": 450,
+                "goldCost": 4000
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 1410
+                },
+                "dustCost": 600,
+                "goldCost": 6000
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 1476
+                },
+                "dustCost": 800,
+                "goldCost": 8000
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 1543
+                },
+                "dustCost": 1000,
+                "goldCost": 10000
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 1609
+                },
+                "dustCost": 1250,
+                "goldCost": 15000
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 1675
+                },
+                "dustCost": 1500,
+                "goldCost": 20000
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 1742
+                },
+                "dustCost": 2000,
+                "goldCost": 30000
+            },
+            {
+                "stats": {
+                    "critChance": 20,
+                    "critDmg": 1808
+                },
+                "dustCost": 3000,
+                "goldCost": 50000
+            }
+        ],
+        "allowedFactions": ["Necrons"]
+    },
+    "I_Crit_U004": {
+        "name": "Heirloom Bolt Pistol",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_R001",
+        "rarity": "Uncommon",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 30,
+                    "critDmg": 40
+                },
+                "dustCost": 25
+            },
+            {
+                "stats": {
+                    "critChance": 30,
+                    "critDmg": 53
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 30,
+                    "critDmg": 66
+                },
+                "dustCost": 15,
+                "goldCost": 150
+            },
+            {
+                "stats": {
+                    "critChance": 30,
+                    "critDmg": 79
+                },
+                "dustCost": 20,
+                "goldCost": 200
+            },
+            {
+                "stats": {
+                    "critChance": 30,
+                    "critDmg": 92
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            }
+        ],
+        "allowedFactions": ["Ultramarines", "Sisterhood", "AstraMilitarum", "BlackTemplars", "AdeptusAstartes"]
+    },
+    "I_Crit_C005": {
+        "name": "Particle Casters",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_U005",
+        "rarity": "Common",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 13
+                },
+                "dustCost": 10
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 22
+                },
+                "dustCost": 5,
+                "goldCost": 50
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 30
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            }
+        ],
+        "allowedFactions": ["Necrons"]
+    },
+    "I_Crit_U005": {
+        "name": "Subjugating Particle Casters",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_R005",
+        "rarity": "Uncommon",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 32
+                },
+                "dustCost": 25
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 43
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 53
+                },
+                "dustCost": 15,
+                "goldCost": 150
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 63
+                },
+                "dustCost": 20,
+                "goldCost": 200
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 74
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            }
+        ],
+        "allowedFactions": ["Necrons"]
+    },
+    "I_Crit_R005": {
+        "name": "Royal Particle Casters",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_E005",
+        "rarity": "Rare",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 80
+                },
+                "dustCost": 60
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 98
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 115
+                },
+                "dustCost": 40,
+                "goldCost": 350
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 132
+                },
+                "dustCost": 60,
+                "goldCost": 450
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 149
+                },
+                "dustCost": 90,
+                "goldCost": 550
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 166
+                },
+                "dustCost": 120,
+                "goldCost": 650
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 183
+                },
+                "dustCost": 150,
+                "goldCost": 750
+            }
+        ],
+        "allowedFactions": ["Necrons"]
+    },
+    "I_Crit_E005": {
+        "name": "Hyperphasing Particle Casters",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_L005",
+        "rarity": "Epic",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 202
+                },
+                "dustCost": 150
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 253
+                },
+                "dustCost": 90,
+                "goldCost": 750
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 303
+                },
+                "dustCost": 120,
+                "goldCost": 1000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 353
+                },
+                "dustCost": 150,
+                "goldCost": 1250
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 403
+                },
+                "dustCost": 200,
+                "goldCost": 1500
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 453
+                },
+                "dustCost": 250,
+                "goldCost": 1750
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 503
+                },
+                "dustCost": 300,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 554
+                },
+                "dustCost": 350,
+                "goldCost": 2250
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 604
+                },
+                "dustCost": 400,
+                "goldCost": 2500
+            }
+        ],
+        "allowedFactions": ["Necrons"]
+    },
+    "I_Crit_L005": {
+        "name": "Transdimensional Particle Casters",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_M005",
+        "rarity": "Legendary",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 648
+                },
+                "dustCost": 400
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 686
+                },
+                "dustCost": 250,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 724
+                },
+                "dustCost": 350,
+                "goldCost": 3000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 761
+                },
+                "dustCost": 450,
+                "goldCost": 4000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 799
+                },
+                "dustCost": 600,
+                "goldCost": 6000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 836
+                },
+                "dustCost": 800,
+                "goldCost": 8000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 874
+                },
+                "dustCost": 1000,
+                "goldCost": 10000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 912
+                },
+                "dustCost": 1250,
+                "goldCost": 15000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 949
+                },
+                "dustCost": 1500,
+                "goldCost": 20000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 987
+                },
+                "dustCost": 2000,
+                "goldCost": 30000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1024
+                },
+                "dustCost": 3000,
+                "goldCost": 50000
+            }
+        ],
+        "allowedFactions": ["Necrons"]
+    },
+    "I_Crit_M005": {
+        "name": "Eternal Particle Casters",
+        "itemType": "I_Crit",
+        "rarity": "Mythic",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1050
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1107
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1164
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1221
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1277
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1334
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1391
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1447
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1504
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1561
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ],
+        "allowedFactions": ["Necrons"]
+    },
+    "I_Crit_C006": {
+        "name": "Blemished Bolt Pistol",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_U006",
+        "rarity": "Common",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 13
+                },
+                "dustCost": 10
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 22
+                },
+                "dustCost": 5,
+                "goldCost": 50
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 30
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            }
+        ],
+        "allowedFactions": ["BlackLegion", "DeathGuard", "ThousandSons", "WorldEaters", "EmperorsChildren"]
+    },
+    "I_Crit_U006": {
+        "name": "Twisted Bolt Pistol",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_R006",
+        "rarity": "Uncommon",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 32
+                },
+                "dustCost": 25
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 43
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 53
+                },
+                "dustCost": 15,
+                "goldCost": 150
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 63
+                },
+                "dustCost": 20,
+                "goldCost": 200
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 74
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            }
+        ],
+        "allowedFactions": ["BlackLegion", "DeathGuard", "ThousandSons", "WorldEaters", "EmperorsChildren"]
+    },
+    "I_Crit_R006": {
+        "name": "Heretical Bolt Pistol",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_E006",
+        "rarity": "Rare",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 80
+                },
+                "dustCost": 60
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 98
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 115
+                },
+                "dustCost": 40,
+                "goldCost": 350
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 132
+                },
+                "dustCost": 60,
+                "goldCost": 450
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 149
+                },
+                "dustCost": 90,
+                "goldCost": 550
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 166
+                },
+                "dustCost": 120,
+                "goldCost": 650
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 183
+                },
+                "dustCost": 150,
+                "goldCost": 750
+            }
+        ],
+        "allowedFactions": ["BlackLegion", "DeathGuard", "ThousandSons", "WorldEaters", "EmperorsChildren"]
+    },
+    "I_Crit_E006": {
+        "name": "Malefic Bolt Pistol",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_L006",
+        "rarity": "Epic",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 202
+                },
+                "dustCost": 150
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 253
+                },
+                "dustCost": 90,
+                "goldCost": 750
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 303
+                },
+                "dustCost": 120,
+                "goldCost": 1000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 353
+                },
+                "dustCost": 150,
+                "goldCost": 1250
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 403
+                },
+                "dustCost": 200,
+                "goldCost": 1500
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 453
+                },
+                "dustCost": 250,
+                "goldCost": 1750
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 503
+                },
+                "dustCost": 300,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 554
+                },
+                "dustCost": 350,
+                "goldCost": 2250
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 604
+                },
+                "dustCost": 400,
+                "goldCost": 2500
+            }
+        ],
+        "allowedFactions": ["BlackLegion", "DeathGuard", "ThousandSons", "WorldEaters", "EmperorsChildren"]
+    },
+    "I_Crit_L006": {
+        "name": "Warpforged Bolt Pistol",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_M006",
+        "rarity": "Legendary",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 648
+                },
+                "dustCost": 400
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 686
+                },
+                "dustCost": 250,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 724
+                },
+                "dustCost": 350,
+                "goldCost": 3000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 761
+                },
+                "dustCost": 450,
+                "goldCost": 4000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 799
+                },
+                "dustCost": 600,
+                "goldCost": 6000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 836
+                },
+                "dustCost": 800,
+                "goldCost": 8000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 874
+                },
+                "dustCost": 1000,
+                "goldCost": 10000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 912
+                },
+                "dustCost": 1250,
+                "goldCost": 15000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 949
+                },
+                "dustCost": 1500,
+                "goldCost": 20000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 987
+                },
+                "dustCost": 2000,
+                "goldCost": 30000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1024
+                },
+                "dustCost": 3000,
+                "goldCost": 50000
+            }
+        ],
+        "allowedFactions": ["BlackLegion", "DeathGuard", "ThousandSons", "WorldEaters", "EmperorsChildren"]
+    },
+    "I_Crit_M006": {
+        "name": "Daemonic Bolt Pistol",
+        "itemType": "I_Crit",
+        "rarity": "Mythic",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1050
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1107
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1164
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1221
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1277
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1334
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1391
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1447
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1504
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1561
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ],
+        "allowedFactions": ["BlackLegion", "DeathGuard", "ThousandSons", "WorldEaters", "EmperorsChildren"]
+    },
+    "I_Crit_C007": {
+        "name": "Slugga",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_U007",
+        "rarity": "Common",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 13
+                },
+                "dustCost": 10
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 22
+                },
+                "dustCost": 5,
+                "goldCost": 50
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 30
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            }
+        ],
+        "allowedFactions": ["Orks"]
+    },
+    "I_Crit_U007": {
+        "name": "Killy Slugga",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_R007",
+        "rarity": "Uncommon",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 32
+                },
+                "dustCost": 25
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 43
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 53
+                },
+                "dustCost": 15,
+                "goldCost": 150
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 63
+                },
+                "dustCost": 20,
+                "goldCost": 200
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 74
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            }
+        ],
+        "allowedFactions": ["Orks"]
+    },
+    "I_Crit_R007": {
+        "name": "Speshul Killy Slugga",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_E007",
+        "rarity": "Rare",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 80
+                },
+                "dustCost": 60
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 98
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 115
+                },
+                "dustCost": 40,
+                "goldCost": 350
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 132
+                },
+                "dustCost": 60,
+                "goldCost": 450
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 149
+                },
+                "dustCost": 90,
+                "goldCost": 550
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 166
+                },
+                "dustCost": 120,
+                "goldCost": 650
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 183
+                },
+                "dustCost": 150,
+                "goldCost": 750
+            }
+        ],
+        "allowedFactions": ["Orks"]
+    },
+    "I_Crit_E007": {
+        "name": "Ded Killy Slugga",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_L007",
+        "rarity": "Epic",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 202
+                },
+                "dustCost": 150
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 253
+                },
+                "dustCost": 90,
+                "goldCost": 750
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 303
+                },
+                "dustCost": 120,
+                "goldCost": 1000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 353
+                },
+                "dustCost": 150,
+                "goldCost": 1250
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 403
+                },
+                "dustCost": 200,
+                "goldCost": 1500
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 453
+                },
+                "dustCost": 250,
+                "goldCost": 1750
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 503
+                },
+                "dustCost": 300,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 554
+                },
+                "dustCost": 350,
+                "goldCost": 2250
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 604
+                },
+                "dustCost": 400,
+                "goldCost": 2500
+            }
+        ],
+        "allowedFactions": ["Orks"]
+    },
+    "I_Crit_L007": {
+        "name": "Ded Shiny Slugga",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_M007",
+        "rarity": "Legendary",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 648
+                },
+                "dustCost": 400
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 686
+                },
+                "dustCost": 250,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 724
+                },
+                "dustCost": 350,
+                "goldCost": 3000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 761
+                },
+                "dustCost": 450,
+                "goldCost": 4000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 799
+                },
+                "dustCost": 600,
+                "goldCost": 6000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 836
+                },
+                "dustCost": 800,
+                "goldCost": 8000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 874
+                },
+                "dustCost": 1000,
+                "goldCost": 10000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 912
+                },
+                "dustCost": 1250,
+                "goldCost": 15000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 949
+                },
+                "dustCost": 1500,
+                "goldCost": 20000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 987
+                },
+                "dustCost": 2000,
+                "goldCost": 30000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1024
+                },
+                "dustCost": 3000,
+                "goldCost": 50000
+            }
+        ],
+        "allowedFactions": ["Orks"]
+    },
+    "I_Crit_M007": {
+        "name": "Supa-Killy Slugga",
+        "itemType": "I_Crit",
+        "rarity": "Mythic",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1050
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1107
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1164
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1221
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1277
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1334
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1391
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1447
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1504
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1561
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ],
+        "allowedFactions": ["Orks"]
+    },
+    "I_Crit_C008": {
+        "name": "Shuriken Pistol",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_U008",
+        "rarity": "Common",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 13
+                },
+                "dustCost": 10
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 22
+                },
+                "dustCost": 5,
+                "goldCost": 50
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 30
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            }
+        ],
+        "allowedFactions": ["Aeldari"]
+    },
+    "I_Crit_U008": {
+        "name": "Aspect Shuriken Pistol",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_R008",
+        "rarity": "Uncommon",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 32
+                },
+                "dustCost": 25
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 43
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 53
+                },
+                "dustCost": 15,
+                "goldCost": 150
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 63
+                },
+                "dustCost": 20,
+                "goldCost": 200
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 74
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            }
+        ],
+        "allowedFactions": ["Aeldari"]
+    },
+    "I_Crit_R008": {
+        "name": "Wraithbone Shuriken Pistol",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_E008",
+        "rarity": "Rare",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 80
+                },
+                "dustCost": 60
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 98
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 115
+                },
+                "dustCost": 40,
+                "goldCost": 350
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 132
+                },
+                "dustCost": 60,
+                "goldCost": 450
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 149
+                },
+                "dustCost": 90,
+                "goldCost": 550
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 166
+                },
+                "dustCost": 120,
+                "goldCost": 650
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 183
+                },
+                "dustCost": 150,
+                "goldCost": 750
+            }
+        ],
+        "allowedFactions": ["Aeldari"]
+    },
+    "I_Crit_E008": {
+        "name": "Mind-Linked Shuriken Pistol",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_L008",
+        "rarity": "Epic",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 202
+                },
+                "dustCost": 150
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 253
+                },
+                "dustCost": 90,
+                "goldCost": 750
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 303
+                },
+                "dustCost": 120,
+                "goldCost": 1000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 353
+                },
+                "dustCost": 150,
+                "goldCost": 1250
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 403
+                },
+                "dustCost": 200,
+                "goldCost": 1500
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 453
+                },
+                "dustCost": 250,
+                "goldCost": 1750
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 503
+                },
+                "dustCost": 300,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 554
+                },
+                "dustCost": 350,
+                "goldCost": 2250
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 604
+                },
+                "dustCost": 400,
+                "goldCost": 2500
+            }
+        ],
+        "allowedFactions": ["Aeldari"]
+    },
+    "I_Crit_L008": {
+        "name": "Soul-Linked Shuriken Pistol",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_M008",
+        "rarity": "Legendary",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 648
+                },
+                "dustCost": 400
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 686
+                },
+                "dustCost": 250,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 724
+                },
+                "dustCost": 350,
+                "goldCost": 3000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 761
+                },
+                "dustCost": 450,
+                "goldCost": 4000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 799
+                },
+                "dustCost": 600,
+                "goldCost": 6000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 836
+                },
+                "dustCost": 800,
+                "goldCost": 8000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 874
+                },
+                "dustCost": 1000,
+                "goldCost": 10000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 912
+                },
+                "dustCost": 1250,
+                "goldCost": 15000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 949
+                },
+                "dustCost": 1500,
+                "goldCost": 20000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 987
+                },
+                "dustCost": 2000,
+                "goldCost": 30000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1024
+                },
+                "dustCost": 3000,
+                "goldCost": 50000
+            }
+        ],
+        "allowedFactions": ["Aeldari"]
+    },
+    "I_Crit_M008": {
+        "name": "Prophesied Shuriken Pistol",
+        "itemType": "I_Crit",
+        "rarity": "Mythic",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1050
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1107
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1164
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1221
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1277
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1334
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1391
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1447
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1504
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1561
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ],
+        "allowedFactions": ["Aeldari"]
+    },
+    "I_Crit_C009": {
+        "name": "Pulse Pistol",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_U009",
+        "rarity": "Common",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 13
+                },
+                "dustCost": 10
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 22
+                },
+                "dustCost": 5,
+                "goldCost": 50
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 30
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            }
+        ],
+        "allowedFactions": ["Tau"]
+    },
+    "I_Crit_U009": {
+        "name": "Fire Caste Pulse Pistol",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_R009",
+        "rarity": "Uncommon",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 32
+                },
+                "dustCost": 25
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 43
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 53
+                },
+                "dustCost": 15,
+                "goldCost": 150
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 63
+                },
+                "dustCost": 20,
+                "goldCost": 200
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 74
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            }
+        ],
+        "allowedFactions": ["Tau"]
+    },
+    "I_Crit_R009": {
+        "name": "Overcharged Pulse Pistol",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_E009",
+        "rarity": "Rare",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 80
+                },
+                "dustCost": 60
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 98
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 115
+                },
+                "dustCost": 40,
+                "goldCost": 350
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 132
+                },
+                "dustCost": 60,
+                "goldCost": 450
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 149
+                },
+                "dustCost": 90,
+                "goldCost": 550
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 166
+                },
+                "dustCost": 120,
+                "goldCost": 650
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 183
+                },
+                "dustCost": 150,
+                "goldCost": 750
+            }
+        ],
+        "allowedFactions": ["Tau"]
+    },
+    "I_Crit_E009": {
+        "name": "Advanced Pulse Pistol",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_L009",
+        "rarity": "Epic",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 202
+                },
+                "dustCost": 150
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 253
+                },
+                "dustCost": 90,
+                "goldCost": 750
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 303
+                },
+                "dustCost": 120,
+                "goldCost": 1000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 353
+                },
+                "dustCost": 150,
+                "goldCost": 1250
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 403
+                },
+                "dustCost": 200,
+                "goldCost": 1500
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 453
+                },
+                "dustCost": 250,
+                "goldCost": 1750
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 503
+                },
+                "dustCost": 300,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 554
+                },
+                "dustCost": 350,
+                "goldCost": 2250
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 604
+                },
+                "dustCost": 400,
+                "goldCost": 2500
+            }
+        ],
+        "allowedFactions": ["Tau"]
+    },
+    "I_Crit_L009": {
+        "name": "Prototype Pulse Pistol",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_M009",
+        "rarity": "Legendary",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 648
+                },
+                "dustCost": 400
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 686
+                },
+                "dustCost": 250,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 724
+                },
+                "dustCost": 350,
+                "goldCost": 3000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 761
+                },
+                "dustCost": 450,
+                "goldCost": 4000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 799
+                },
+                "dustCost": 600,
+                "goldCost": 6000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 836
+                },
+                "dustCost": 800,
+                "goldCost": 8000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 874
+                },
+                "dustCost": 1000,
+                "goldCost": 10000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 912
+                },
+                "dustCost": 1250,
+                "goldCost": 15000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 949
+                },
+                "dustCost": 1500,
+                "goldCost": 20000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 987
+                },
+                "dustCost": 2000,
+                "goldCost": 30000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1024
+                },
+                "dustCost": 3000,
+                "goldCost": 50000
+            }
+        ],
+        "allowedFactions": ["Tau"]
+    },
+    "I_Crit_M009": {
+        "name": "Signature Pulse Pistol",
+        "itemType": "I_Crit",
+        "rarity": "Mythic",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1050
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1107
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1164
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1221
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1277
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1334
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1391
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1447
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1504
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1561
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ],
+        "allowedFactions": ["Tau"]
+    },
+    "I_Crit_C010": {
+        "name": "Ceremonial Knife",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_U010",
+        "rarity": "Common",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 18
+                },
+                "dustCost": 10
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 30
+                },
+                "dustCost": 5,
+                "goldCost": 50
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 41
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            }
+        ],
+        "allowedFactions": ["AstraMilitarum", "Aeldari", "Tau", "ThousandSons", "Custodes"]
+    },
+    "I_Crit_U010": {
+        "name": "Good Ceremonial Knife",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_R010",
+        "rarity": "Uncommon",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 44
+                },
+                "dustCost": 25
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 59
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 73
+                },
+                "dustCost": 15,
+                "goldCost": 150
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 87
+                },
+                "dustCost": 20,
+                "goldCost": 200
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 101
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            }
+        ],
+        "allowedFactions": ["AstraMilitarum", "Aeldari", "Tau", "ThousandSons", "Custodes"]
+    },
+    "I_Crit_R010": {
+        "name": "Fine Ceremonial Knife",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_E010",
+        "rarity": "Rare",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 110
+                },
+                "dustCost": 60
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 134
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 157
+                },
+                "dustCost": 40,
+                "goldCost": 350
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 181
+                },
+                "dustCost": 60,
+                "goldCost": 450
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 204
+                },
+                "dustCost": 90,
+                "goldCost": 550
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 228
+                },
+                "dustCost": 120,
+                "goldCost": 650
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 251
+                },
+                "dustCost": 150,
+                "goldCost": 750
+            }
+        ],
+        "allowedFactions": ["AstraMilitarum", "Aeldari", "Tau", "ThousandSons", "Custodes"]
+    },
+    "I_Crit_E010": {
+        "name": "Adorned Ceremonial Knife",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_L010",
+        "rarity": "Epic",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 279
+                },
+                "dustCost": 150
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 349
+                },
+                "dustCost": 90,
+                "goldCost": 750
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 418
+                },
+                "dustCost": 120,
+                "goldCost": 1000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 487
+                },
+                "dustCost": 150,
+                "goldCost": 1250
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 557
+                },
+                "dustCost": 200,
+                "goldCost": 1500
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 626
+                },
+                "dustCost": 250,
+                "goldCost": 1750
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 695
+                },
+                "dustCost": 300,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 764
+                },
+                "dustCost": 350,
+                "goldCost": 2250
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 834
+                },
+                "dustCost": 400,
+                "goldCost": 2500
+            }
+        ],
+        "allowedFactions": ["AstraMilitarum", "Aeldari", "Tau", "ThousandSons", "Custodes"]
+    },
+    "I_Crit_L010": {
+        "name": "Grand Ceremonial Knife",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_M010",
+        "rarity": "Legendary",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 915
+                },
+                "dustCost": 400
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 969
+                },
+                "dustCost": 250,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1022
+                },
+                "dustCost": 350,
+                "goldCost": 3000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1075
+                },
+                "dustCost": 450,
+                "goldCost": 4000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1128
+                },
+                "dustCost": 600,
+                "goldCost": 6000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1181
+                },
+                "dustCost": 800,
+                "goldCost": 8000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1234
+                },
+                "dustCost": 1000,
+                "goldCost": 10000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1287
+                },
+                "dustCost": 1250,
+                "goldCost": 15000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1340
+                },
+                "dustCost": 1500,
+                "goldCost": 20000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1393
+                },
+                "dustCost": 2000,
+                "goldCost": 30000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1446
+                },
+                "dustCost": 3000,
+                "goldCost": 50000
+            }
+        ],
+        "allowedFactions": ["AstraMilitarum", "Aeldari", "Tau", "ThousandSons", "Custodes"]
+    },
+    "I_Crit_M010": {
+        "name": "Ancient Ceremonial Knife",
+        "itemType": "I_Crit",
+        "rarity": "Mythic",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1470
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1550
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1629
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1709
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1788
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1867
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1947
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 2026
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 2105
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 2185
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ],
+        "allowedFactions": ["AstraMilitarum", "Aeldari", "Tau", "ThousandSons", "Custodes"]
+    },
+    "I_Crit_C011": {
+        "name": "Bonesword",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_U011",
+        "rarity": "Common",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 18
+                },
+                "dustCost": 10
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 30
+                },
+                "dustCost": 5,
+                "goldCost": 50
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 41
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            }
+        ],
+        "allowedFactions": ["Tyranids", "Genestealers"]
+    },
+    "I_Crit_U011": {
+        "name": "Evolved Bonesword",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_R011",
+        "rarity": "Uncommon",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 44
+                },
+                "dustCost": 25
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 59
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 73
+                },
+                "dustCost": 15,
+                "goldCost": 150
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 87
+                },
+                "dustCost": 20,
+                "goldCost": 200
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 101
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            }
+        ],
+        "allowedFactions": ["Tyranids", "Genestealers"]
+    },
+    "I_Crit_R011": {
+        "name": "Augmented Bonesword",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_E011",
+        "rarity": "Rare",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 110
+                },
+                "dustCost": 60
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 134
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 157
+                },
+                "dustCost": 40,
+                "goldCost": 350
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 181
+                },
+                "dustCost": 60,
+                "goldCost": 450
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 204
+                },
+                "dustCost": 90,
+                "goldCost": 550
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 228
+                },
+                "dustCost": 120,
+                "goldCost": 650
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 251
+                },
+                "dustCost": 150,
+                "goldCost": 750
+            }
+        ],
+        "allowedFactions": ["Tyranids", "Genestealers"]
+    },
+    "I_Crit_E011": {
+        "name": "Symbiotic Bonesword",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_L011",
+        "rarity": "Epic",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 279
+                },
+                "dustCost": 150
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 349
+                },
+                "dustCost": 90,
+                "goldCost": 750
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 418
+                },
+                "dustCost": 120,
+                "goldCost": 1000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 487
+                },
+                "dustCost": 150,
+                "goldCost": 1250
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 557
+                },
+                "dustCost": 200,
+                "goldCost": 1500
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 626
+                },
+                "dustCost": 250,
+                "goldCost": 1750
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 695
+                },
+                "dustCost": 300,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 764
+                },
+                "dustCost": 350,
+                "goldCost": 2250
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 834
+                },
+                "dustCost": 400,
+                "goldCost": 2500
+            }
+        ],
+        "allowedFactions": ["Tyranids", "Genestealers"]
+    },
+    "I_Crit_L011": {
+        "name": "Monstrous Bonesword",
+        "itemType": "I_Crit",
+        "nextInSeries": "I_Crit_M011",
+        "rarity": "Legendary",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 915
+                },
+                "dustCost": 400
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 969
+                },
+                "dustCost": 250,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1022
+                },
+                "dustCost": 350,
+                "goldCost": 3000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1075
+                },
+                "dustCost": 450,
+                "goldCost": 4000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1128
+                },
+                "dustCost": 600,
+                "goldCost": 6000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1181
+                },
+                "dustCost": 800,
+                "goldCost": 8000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1234
+                },
+                "dustCost": 1000,
+                "goldCost": 10000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1287
+                },
+                "dustCost": 1250,
+                "goldCost": 15000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1340
+                },
+                "dustCost": 1500,
+                "goldCost": 20000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1393
+                },
+                "dustCost": 2000,
+                "goldCost": 30000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1446
+                },
+                "dustCost": 3000,
+                "goldCost": 50000
+            }
+        ],
+        "allowedFactions": ["Tyranids", "Genestealers"]
+    },
+    "I_Crit_M011": {
+        "name": "Apex Bonesword",
+        "itemType": "I_Crit",
+        "rarity": "Mythic",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1470
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1550
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1629
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1709
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1788
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1867
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1947
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 2026
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 2105
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 2185
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ],
+        "allowedFactions": ["Tyranids", "Genestealers"]
+    },
+    "I_Crit_L132": {
+        "name": "Heavenfall Blade",
+        "itemType": "I_Crit",
+        "rarity": "Legendary",
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 40,
+                    "critDmg": 572
+                },
+                "dustCost": 400
+            },
+            {
+                "stats": {
+                    "critChance": 40,
+                    "critDmg": 606
+                },
+                "dustCost": 250,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "critChance": 40,
+                    "critDmg": 639
+                },
+                "dustCost": 350,
+                "goldCost": 3000
+            },
+            {
+                "stats": {
+                    "critChance": 40,
+                    "critDmg": 672
+                },
+                "dustCost": 450,
+                "goldCost": 4000
+            },
+            {
+                "stats": {
+                    "critChance": 40,
+                    "critDmg": 705
+                },
+                "dustCost": 600,
+                "goldCost": 6000
+            },
+            {
+                "stats": {
+                    "critChance": 40,
+                    "critDmg": 738
+                },
+                "dustCost": 800,
+                "goldCost": 8000
+            },
+            {
+                "stats": {
+                    "critChance": 40,
+                    "critDmg": 772
+                },
+                "dustCost": 1000,
+                "goldCost": 10000
+            },
+            {
+                "stats": {
+                    "critChance": 40,
+                    "critDmg": 805
+                },
+                "dustCost": 1250,
+                "goldCost": 15000
+            },
+            {
+                "stats": {
+                    "critChance": 40,
+                    "critDmg": 838
+                },
+                "dustCost": 1500,
+                "goldCost": 20000
+            },
+            {
+                "stats": {
+                    "critChance": 40,
+                    "critDmg": 871
+                },
+                "dustCost": 2000,
+                "goldCost": 30000
+            },
+            {
+                "stats": {
+                    "critChance": 40,
+                    "critDmg": 904
+                },
+                "dustCost": 3000,
+                "goldCost": 50000
+            }
+        ],
+        "allowedFactions": ["DarkAngels"]
+    },
+    "I_Booster_Crit_C001": {
+        "name": "Standard-Issue Frag Grenades",
+        "itemType": "I_Booster_Crit",
+        "nextInSeries": "I_Booster_Crit_U001",
+        "rarity": "Common",
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 1,
+                    "critDmgBonus": 5
+                },
+                "dustCost": 10
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 1,
+                    "critDmgBonus": 9
+                },
+                "dustCost": 5,
+                "goldCost": 50
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 1,
+                    "critDmgBonus": 12
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "Sisterhood",
+            "AstraMilitarum",
+            "BlackTemplars",
+            "SpaceWolves",
+            "DarkAngels",
+            "AdeptusMechanicus",
+            "BloodAngels",
+            "Custodes",
+            "LeaguesOfVotann",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Booster_Crit_U001": {
+        "name": "Battle Hardened Frag Grenades",
+        "itemType": "I_Booster_Crit",
+        "nextInSeries": "I_Booster_Crit_R001",
+        "rarity": "Uncommon",
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 2,
+                    "critDmgBonus": 13
+                },
+                "dustCost": 25
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 2,
+                    "critDmgBonus": 18
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 2,
+                    "critDmgBonus": 22
+                },
+                "dustCost": 15,
+                "goldCost": 150
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 2,
+                    "critDmgBonus": 26
+                },
+                "dustCost": 20,
+                "goldCost": 200
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 2,
+                    "critDmgBonus": 30
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "Sisterhood",
+            "AstraMilitarum",
+            "BlackTemplars",
+            "SpaceWolves",
+            "DarkAngels",
+            "AdeptusMechanicus",
+            "BloodAngels",
+            "Custodes",
+            "LeaguesOfVotann",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Booster_Crit_R001": {
+        "name": "Sanctified Frag Grenades",
+        "itemType": "I_Booster_Crit",
+        "nextInSeries": "I_Booster_Crit_E001",
+        "rarity": "Rare",
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 30
+                },
+                "dustCost": 60
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 37
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 43
+                },
+                "dustCost": 40,
+                "goldCost": 350
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 50
+                },
+                "dustCost": 60,
+                "goldCost": 450
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 56
+                },
+                "dustCost": 90,
+                "goldCost": 550
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 62
+                },
+                "dustCost": 120,
+                "goldCost": 650
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 69
+                },
+                "dustCost": 150,
+                "goldCost": 750
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "Sisterhood",
+            "AstraMilitarum",
+            "BlackTemplars",
+            "SpaceWolves",
+            "DarkAngels",
+            "AdeptusMechanicus",
+            "BloodAngels",
+            "Custodes",
+            "LeaguesOfVotann",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Booster_Crit_E001": {
+        "name": "Master-Crafted Frag Grenades",
+        "itemType": "I_Booster_Crit",
+        "nextInSeries": "I_Booster_Crit_L001",
+        "rarity": "Epic",
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 69
+                },
+                "dustCost": 150
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 87
+                },
+                "dustCost": 90,
+                "goldCost": 750
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 104
+                },
+                "dustCost": 120,
+                "goldCost": 1000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 121
+                },
+                "dustCost": 150,
+                "goldCost": 1250
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 138
+                },
+                "dustCost": 200,
+                "goldCost": 1500
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 155
+                },
+                "dustCost": 250,
+                "goldCost": 1750
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 172
+                },
+                "dustCost": 300,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 189
+                },
+                "dustCost": 350,
+                "goldCost": 2250
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 207
+                },
+                "dustCost": 400,
+                "goldCost": 2500
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "Sisterhood",
+            "AstraMilitarum",
+            "BlackTemplars",
+            "SpaceWolves",
+            "DarkAngels",
+            "AdeptusMechanicus",
+            "BloodAngels",
+            "Custodes",
+            "LeaguesOfVotann",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Booster_Crit_L001": {
+        "name": "Artificer Frag Grenades",
+        "itemType": "I_Booster_Crit",
+        "nextInSeries": "I_Booster_Crit_M001",
+        "rarity": "Legendary",
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 210
+                },
+                "dustCost": 400
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 223
+                },
+                "dustCost": 250,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 235
+                },
+                "dustCost": 350,
+                "goldCost": 3000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 247
+                },
+                "dustCost": 450,
+                "goldCost": 4000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 259
+                },
+                "dustCost": 600,
+                "goldCost": 6000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 271
+                },
+                "dustCost": 800,
+                "goldCost": 8000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 284
+                },
+                "dustCost": 1000,
+                "goldCost": 10000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 296
+                },
+                "dustCost": 1250,
+                "goldCost": 15000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 308
+                },
+                "dustCost": 1500,
+                "goldCost": 20000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 320
+                },
+                "dustCost": 2000,
+                "goldCost": 30000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 332
+                },
+                "dustCost": 3000,
+                "goldCost": 50000
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "Sisterhood",
+            "AstraMilitarum",
+            "BlackTemplars",
+            "SpaceWolves",
+            "DarkAngels",
+            "AdeptusMechanicus",
+            "BloodAngels",
+            "Custodes",
+            "LeaguesOfVotann",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Booster_Crit_M001": {
+        "name": "Archeotech Frag Grenades",
+        "itemType": "I_Booster_Crit",
+        "rarity": "Mythic",
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 350
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 369
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 388
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 407
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 426
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 445
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 464
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 483
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 502
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 521
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "Sisterhood",
+            "AstraMilitarum",
+            "BlackTemplars",
+            "SpaceWolves",
+            "DarkAngels",
+            "AdeptusMechanicus",
+            "BloodAngels",
+            "Custodes",
+            "LeaguesOfVotann",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Booster_Crit_C002": {
+        "name": "Disruption Fields",
+        "itemType": "I_Booster_Crit",
+        "nextInSeries": "I_Booster_Crit_U002",
+        "rarity": "Common",
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 1,
+                    "critDmgBonus": 5
+                },
+                "dustCost": 10
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 1,
+                    "critDmgBonus": 9
+                },
+                "dustCost": 5,
+                "goldCost": 50
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 1,
+                    "critDmgBonus": 12
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            }
+        ],
+        "allowedFactions": ["Necrons"]
+    },
+    "I_Booster_Crit_U002": {
+        "name": "Subjugating Disruption Fields",
+        "itemType": "I_Booster_Crit",
+        "nextInSeries": "I_Booster_Crit_R002",
+        "rarity": "Uncommon",
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 2,
+                    "critDmgBonus": 13
+                },
+                "dustCost": 25
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 2,
+                    "critDmgBonus": 18
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 2,
+                    "critDmgBonus": 22
+                },
+                "dustCost": 15,
+                "goldCost": 150
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 2,
+                    "critDmgBonus": 26
+                },
+                "dustCost": 20,
+                "goldCost": 200
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 2,
+                    "critDmgBonus": 30
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            }
+        ],
+        "allowedFactions": ["Necrons"]
+    },
+    "I_Booster_Crit_R002": {
+        "name": "Royal Disruption Fields",
+        "itemType": "I_Booster_Crit",
+        "nextInSeries": "I_Booster_Crit_E002",
+        "rarity": "Rare",
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 30
+                },
+                "dustCost": 60
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 37
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 43
+                },
+                "dustCost": 40,
+                "goldCost": 350
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 50
+                },
+                "dustCost": 60,
+                "goldCost": 450
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 56
+                },
+                "dustCost": 90,
+                "goldCost": 550
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 62
+                },
+                "dustCost": 120,
+                "goldCost": 650
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 69
+                },
+                "dustCost": 150,
+                "goldCost": 750
+            }
+        ],
+        "allowedFactions": ["Necrons"]
+    },
+    "I_Booster_Crit_E002": {
+        "name": "Hyperphasing Disruption Fields",
+        "itemType": "I_Booster_Crit",
+        "nextInSeries": "I_Booster_Crit_L002",
+        "rarity": "Epic",
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 69
+                },
+                "dustCost": 150
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 87
+                },
+                "dustCost": 90,
+                "goldCost": 750
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 104
+                },
+                "dustCost": 120,
+                "goldCost": 1000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 121
+                },
+                "dustCost": 150,
+                "goldCost": 1250
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 138
+                },
+                "dustCost": 200,
+                "goldCost": 1500
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 155
+                },
+                "dustCost": 250,
+                "goldCost": 1750
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 172
+                },
+                "dustCost": 300,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 189
+                },
+                "dustCost": 350,
+                "goldCost": 2250
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 207
+                },
+                "dustCost": 400,
+                "goldCost": 2500
+            }
+        ],
+        "allowedFactions": ["Necrons"]
+    },
+    "I_Booster_Crit_L002": {
+        "name": "Transdimensional Disruption Fields",
+        "itemType": "I_Booster_Crit",
+        "nextInSeries": "I_Booster_Crit_M002",
+        "rarity": "Legendary",
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 210
+                },
+                "dustCost": 400
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 223
+                },
+                "dustCost": 250,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 235
+                },
+                "dustCost": 350,
+                "goldCost": 3000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 247
+                },
+                "dustCost": 450,
+                "goldCost": 4000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 259
+                },
+                "dustCost": 600,
+                "goldCost": 6000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 271
+                },
+                "dustCost": 800,
+                "goldCost": 8000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 284
+                },
+                "dustCost": 1000,
+                "goldCost": 10000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 296
+                },
+                "dustCost": 1250,
+                "goldCost": 15000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 308
+                },
+                "dustCost": 1500,
+                "goldCost": 20000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 320
+                },
+                "dustCost": 2000,
+                "goldCost": 30000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 332
+                },
+                "dustCost": 3000,
+                "goldCost": 50000
+            }
+        ],
+        "allowedFactions": ["Necrons"]
+    },
+    "I_Booster_Crit_M002": {
+        "name": "Eternal Disruption Fields",
+        "itemType": "I_Booster_Crit",
+        "rarity": "Mythic",
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 350
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 369
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 388
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 407
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 426
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 445
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 464
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 483
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 502
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 521
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ],
+        "allowedFactions": ["Necrons"]
+    },
+    "I_Booster_Crit_C003": {
+        "name": "Blemished Frag Grenades",
+        "itemType": "I_Booster_Crit",
+        "nextInSeries": "I_Booster_Crit_U003",
+        "rarity": "Common",
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 1,
+                    "critDmgBonus": 5
+                },
+                "dustCost": 10
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 1,
+                    "critDmgBonus": 9
+                },
+                "dustCost": 5,
+                "goldCost": 50
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 1,
+                    "critDmgBonus": 12
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            }
+        ],
+        "allowedFactions": ["BlackLegion", "DeathGuard", "ThousandSons", "WorldEaters", "EmperorsChildren"]
+    },
+    "I_Booster_Crit_U003": {
+        "name": "Twisted Frag Grenades",
+        "itemType": "I_Booster_Crit",
+        "nextInSeries": "I_Booster_Crit_R003",
+        "rarity": "Uncommon",
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 2,
+                    "critDmgBonus": 13
+                },
+                "dustCost": 25
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 2,
+                    "critDmgBonus": 18
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 2,
+                    "critDmgBonus": 22
+                },
+                "dustCost": 15,
+                "goldCost": 150
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 2,
+                    "critDmgBonus": 26
+                },
+                "dustCost": 20,
+                "goldCost": 200
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 2,
+                    "critDmgBonus": 30
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            }
+        ],
+        "allowedFactions": ["BlackLegion", "DeathGuard", "ThousandSons", "WorldEaters", "EmperorsChildren"]
+    },
+    "I_Booster_Crit_R003": {
+        "name": "Heretical Frag Grenades",
+        "itemType": "I_Booster_Crit",
+        "nextInSeries": "I_Booster_Crit_E003",
+        "rarity": "Rare",
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 30
+                },
+                "dustCost": 60
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 37
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 43
+                },
+                "dustCost": 40,
+                "goldCost": 350
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 50
+                },
+                "dustCost": 60,
+                "goldCost": 450
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 56
+                },
+                "dustCost": 90,
+                "goldCost": 550
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 62
+                },
+                "dustCost": 120,
+                "goldCost": 650
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 69
+                },
+                "dustCost": 150,
+                "goldCost": 750
+            }
+        ],
+        "allowedFactions": ["BlackLegion", "DeathGuard", "ThousandSons", "WorldEaters", "EmperorsChildren"]
+    },
+    "I_Booster_Crit_E003": {
+        "name": "Malefic Frag Grenades",
+        "itemType": "I_Booster_Crit",
+        "nextInSeries": "I_Booster_Crit_L003",
+        "rarity": "Epic",
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 69
+                },
+                "dustCost": 150
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 87
+                },
+                "dustCost": 90,
+                "goldCost": 750
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 104
+                },
+                "dustCost": 120,
+                "goldCost": 1000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 121
+                },
+                "dustCost": 150,
+                "goldCost": 1250
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 138
+                },
+                "dustCost": 200,
+                "goldCost": 1500
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 155
+                },
+                "dustCost": 250,
+                "goldCost": 1750
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 172
+                },
+                "dustCost": 300,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 189
+                },
+                "dustCost": 350,
+                "goldCost": 2250
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 207
+                },
+                "dustCost": 400,
+                "goldCost": 2500
+            }
+        ],
+        "allowedFactions": ["BlackLegion", "DeathGuard", "ThousandSons", "WorldEaters", "EmperorsChildren"]
+    },
+    "I_Booster_Crit_L003": {
+        "name": "Warpforged Frag Grenades",
+        "itemType": "I_Booster_Crit",
+        "nextInSeries": "I_Booster_Crit_M003",
+        "rarity": "Legendary",
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 210
+                },
+                "dustCost": 400
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 223
+                },
+                "dustCost": 250,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 235
+                },
+                "dustCost": 350,
+                "goldCost": 3000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 247
+                },
+                "dustCost": 450,
+                "goldCost": 4000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 259
+                },
+                "dustCost": 600,
+                "goldCost": 6000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 271
+                },
+                "dustCost": 800,
+                "goldCost": 8000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 284
+                },
+                "dustCost": 1000,
+                "goldCost": 10000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 296
+                },
+                "dustCost": 1250,
+                "goldCost": 15000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 308
+                },
+                "dustCost": 1500,
+                "goldCost": 20000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 320
+                },
+                "dustCost": 2000,
+                "goldCost": 30000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 332
+                },
+                "dustCost": 3000,
+                "goldCost": 50000
+            }
+        ],
+        "allowedFactions": ["BlackLegion", "DeathGuard", "ThousandSons", "WorldEaters", "EmperorsChildren"]
+    },
+    "I_Booster_Crit_M003": {
+        "name": "Daemonic Frag Grenades",
+        "itemType": "I_Booster_Crit",
+        "rarity": "Mythic",
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 350
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 369
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 388
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 407
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 426
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 445
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 464
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 483
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 502
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 521
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ],
+        "allowedFactions": ["BlackLegion", "DeathGuard", "ThousandSons", "WorldEaters", "EmperorsChildren"]
+    },
+    "I_Booster_Crit_C004": {
+        "name": "Stikkbomz",
+        "itemType": "I_Booster_Crit",
+        "nextInSeries": "I_Booster_Crit_U004",
+        "rarity": "Common",
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 1,
+                    "critDmgBonus": 5
+                },
+                "dustCost": 10
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 1,
+                    "critDmgBonus": 9
+                },
+                "dustCost": 5,
+                "goldCost": 50
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 1,
+                    "critDmgBonus": 12
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            }
+        ],
+        "allowedFactions": ["Orks"]
+    },
+    "I_Booster_Crit_U004": {
+        "name": "Killy Stikkbomz",
+        "itemType": "I_Booster_Crit",
+        "nextInSeries": "I_Booster_Crit_R004",
+        "rarity": "Uncommon",
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 2,
+                    "critDmgBonus": 13
+                },
+                "dustCost": 25
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 2,
+                    "critDmgBonus": 18
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 2,
+                    "critDmgBonus": 22
+                },
+                "dustCost": 15,
+                "goldCost": 150
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 2,
+                    "critDmgBonus": 26
+                },
+                "dustCost": 20,
+                "goldCost": 200
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 2,
+                    "critDmgBonus": 30
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            }
+        ],
+        "allowedFactions": ["Orks"]
+    },
+    "I_Booster_Crit_R004": {
+        "name": "Speshul Killy Stikkbomz",
+        "itemType": "I_Booster_Crit",
+        "nextInSeries": "I_Booster_Crit_E004",
+        "rarity": "Rare",
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 30
+                },
+                "dustCost": 60
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 37
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 43
+                },
+                "dustCost": 40,
+                "goldCost": 350
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 50
+                },
+                "dustCost": 60,
+                "goldCost": 450
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 56
+                },
+                "dustCost": 90,
+                "goldCost": 550
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 62
+                },
+                "dustCost": 120,
+                "goldCost": 650
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 69
+                },
+                "dustCost": 150,
+                "goldCost": 750
+            }
+        ],
+        "allowedFactions": ["Orks"]
+    },
+    "I_Booster_Crit_E004": {
+        "name": "Ded Killy Stikkbomz",
+        "itemType": "I_Booster_Crit",
+        "nextInSeries": "I_Booster_Crit_L004",
+        "rarity": "Epic",
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 69
+                },
+                "dustCost": 150
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 87
+                },
+                "dustCost": 90,
+                "goldCost": 750
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 104
+                },
+                "dustCost": 120,
+                "goldCost": 1000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 121
+                },
+                "dustCost": 150,
+                "goldCost": 1250
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 138
+                },
+                "dustCost": 200,
+                "goldCost": 1500
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 155
+                },
+                "dustCost": 250,
+                "goldCost": 1750
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 172
+                },
+                "dustCost": 300,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 189
+                },
+                "dustCost": 350,
+                "goldCost": 2250
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 207
+                },
+                "dustCost": 400,
+                "goldCost": 2500
+            }
+        ],
+        "allowedFactions": ["Orks"]
+    },
+    "I_Booster_Crit_L004": {
+        "name": "Ded Shiny Stikkbomz",
+        "itemType": "I_Booster_Crit",
+        "nextInSeries": "I_Booster_Crit_M004",
+        "rarity": "Legendary",
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 210
+                },
+                "dustCost": 400
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 223
+                },
+                "dustCost": 250,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 235
+                },
+                "dustCost": 350,
+                "goldCost": 3000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 247
+                },
+                "dustCost": 450,
+                "goldCost": 4000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 259
+                },
+                "dustCost": 600,
+                "goldCost": 6000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 271
+                },
+                "dustCost": 800,
+                "goldCost": 8000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 284
+                },
+                "dustCost": 1000,
+                "goldCost": 10000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 296
+                },
+                "dustCost": 1250,
+                "goldCost": 15000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 308
+                },
+                "dustCost": 1500,
+                "goldCost": 20000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 320
+                },
+                "dustCost": 2000,
+                "goldCost": 30000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 332
+                },
+                "dustCost": 3000,
+                "goldCost": 50000
+            }
+        ],
+        "allowedFactions": ["Orks"]
+    },
+    "I_Booster_Crit_M004": {
+        "name": "Supa-Killy Stikkbomz",
+        "itemType": "I_Booster_Crit",
+        "rarity": "Mythic",
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 350
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 369
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 388
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 407
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 426
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 445
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 464
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 483
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 502
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 521
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ],
+        "allowedFactions": ["Orks"]
+    },
+    "I_Booster_Crit_C005": {
+        "name": "Fusion Charges",
+        "itemType": "I_Booster_Crit",
+        "nextInSeries": "I_Booster_Crit_U005",
+        "rarity": "Common",
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 1,
+                    "critDmgBonus": 5
+                },
+                "dustCost": 10
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 1,
+                    "critDmgBonus": 9
+                },
+                "dustCost": 5,
+                "goldCost": 50
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 1,
+                    "critDmgBonus": 12
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            }
+        ],
+        "allowedFactions": ["Aeldari", "Tau"]
+    },
+    "I_Booster_Crit_U005": {
+        "name": "Improved Fusion Charges",
+        "itemType": "I_Booster_Crit",
+        "nextInSeries": "I_Booster_Crit_R005",
+        "rarity": "Uncommon",
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 2,
+                    "critDmgBonus": 13
+                },
+                "dustCost": 25
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 2,
+                    "critDmgBonus": 18
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 2,
+                    "critDmgBonus": 22
+                },
+                "dustCost": 15,
+                "goldCost": 150
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 2,
+                    "critDmgBonus": 26
+                },
+                "dustCost": 20,
+                "goldCost": 200
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 2,
+                    "critDmgBonus": 30
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            }
+        ],
+        "allowedFactions": ["Aeldari", "Tau"]
+    },
+    "I_Booster_Crit_R005": {
+        "name": "Refined Fusion Charges",
+        "itemType": "I_Booster_Crit",
+        "nextInSeries": "I_Booster_Crit_E005",
+        "rarity": "Rare",
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 30
+                },
+                "dustCost": 60
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 37
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 43
+                },
+                "dustCost": 40,
+                "goldCost": 350
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 50
+                },
+                "dustCost": 60,
+                "goldCost": 450
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 56
+                },
+                "dustCost": 90,
+                "goldCost": 550
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 62
+                },
+                "dustCost": 120,
+                "goldCost": 650
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 69
+                },
+                "dustCost": 150,
+                "goldCost": 750
+            }
+        ],
+        "allowedFactions": ["Aeldari", "Tau"]
+    },
+    "I_Booster_Crit_E005": {
+        "name": "Advanced Fusion Charges",
+        "itemType": "I_Booster_Crit",
+        "nextInSeries": "I_Booster_Crit_L005",
+        "rarity": "Epic",
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 69
+                },
+                "dustCost": 150
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 87
+                },
+                "dustCost": 90,
+                "goldCost": 750
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 104
+                },
+                "dustCost": 120,
+                "goldCost": 1000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 121
+                },
+                "dustCost": 150,
+                "goldCost": 1250
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 138
+                },
+                "dustCost": 200,
+                "goldCost": 1500
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 155
+                },
+                "dustCost": 250,
+                "goldCost": 1750
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 172
+                },
+                "dustCost": 300,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 189
+                },
+                "dustCost": 350,
+                "goldCost": 2250
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 207
+                },
+                "dustCost": 400,
+                "goldCost": 2500
+            }
+        ],
+        "allowedFactions": ["Aeldari", "Tau"]
+    },
+    "I_Booster_Crit_L005": {
+        "name": "Optimal Fusion Charges",
+        "itemType": "I_Booster_Crit",
+        "nextInSeries": "I_Booster_Crit_M005",
+        "rarity": "Legendary",
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 210
+                },
+                "dustCost": 400
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 223
+                },
+                "dustCost": 250,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 235
+                },
+                "dustCost": 350,
+                "goldCost": 3000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 247
+                },
+                "dustCost": 450,
+                "goldCost": 4000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 259
+                },
+                "dustCost": 600,
+                "goldCost": 6000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 271
+                },
+                "dustCost": 800,
+                "goldCost": 8000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 284
+                },
+                "dustCost": 1000,
+                "goldCost": 10000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 296
+                },
+                "dustCost": 1250,
+                "goldCost": 15000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 308
+                },
+                "dustCost": 1500,
+                "goldCost": 20000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 320
+                },
+                "dustCost": 2000,
+                "goldCost": 30000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 332
+                },
+                "dustCost": 3000,
+                "goldCost": 50000
+            }
+        ],
+        "allowedFactions": ["Aeldari", "Tau"]
+    },
+    "I_Booster_Crit_M005": {
+        "name": "Perfected Fusion Charges",
+        "itemType": "I_Booster_Crit",
+        "rarity": "Mythic",
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 350
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 369
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 388
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 407
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 426
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 445
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 464
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 483
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 502
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 521
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ],
+        "allowedFactions": ["Aeldari", "Tau"]
+    },
+    "I_Booster_Crit_C006": {
+        "name": "Lash-Whip",
+        "itemType": "I_Booster_Crit",
+        "nextInSeries": "I_Booster_Crit_U006",
+        "rarity": "Common",
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 1,
+                    "critDmgBonus": 5
+                },
+                "dustCost": 10
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 1,
+                    "critDmgBonus": 9
+                },
+                "dustCost": 5,
+                "goldCost": 50
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 1,
+                    "critDmgBonus": 12
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            }
+        ],
+        "allowedFactions": ["Tyranids", "Genestealers"]
+    },
+    "I_Booster_Crit_U006": {
+        "name": "Evolved Lash-Whip",
+        "itemType": "I_Booster_Crit",
+        "nextInSeries": "I_Booster_Crit_R006",
+        "rarity": "Uncommon",
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 2,
+                    "critDmgBonus": 13
+                },
+                "dustCost": 25
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 2,
+                    "critDmgBonus": 18
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 2,
+                    "critDmgBonus": 22
+                },
+                "dustCost": 15,
+                "goldCost": 150
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 2,
+                    "critDmgBonus": 26
+                },
+                "dustCost": 20,
+                "goldCost": 200
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 2,
+                    "critDmgBonus": 30
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            }
+        ],
+        "allowedFactions": ["Tyranids", "Genestealers"]
+    },
+    "I_Booster_Crit_R006": {
+        "name": "Augmented Lash-Whip",
+        "itemType": "I_Booster_Crit",
+        "nextInSeries": "I_Booster_Crit_E006",
+        "rarity": "Rare",
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 30
+                },
+                "dustCost": 60
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 37
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 43
+                },
+                "dustCost": 40,
+                "goldCost": 350
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 50
+                },
+                "dustCost": 60,
+                "goldCost": 450
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 56
+                },
+                "dustCost": 90,
+                "goldCost": 550
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 62
+                },
+                "dustCost": 120,
+                "goldCost": 650
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 3,
+                    "critDmgBonus": 69
+                },
+                "dustCost": 150,
+                "goldCost": 750
+            }
+        ],
+        "allowedFactions": ["Tyranids", "Genestealers"]
+    },
+    "I_Booster_Crit_E006": {
+        "name": "Symbiotic Lash-Whip",
+        "itemType": "I_Booster_Crit",
+        "nextInSeries": "I_Booster_Crit_L006",
+        "rarity": "Epic",
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 69
+                },
+                "dustCost": 150
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 87
+                },
+                "dustCost": 90,
+                "goldCost": 750
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 104
+                },
+                "dustCost": 120,
+                "goldCost": 1000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 121
+                },
+                "dustCost": 150,
+                "goldCost": 1250
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 138
+                },
+                "dustCost": 200,
+                "goldCost": 1500
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 155
+                },
+                "dustCost": 250,
+                "goldCost": 1750
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 172
+                },
+                "dustCost": 300,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 189
+                },
+                "dustCost": 350,
+                "goldCost": 2250
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 4,
+                    "critDmgBonus": 207
+                },
+                "dustCost": 400,
+                "goldCost": 2500
+            }
+        ],
+        "allowedFactions": ["Tyranids", "Genestealers"]
+    },
+    "I_Booster_Crit_L006": {
+        "name": "Monstrous Lash-Whip",
+        "itemType": "I_Booster_Crit",
+        "nextInSeries": "I_Booster_Crit_M006",
+        "rarity": "Legendary",
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 210
+                },
+                "dustCost": 400
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 223
+                },
+                "dustCost": 250,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 235
+                },
+                "dustCost": 350,
+                "goldCost": 3000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 247
+                },
+                "dustCost": 450,
+                "goldCost": 4000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 259
+                },
+                "dustCost": 600,
+                "goldCost": 6000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 271
+                },
+                "dustCost": 800,
+                "goldCost": 8000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 284
+                },
+                "dustCost": 1000,
+                "goldCost": 10000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 296
+                },
+                "dustCost": 1250,
+                "goldCost": 15000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 308
+                },
+                "dustCost": 1500,
+                "goldCost": 20000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 320
+                },
+                "dustCost": 2000,
+                "goldCost": 30000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 5,
+                    "critDmgBonus": 332
+                },
+                "dustCost": 3000,
+                "goldCost": 50000
+            }
+        ],
+        "allowedFactions": ["Tyranids", "Genestealers"]
+    },
+    "I_Booster_Crit_M006": {
+        "name": "Apex Lash-Whip",
+        "itemType": "I_Booster_Crit",
+        "rarity": "Mythic",
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 350
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 369
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 388
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 407
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 426
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 445
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 464
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 483
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 502
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 521
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ],
+        "allowedFactions": ["Tyranids", "Genestealers"]
+    },
+    "I_Defensive_C001": {
+        "name": "_I_Defensive_C001",
+        "itemType": "I_Defensive",
+        "rarity": "Common",
+        "levels": [
+            {
+                "stats": {
+                    "hp": 12,
+                    "fixedArmor": 3
+                },
+                "dustCost": 10
+            },
+            {
+                "stats": {
+                    "hp": 20,
+                    "fixedArmor": 5
+                },
+                "dustCost": 5,
+                "goldCost": 50
+            },
+            {
+                "stats": {
+                    "hp": 28,
+                    "fixedArmor": 7
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            }
+        ]
+    },
+    "I_Defensive_U001": {
+        "name": "_I_Defensive_U001",
+        "itemType": "I_Defensive",
+        "rarity": "Uncommon",
+        "levels": [
+            {
+                "stats": {
+                    "hp": 29,
+                    "fixedArmor": 8
+                },
+                "dustCost": 25
+            },
+            {
+                "stats": {
+                    "hp": 39,
+                    "fixedArmor": 11
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            },
+            {
+                "stats": {
+                    "hp": 48,
+                    "fixedArmor": 14
+                },
+                "dustCost": 15,
+                "goldCost": 150
+            },
+            {
+                "stats": {
+                    "hp": 58,
+                    "fixedArmor": 16
+                },
+                "dustCost": 20,
+                "goldCost": 200
+            },
+            {
+                "stats": {
+                    "hp": 67,
+                    "fixedArmor": 19
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            }
+        ]
+    },
+    "I_Defensive_R001": {
+        "name": "_I_Defensive_R001",
+        "itemType": "I_Defensive",
+        "rarity": "Rare",
+        "levels": [
+            {
+                "stats": {
+                    "hp": 72,
+                    "fixedArmor": 20
+                },
+                "dustCost": 60
+            },
+            {
+                "stats": {
+                    "hp": 88,
+                    "fixedArmor": 25
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            },
+            {
+                "stats": {
+                    "hp": 103,
+                    "fixedArmor": 29
+                },
+                "dustCost": 40,
+                "goldCost": 350
+            },
+            {
+                "stats": {
+                    "hp": 119,
+                    "fixedArmor": 33
+                },
+                "dustCost": 60,
+                "goldCost": 450
+            },
+            {
+                "stats": {
+                    "hp": 134,
+                    "fixedArmor": 38
+                },
+                "dustCost": 90,
+                "goldCost": 550
+            },
+            {
+                "stats": {
+                    "hp": 149,
+                    "fixedArmor": 42
+                },
+                "dustCost": 120,
+                "goldCost": 650
+            },
+            {
+                "stats": {
+                    "hp": 165,
+                    "fixedArmor": 46
+                },
+                "dustCost": 150,
+                "goldCost": 750
+            }
+        ]
+    },
+    "I_Defensive_E001": {
+        "name": "_I_Defensive_E001",
+        "itemType": "I_Defensive",
+        "rarity": "Epic",
+        "levels": [
+            {
+                "stats": {
+                    "hp": 187,
+                    "fixedArmor": 46
+                },
+                "dustCost": 150
+            },
+            {
+                "stats": {
+                    "hp": 234,
+                    "fixedArmor": 58
+                },
+                "dustCost": 90,
+                "goldCost": 750
+            },
+            {
+                "stats": {
+                    "hp": 280,
+                    "fixedArmor": 69
+                },
+                "dustCost": 120,
+                "goldCost": 1000
+            },
+            {
+                "stats": {
+                    "hp": 327,
+                    "fixedArmor": 81
+                },
+                "dustCost": 150,
+                "goldCost": 1250
+            },
+            {
+                "stats": {
+                    "hp": 373,
+                    "fixedArmor": 92
+                },
+                "dustCost": 200,
+                "goldCost": 1500
+            },
+            {
+                "stats": {
+                    "hp": 420,
+                    "fixedArmor": 104
+                },
+                "dustCost": 250,
+                "goldCost": 1750
+            },
+            {
+                "stats": {
+                    "hp": 466,
+                    "fixedArmor": 115
+                },
+                "dustCost": 300,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "hp": 512,
+                    "fixedArmor": 126
+                },
+                "dustCost": 350,
+                "goldCost": 2250
+            },
+            {
+                "stats": {
+                    "hp": 559,
+                    "fixedArmor": 138
+                },
+                "dustCost": 400,
+                "goldCost": 2500
+            }
+        ]
+    },
+    "I_Defensive_L001": {
+        "name": "_I_Defensive_L001",
+        "itemType": "I_Defensive",
+        "rarity": "Legendary",
+        "levels": [
+            {
+                "stats": {
+                    "hp": 610,
+                    "fixedArmor": 153
+                },
+                "dustCost": 400
+            },
+            {
+                "stats": {
+                    "hp": 646,
+                    "fixedArmor": 162
+                },
+                "dustCost": 250,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "hp": 681,
+                    "fixedArmor": 171
+                },
+                "dustCost": 350,
+                "goldCost": 3000
+            },
+            {
+                "stats": {
+                    "hp": 717,
+                    "fixedArmor": 180
+                },
+                "dustCost": 450,
+                "goldCost": 4000
+            },
+            {
+                "stats": {
+                    "hp": 752,
+                    "fixedArmor": 189
+                },
+                "dustCost": 600,
+                "goldCost": 6000
+            },
+            {
+                "stats": {
+                    "hp": 787,
+                    "fixedArmor": 198
+                },
+                "dustCost": 800,
+                "goldCost": 8000
+            },
+            {
+                "stats": {
+                    "hp": 823,
+                    "fixedArmor": 207
+                },
+                "dustCost": 1000,
+                "goldCost": 10000
+            },
+            {
+                "stats": {
+                    "hp": 858,
+                    "fixedArmor": 216
+                },
+                "dustCost": 1250,
+                "goldCost": 15000
+            },
+            {
+                "stats": {
+                    "hp": 894,
+                    "fixedArmor": 224
+                },
+                "dustCost": 1500,
+                "goldCost": 20000
+            },
+            {
+                "stats": {
+                    "hp": 929,
+                    "fixedArmor": 233
+                },
+                "dustCost": 2000,
+                "goldCost": 30000
+            },
+            {
+                "stats": {
+                    "hp": 964,
+                    "fixedArmor": 242
+                },
+                "dustCost": 3000,
+                "goldCost": 50000
+            }
+        ]
+    },
+    "I_Defensive_C002": {
+        "name": "Standard-Issue MK X Pauldron",
+        "itemType": "I_Defensive",
+        "nextInSeries": "I_Defensive_U002",
+        "rarity": "Common",
+        "levels": [
+            {
+                "stats": {
+                    "hp": 7,
+                    "fixedArmor": 4
+                },
+                "dustCost": 10
+            },
+            {
+                "stats": {
+                    "hp": 12,
+                    "fixedArmor": 7
+                },
+                "dustCost": 5,
+                "goldCost": 50
+            },
+            {
+                "stats": {
+                    "hp": 16,
+                    "fixedArmor": 10
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "BlackTemplars",
+            "SpaceWolves",
+            "DarkAngels",
+            "BloodAngels",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Defensive_U002": {
+        "name": "Battle-Hardened MK X Pauldron",
+        "itemType": "I_Defensive",
+        "nextInSeries": "I_Defensive_R002",
+        "rarity": "Uncommon",
+        "levels": [
+            {
+                "stats": {
+                    "hp": 17,
+                    "fixedArmor": 10
+                },
+                "dustCost": 25
+            },
+            {
+                "stats": {
+                    "hp": 23,
+                    "fixedArmor": 14
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            },
+            {
+                "stats": {
+                    "hp": 28,
+                    "fixedArmor": 17
+                },
+                "dustCost": 15,
+                "goldCost": 150
+            },
+            {
+                "stats": {
+                    "hp": 34,
+                    "fixedArmor": 20
+                },
+                "dustCost": 20,
+                "goldCost": 200
+            },
+            {
+                "stats": {
+                    "hp": 39,
+                    "fixedArmor": 23
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "BlackTemplars",
+            "SpaceWolves",
+            "DarkAngels",
+            "BloodAngels",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Defensive_R002": {
+        "name": "Sanctified MK X Pauldron",
+        "itemType": "I_Defensive",
+        "nextInSeries": "I_Defensive_E002",
+        "rarity": "Rare",
+        "levels": [
+            {
+                "stats": {
+                    "hp": 46,
+                    "fixedArmor": 25
+                },
+                "dustCost": 60
+            },
+            {
+                "stats": {
+                    "hp": 56,
+                    "fixedArmor": 31
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            },
+            {
+                "stats": {
+                    "hp": 66,
+                    "fixedArmor": 36
+                },
+                "dustCost": 40,
+                "goldCost": 350
+            },
+            {
+                "stats": {
+                    "hp": 76,
+                    "fixedArmor": 41
+                },
+                "dustCost": 60,
+                "goldCost": 450
+            },
+            {
+                "stats": {
+                    "hp": 86,
+                    "fixedArmor": 47
+                },
+                "dustCost": 90,
+                "goldCost": 550
+            },
+            {
+                "stats": {
+                    "hp": 96,
+                    "fixedArmor": 52
+                },
+                "dustCost": 120,
+                "goldCost": 650
+            },
+            {
+                "stats": {
+                    "hp": 105,
+                    "fixedArmor": 57
+                },
+                "dustCost": 150,
+                "goldCost": 750
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "BlackTemplars",
+            "SpaceWolves",
+            "DarkAngels",
+            "BloodAngels",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Defensive_E002": {
+        "name": "Master-Crafted MK X Pauldron",
+        "itemType": "I_Defensive",
+        "nextInSeries": "I_Defensive_L002",
+        "rarity": "Epic",
+        "levels": [
+            {
+                "stats": {
+                    "hp": 111,
+                    "fixedArmor": 62
+                },
+                "dustCost": 150
+            },
+            {
+                "stats": {
+                    "hp": 139,
+                    "fixedArmor": 78
+                },
+                "dustCost": 90,
+                "goldCost": 750
+            },
+            {
+                "stats": {
+                    "hp": 167,
+                    "fixedArmor": 93
+                },
+                "dustCost": 120,
+                "goldCost": 1000
+            },
+            {
+                "stats": {
+                    "hp": 194,
+                    "fixedArmor": 109
+                },
+                "dustCost": 150,
+                "goldCost": 1250
+            },
+            {
+                "stats": {
+                    "hp": 222,
+                    "fixedArmor": 124
+                },
+                "dustCost": 200,
+                "goldCost": 1500
+            },
+            {
+                "stats": {
+                    "hp": 249,
+                    "fixedArmor": 139
+                },
+                "dustCost": 250,
+                "goldCost": 1750
+            },
+            {
+                "stats": {
+                    "hp": 277,
+                    "fixedArmor": 155
+                },
+                "dustCost": 300,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "hp": 304,
+                    "fixedArmor": 170
+                },
+                "dustCost": 350,
+                "goldCost": 2250
+            },
+            {
+                "stats": {
+                    "hp": 332,
+                    "fixedArmor": 186
+                },
+                "dustCost": 400,
+                "goldCost": 2500
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "BlackTemplars",
+            "SpaceWolves",
+            "DarkAngels",
+            "BloodAngels",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Defensive_L002": {
+        "name": "Artificer MK X Pauldron",
+        "itemType": "I_Defensive",
+        "rarity": "Legendary",
+        "levels": [
+            {
+                "stats": {
+                    "hp": 359,
+                    "fixedArmor": 201
+                },
+                "dustCost": 400
+            },
+            {
+                "stats": {
+                    "hp": 380,
+                    "fixedArmor": 213
+                },
+                "dustCost": 250,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "hp": 401,
+                    "fixedArmor": 225
+                },
+                "dustCost": 350,
+                "goldCost": 3000
+            },
+            {
+                "stats": {
+                    "hp": 422,
+                    "fixedArmor": 236
+                },
+                "dustCost": 450,
+                "goldCost": 4000
+            },
+            {
+                "stats": {
+                    "hp": 443,
+                    "fixedArmor": 248
+                },
+                "dustCost": 600,
+                "goldCost": 6000
+            },
+            {
+                "stats": {
+                    "hp": 464,
+                    "fixedArmor": 260
+                },
+                "dustCost": 800,
+                "goldCost": 8000
+            },
+            {
+                "stats": {
+                    "hp": 484,
+                    "fixedArmor": 271
+                },
+                "dustCost": 1000,
+                "goldCost": 10000
+            },
+            {
+                "stats": {
+                    "hp": 505,
+                    "fixedArmor": 283
+                },
+                "dustCost": 1250,
+                "goldCost": 15000
+            },
+            {
+                "stats": {
+                    "hp": 526,
+                    "fixedArmor": 295
+                },
+                "dustCost": 1500,
+                "goldCost": 20000
+            },
+            {
+                "stats": {
+                    "hp": 547,
+                    "fixedArmor": 306
+                },
+                "dustCost": 2000,
+                "goldCost": 30000
+            },
+            {
+                "stats": {
+                    "hp": 568,
+                    "fixedArmor": 318
+                },
+                "dustCost": 3000,
+                "goldCost": 50000
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "BlackTemplars",
+            "SpaceWolves",
+            "DarkAngels",
+            "BloodAngels",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Defensive_C003": {
+        "name": "Plated Greaves",
+        "itemType": "I_Defensive",
+        "nextInSeries": "I_Defensive_U003",
+        "rarity": "Common",
+        "levels": [
+            {
+                "stats": {
+                    "fixedArmor": 6
+                },
+                "dustCost": 10
+            },
+            {
+                "stats": {
+                    "fixedArmor": 10
+                },
+                "dustCost": 5,
+                "goldCost": 50
+            },
+            {
+                "stats": {
+                    "fixedArmor": 14
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "Necrons",
+            "Sisterhood",
+            "AstraMilitarum",
+            "BlackLegion",
+            "DeathGuard",
+            "Orks",
+            "BlackTemplars",
+            "Aeldari",
+            "Tau",
+            "SpaceWolves",
+            "ThousandSons",
+            "DarkAngels",
+            "AdeptusMechanicus",
+            "WorldEaters",
+            "BloodAngels",
+            "Genestealers",
+            "Custodes",
+            "EmperorsChildren",
+            "LeaguesOfVotann",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Defensive_U003": {
+        "name": "Good Plated Greaves",
+        "itemType": "I_Defensive",
+        "nextInSeries": "I_Defensive_R003",
+        "rarity": "Uncommon",
+        "levels": [
+            {
+                "stats": {
+                    "fixedArmor": 14
+                },
+                "dustCost": 25
+            },
+            {
+                "stats": {
+                    "fixedArmor": 19
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            },
+            {
+                "stats": {
+                    "fixedArmor": 24
+                },
+                "dustCost": 15,
+                "goldCost": 150
+            },
+            {
+                "stats": {
+                    "fixedArmor": 28
+                },
+                "dustCost": 20,
+                "goldCost": 200
+            },
+            {
+                "stats": {
+                    "fixedArmor": 33
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "Necrons",
+            "Sisterhood",
+            "AstraMilitarum",
+            "BlackLegion",
+            "DeathGuard",
+            "Orks",
+            "BlackTemplars",
+            "Aeldari",
+            "Tau",
+            "SpaceWolves",
+            "ThousandSons",
+            "DarkAngels",
+            "AdeptusMechanicus",
+            "WorldEaters",
+            "BloodAngels",
+            "Genestealers",
+            "Custodes",
+            "EmperorsChildren",
+            "LeaguesOfVotann",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Defensive_R003": {
+        "name": "Fine Plated Greaves",
+        "itemType": "I_Defensive",
+        "nextInSeries": "I_Defensive_E003",
+        "rarity": "Rare",
+        "levels": [
+            {
+                "stats": {
+                    "fixedArmor": 34
+                },
+                "dustCost": 60
+            },
+            {
+                "stats": {
+                    "fixedArmor": 42
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            },
+            {
+                "stats": {
+                    "fixedArmor": 49
+                },
+                "dustCost": 40,
+                "goldCost": 350
+            },
+            {
+                "stats": {
+                    "fixedArmor": 56
+                },
+                "dustCost": 60,
+                "goldCost": 450
+            },
+            {
+                "stats": {
+                    "fixedArmor": 64
+                },
+                "dustCost": 90,
+                "goldCost": 550
+            },
+            {
+                "stats": {
+                    "fixedArmor": 71
+                },
+                "dustCost": 120,
+                "goldCost": 650
+            },
+            {
+                "stats": {
+                    "fixedArmor": 78
+                },
+                "dustCost": 150,
+                "goldCost": 750
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "Necrons",
+            "Sisterhood",
+            "AstraMilitarum",
+            "BlackLegion",
+            "DeathGuard",
+            "Orks",
+            "BlackTemplars",
+            "Aeldari",
+            "Tau",
+            "SpaceWolves",
+            "ThousandSons",
+            "DarkAngels",
+            "AdeptusMechanicus",
+            "WorldEaters",
+            "BloodAngels",
+            "Genestealers",
+            "Custodes",
+            "EmperorsChildren",
+            "LeaguesOfVotann",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Defensive_E003": {
+        "name": "Adorned Plated Greaves",
+        "itemType": "I_Defensive",
+        "nextInSeries": "I_Defensive_L003",
+        "rarity": "Epic",
+        "levels": [
+            {
+                "stats": {
+                    "fixedArmor": 87
+                },
+                "dustCost": 150
+            },
+            {
+                "stats": {
+                    "fixedArmor": 109
+                },
+                "dustCost": 90,
+                "goldCost": 750
+            },
+            {
+                "stats": {
+                    "fixedArmor": 131
+                },
+                "dustCost": 120,
+                "goldCost": 1000
+            },
+            {
+                "stats": {
+                    "fixedArmor": 152
+                },
+                "dustCost": 150,
+                "goldCost": 1250
+            },
+            {
+                "stats": {
+                    "fixedArmor": 174
+                },
+                "dustCost": 200,
+                "goldCost": 1500
+            },
+            {
+                "stats": {
+                    "fixedArmor": 195
+                },
+                "dustCost": 250,
+                "goldCost": 1750
+            },
+            {
+                "stats": {
+                    "fixedArmor": 217
+                },
+                "dustCost": 300,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "fixedArmor": 239
+                },
+                "dustCost": 350,
+                "goldCost": 2250
+            },
+            {
+                "stats": {
+                    "fixedArmor": 260
+                },
+                "dustCost": 400,
+                "goldCost": 2500
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "Necrons",
+            "Sisterhood",
+            "AstraMilitarum",
+            "BlackLegion",
+            "DeathGuard",
+            "Orks",
+            "BlackTemplars",
+            "Aeldari",
+            "Tau",
+            "SpaceWolves",
+            "ThousandSons",
+            "DarkAngels",
+            "AdeptusMechanicus",
+            "WorldEaters",
+            "BloodAngels",
+            "Genestealers",
+            "Custodes",
+            "EmperorsChildren",
+            "LeaguesOfVotann",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Defensive_L003": {
+        "name": "Grand Plated Greaves",
+        "itemType": "I_Defensive",
+        "nextInSeries": "I_Defensive_M003",
+        "rarity": "Legendary",
+        "levels": [
+            {
+                "stats": {
+                    "fixedArmor": 277
+                },
+                "dustCost": 400
+            },
+            {
+                "stats": {
+                    "fixedArmor": 294
+                },
+                "dustCost": 250,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "fixedArmor": 310
+                },
+                "dustCost": 350,
+                "goldCost": 3000
+            },
+            {
+                "stats": {
+                    "fixedArmor": 326
+                },
+                "dustCost": 450,
+                "goldCost": 4000
+            },
+            {
+                "stats": {
+                    "fixedArmor": 342
+                },
+                "dustCost": 600,
+                "goldCost": 6000
+            },
+            {
+                "stats": {
+                    "fixedArmor": 358
+                },
+                "dustCost": 800,
+                "goldCost": 8000
+            },
+            {
+                "stats": {
+                    "fixedArmor": 374
+                },
+                "dustCost": 1000,
+                "goldCost": 10000
+            },
+            {
+                "stats": {
+                    "fixedArmor": 390
+                },
+                "dustCost": 1250,
+                "goldCost": 15000
+            },
+            {
+                "stats": {
+                    "fixedArmor": 406
+                },
+                "dustCost": 1500,
+                "goldCost": 20000
+            },
+            {
+                "stats": {
+                    "fixedArmor": 422
+                },
+                "dustCost": 2000,
+                "goldCost": 30000
+            },
+            {
+                "stats": {
+                    "fixedArmor": 438
+                },
+                "dustCost": 3000,
+                "goldCost": 50000
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "Necrons",
+            "Sisterhood",
+            "AstraMilitarum",
+            "BlackLegion",
+            "DeathGuard",
+            "Orks",
+            "BlackTemplars",
+            "Aeldari",
+            "Tau",
+            "SpaceWolves",
+            "ThousandSons",
+            "DarkAngels",
+            "AdeptusMechanicus",
+            "WorldEaters",
+            "BloodAngels",
+            "Genestealers",
+            "Custodes",
+            "EmperorsChildren",
+            "LeaguesOfVotann",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Defensive_M003": {
+        "name": "Ancient Plated Greaves",
+        "itemType": "I_Defensive",
+        "rarity": "Mythic",
+        "levels": [
+            {
+                "stats": {
+                    "fixedArmor": 440
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "fixedArmor": 464
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "fixedArmor": 488
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "fixedArmor": 512
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "fixedArmor": 536
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "fixedArmor": 559
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "fixedArmor": 583
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "fixedArmor": 607
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "fixedArmor": 631
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "fixedArmor": 654
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "Necrons",
+            "Sisterhood",
+            "AstraMilitarum",
+            "BlackLegion",
+            "DeathGuard",
+            "Orks",
+            "BlackTemplars",
+            "Aeldari",
+            "Tau",
+            "SpaceWolves",
+            "ThousandSons",
+            "DarkAngels",
+            "AdeptusMechanicus",
+            "WorldEaters",
+            "BloodAngels",
+            "Genestealers",
+            "Custodes",
+            "EmperorsChildren",
+            "LeaguesOfVotann",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Defensive_C004": {
+        "name": "Mantle",
+        "itemType": "I_Defensive",
+        "nextInSeries": "I_Defensive_U004",
+        "rarity": "Common",
+        "levels": [
+            {
+                "stats": {
+                    "hp": 7,
+                    "fixedArmor": 4
+                },
+                "dustCost": 10
+            },
+            {
+                "stats": {
+                    "hp": 12,
+                    "fixedArmor": 7
+                },
+                "dustCost": 5,
+                "goldCost": 50
+            },
+            {
+                "stats": {
+                    "hp": 16,
+                    "fixedArmor": 10
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            }
+        ],
+        "allowedFactions": ["Sisterhood", "AstraMilitarum", "AdeptusMechanicus", "Custodes"]
+    },
+    "I_Defensive_U004": {
+        "name": "Good Mantle",
+        "itemType": "I_Defensive",
+        "nextInSeries": "I_Defensive_R004",
+        "rarity": "Uncommon",
+        "levels": [
+            {
+                "stats": {
+                    "hp": 17,
+                    "fixedArmor": 10
+                },
+                "dustCost": 25
+            },
+            {
+                "stats": {
+                    "hp": 23,
+                    "fixedArmor": 14
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            },
+            {
+                "stats": {
+                    "hp": 28,
+                    "fixedArmor": 17
+                },
+                "dustCost": 15,
+                "goldCost": 150
+            },
+            {
+                "stats": {
+                    "hp": 34,
+                    "fixedArmor": 20
+                },
+                "dustCost": 20,
+                "goldCost": 200
+            },
+            {
+                "stats": {
+                    "hp": 39,
+                    "fixedArmor": 23
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            }
+        ],
+        "allowedFactions": ["Sisterhood", "AstraMilitarum", "AdeptusMechanicus", "Custodes"]
+    },
+    "I_Defensive_R004": {
+        "name": "Fine Mantle",
+        "itemType": "I_Defensive",
+        "nextInSeries": "I_Defensive_E004",
+        "rarity": "Rare",
+        "levels": [
+            {
+                "stats": {
+                    "hp": 46,
+                    "fixedArmor": 25
+                },
+                "dustCost": 60
+            },
+            {
+                "stats": {
+                    "hp": 56,
+                    "fixedArmor": 31
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            },
+            {
+                "stats": {
+                    "hp": 66,
+                    "fixedArmor": 36
+                },
+                "dustCost": 40,
+                "goldCost": 350
+            },
+            {
+                "stats": {
+                    "hp": 76,
+                    "fixedArmor": 41
+                },
+                "dustCost": 60,
+                "goldCost": 450
+            },
+            {
+                "stats": {
+                    "hp": 86,
+                    "fixedArmor": 47
+                },
+                "dustCost": 90,
+                "goldCost": 550
+            },
+            {
+                "stats": {
+                    "hp": 96,
+                    "fixedArmor": 52
+                },
+                "dustCost": 120,
+                "goldCost": 650
+            },
+            {
+                "stats": {
+                    "hp": 105,
+                    "fixedArmor": 57
+                },
+                "dustCost": 150,
+                "goldCost": 750
+            }
+        ],
+        "allowedFactions": ["Sisterhood", "AstraMilitarum", "AdeptusMechanicus", "Custodes"]
+    },
+    "I_Defensive_E004": {
+        "name": "Adorned Mantle",
+        "itemType": "I_Defensive",
+        "nextInSeries": "I_Defensive_L004",
+        "rarity": "Epic",
+        "levels": [
+            {
+                "stats": {
+                    "hp": 111,
+                    "fixedArmor": 62
+                },
+                "dustCost": 150
+            },
+            {
+                "stats": {
+                    "hp": 139,
+                    "fixedArmor": 78
+                },
+                "dustCost": 90,
+                "goldCost": 750
+            },
+            {
+                "stats": {
+                    "hp": 167,
+                    "fixedArmor": 93
+                },
+                "dustCost": 120,
+                "goldCost": 1000
+            },
+            {
+                "stats": {
+                    "hp": 194,
+                    "fixedArmor": 109
+                },
+                "dustCost": 150,
+                "goldCost": 1250
+            },
+            {
+                "stats": {
+                    "hp": 222,
+                    "fixedArmor": 124
+                },
+                "dustCost": 200,
+                "goldCost": 1500
+            },
+            {
+                "stats": {
+                    "hp": 249,
+                    "fixedArmor": 139
+                },
+                "dustCost": 250,
+                "goldCost": 1750
+            },
+            {
+                "stats": {
+                    "hp": 277,
+                    "fixedArmor": 155
+                },
+                "dustCost": 300,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "hp": 304,
+                    "fixedArmor": 170
+                },
+                "dustCost": 350,
+                "goldCost": 2250
+            },
+            {
+                "stats": {
+                    "hp": 332,
+                    "fixedArmor": 186
+                },
+                "dustCost": 400,
+                "goldCost": 2500
+            }
+        ],
+        "allowedFactions": ["Sisterhood", "AstraMilitarum", "AdeptusMechanicus", "Custodes"]
+    },
+    "I_Defensive_L004": {
+        "name": "Grand Mantle",
+        "itemType": "I_Defensive",
+        "rarity": "Legendary",
+        "levels": [
+            {
+                "stats": {
+                    "hp": 359,
+                    "fixedArmor": 201
+                },
+                "dustCost": 400
+            },
+            {
+                "stats": {
+                    "hp": 380,
+                    "fixedArmor": 213
+                },
+                "dustCost": 250,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "hp": 401,
+                    "fixedArmor": 225
+                },
+                "dustCost": 350,
+                "goldCost": 3000
+            },
+            {
+                "stats": {
+                    "hp": 422,
+                    "fixedArmor": 236
+                },
+                "dustCost": 450,
+                "goldCost": 4000
+            },
+            {
+                "stats": {
+                    "hp": 443,
+                    "fixedArmor": 248
+                },
+                "dustCost": 600,
+                "goldCost": 6000
+            },
+            {
+                "stats": {
+                    "hp": 464,
+                    "fixedArmor": 260
+                },
+                "dustCost": 800,
+                "goldCost": 8000
+            },
+            {
+                "stats": {
+                    "hp": 484,
+                    "fixedArmor": 271
+                },
+                "dustCost": 1000,
+                "goldCost": 10000
+            },
+            {
+                "stats": {
+                    "hp": 505,
+                    "fixedArmor": 283
+                },
+                "dustCost": 1250,
+                "goldCost": 15000
+            },
+            {
+                "stats": {
+                    "hp": 526,
+                    "fixedArmor": 295
+                },
+                "dustCost": 1500,
+                "goldCost": 20000
+            },
+            {
+                "stats": {
+                    "hp": 547,
+                    "fixedArmor": 306
+                },
+                "dustCost": 2000,
+                "goldCost": 30000
+            },
+            {
+                "stats": {
+                    "hp": 568,
+                    "fixedArmor": 318
+                },
+                "dustCost": 3000,
+                "goldCost": 50000
+            }
+        ],
+        "allowedFactions": ["Sisterhood", "AstraMilitarum", "AdeptusMechanicus", "Custodes"]
+    },
+    "I_Defensive_C005": {
+        "name": "Nanocrystalline Plating",
+        "itemType": "I_Defensive",
+        "nextInSeries": "I_Defensive_U005",
+        "rarity": "Common",
+        "levels": [
+            {
+                "stats": {
+                    "hp": 7,
+                    "fixedArmor": 4
+                },
+                "dustCost": 10
+            },
+            {
+                "stats": {
+                    "hp": 12,
+                    "fixedArmor": 7
+                },
+                "dustCost": 5,
+                "goldCost": 50
+            },
+            {
+                "stats": {
+                    "hp": 16,
+                    "fixedArmor": 10
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            }
+        ],
+        "allowedFactions": ["Necrons", "Tau"]
+    },
+    "I_Defensive_U005": {
+        "name": "Improved Nanocrystalline Plating",
+        "itemType": "I_Defensive",
+        "nextInSeries": "I_Defensive_R005",
+        "rarity": "Uncommon",
+        "levels": [
+            {
+                "stats": {
+                    "hp": 17,
+                    "fixedArmor": 10
+                },
+                "dustCost": 25
+            },
+            {
+                "stats": {
+                    "hp": 23,
+                    "fixedArmor": 14
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            },
+            {
+                "stats": {
+                    "hp": 28,
+                    "fixedArmor": 17
+                },
+                "dustCost": 15,
+                "goldCost": 150
+            },
+            {
+                "stats": {
+                    "hp": 34,
+                    "fixedArmor": 20
+                },
+                "dustCost": 20,
+                "goldCost": 200
+            },
+            {
+                "stats": {
+                    "hp": 39,
+                    "fixedArmor": 23
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            }
+        ],
+        "allowedFactions": ["Necrons", "Tau"]
+    },
+    "I_Defensive_R005": {
+        "name": "Refined Nanocrystalline Plating",
+        "itemType": "I_Defensive",
+        "nextInSeries": "I_Defensive_E005",
+        "rarity": "Rare",
+        "levels": [
+            {
+                "stats": {
+                    "hp": 46,
+                    "fixedArmor": 25
+                },
+                "dustCost": 60
+            },
+            {
+                "stats": {
+                    "hp": 56,
+                    "fixedArmor": 31
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            },
+            {
+                "stats": {
+                    "hp": 66,
+                    "fixedArmor": 36
+                },
+                "dustCost": 40,
+                "goldCost": 350
+            },
+            {
+                "stats": {
+                    "hp": 76,
+                    "fixedArmor": 41
+                },
+                "dustCost": 60,
+                "goldCost": 450
+            },
+            {
+                "stats": {
+                    "hp": 86,
+                    "fixedArmor": 47
+                },
+                "dustCost": 90,
+                "goldCost": 550
+            },
+            {
+                "stats": {
+                    "hp": 96,
+                    "fixedArmor": 52
+                },
+                "dustCost": 120,
+                "goldCost": 650
+            },
+            {
+                "stats": {
+                    "hp": 105,
+                    "fixedArmor": 57
+                },
+                "dustCost": 150,
+                "goldCost": 750
+            }
+        ],
+        "allowedFactions": ["Necrons", "Tau"]
+    },
+    "I_Defensive_E005": {
+        "name": "Advanced Nanocrystalline Plating",
+        "itemType": "I_Defensive",
+        "nextInSeries": "I_Defensive_L005",
+        "rarity": "Epic",
+        "levels": [
+            {
+                "stats": {
+                    "hp": 111,
+                    "fixedArmor": 62
+                },
+                "dustCost": 150
+            },
+            {
+                "stats": {
+                    "hp": 139,
+                    "fixedArmor": 78
+                },
+                "dustCost": 90,
+                "goldCost": 750
+            },
+            {
+                "stats": {
+                    "hp": 167,
+                    "fixedArmor": 93
+                },
+                "dustCost": 120,
+                "goldCost": 1000
+            },
+            {
+                "stats": {
+                    "hp": 194,
+                    "fixedArmor": 109
+                },
+                "dustCost": 150,
+                "goldCost": 1250
+            },
+            {
+                "stats": {
+                    "hp": 222,
+                    "fixedArmor": 124
+                },
+                "dustCost": 200,
+                "goldCost": 1500
+            },
+            {
+                "stats": {
+                    "hp": 249,
+                    "fixedArmor": 139
+                },
+                "dustCost": 250,
+                "goldCost": 1750
+            },
+            {
+                "stats": {
+                    "hp": 277,
+                    "fixedArmor": 155
+                },
+                "dustCost": 300,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "hp": 304,
+                    "fixedArmor": 170
+                },
+                "dustCost": 350,
+                "goldCost": 2250
+            },
+            {
+                "stats": {
+                    "hp": 332,
+                    "fixedArmor": 186
+                },
+                "dustCost": 400,
+                "goldCost": 2500
+            }
+        ],
+        "allowedFactions": ["Necrons", "Tau"]
+    },
+    "I_Defensive_L005": {
+        "name": "Optimal Nanocrystalline Plating",
+        "itemType": "I_Defensive",
+        "nextInSeries": "I_Defensive_M005",
+        "rarity": "Legendary",
+        "levels": [
+            {
+                "stats": {
+                    "hp": 359,
+                    "fixedArmor": 201
+                },
+                "dustCost": 400
+            },
+            {
+                "stats": {
+                    "hp": 380,
+                    "fixedArmor": 213
+                },
+                "dustCost": 250,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "hp": 401,
+                    "fixedArmor": 225
+                },
+                "dustCost": 350,
+                "goldCost": 3000
+            },
+            {
+                "stats": {
+                    "hp": 422,
+                    "fixedArmor": 236
+                },
+                "dustCost": 450,
+                "goldCost": 4000
+            },
+            {
+                "stats": {
+                    "hp": 443,
+                    "fixedArmor": 248
+                },
+                "dustCost": 600,
+                "goldCost": 6000
+            },
+            {
+                "stats": {
+                    "hp": 464,
+                    "fixedArmor": 260
+                },
+                "dustCost": 800,
+                "goldCost": 8000
+            },
+            {
+                "stats": {
+                    "hp": 484,
+                    "fixedArmor": 271
+                },
+                "dustCost": 1000,
+                "goldCost": 10000
+            },
+            {
+                "stats": {
+                    "hp": 505,
+                    "fixedArmor": 283
+                },
+                "dustCost": 1250,
+                "goldCost": 15000
+            },
+            {
+                "stats": {
+                    "hp": 526,
+                    "fixedArmor": 295
+                },
+                "dustCost": 1500,
+                "goldCost": 20000
+            },
+            {
+                "stats": {
+                    "hp": 547,
+                    "fixedArmor": 306
+                },
+                "dustCost": 2000,
+                "goldCost": 30000
+            },
+            {
+                "stats": {
+                    "hp": 568,
+                    "fixedArmor": 318
+                },
+                "dustCost": 3000,
+                "goldCost": 50000
+            }
+        ],
+        "allowedFactions": ["Necrons", "Tau"]
+    },
+    "I_Defensive_M005": {
+        "name": "Perfected Nanocrystalline Plating",
+        "itemType": "I_Defensive",
+        "rarity": "Mythic",
+        "levels": [
+            {
+                "stats": {
+                    "hp": 600,
+                    "fixedArmor": 320
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "hp": 633,
+                    "fixedArmor": 338
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "hp": 665,
+                    "fixedArmor": 355
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "hp": 698,
+                    "fixedArmor": 372
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "hp": 730,
+                    "fixedArmor": 390
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "hp": 762,
+                    "fixedArmor": 407
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "hp": 795,
+                    "fixedArmor": 424
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "hp": 827,
+                    "fixedArmor": 441
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "hp": 860,
+                    "fixedArmor": 459
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "hp": 892,
+                    "fixedArmor": 476
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ],
+        "allowedFactions": ["Necrons", "Tau"]
+    },
+    "I_Defensive_C006": {
+        "name": "Exoskeleton",
+        "itemType": "I_Defensive",
+        "nextInSeries": "I_Defensive_U006",
+        "rarity": "Common",
+        "levels": [
+            {
+                "stats": {
+                    "hp": 7,
+                    "fixedArmor": 4
+                },
+                "dustCost": 10
+            },
+            {
+                "stats": {
+                    "hp": 12,
+                    "fixedArmor": 7
+                },
+                "dustCost": 5,
+                "goldCost": 50
+            },
+            {
+                "stats": {
+                    "hp": 16,
+                    "fixedArmor": 10
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            }
+        ],
+        "allowedFactions": ["Tyranids", "Genestealers"]
+    },
+    "I_Defensive_U006": {
+        "name": "Evolved Exoskeleton",
+        "itemType": "I_Defensive",
+        "nextInSeries": "I_Defensive_R006",
+        "rarity": "Uncommon",
+        "levels": [
+            {
+                "stats": {
+                    "hp": 17,
+                    "fixedArmor": 10
+                },
+                "dustCost": 25
+            },
+            {
+                "stats": {
+                    "hp": 23,
+                    "fixedArmor": 14
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            },
+            {
+                "stats": {
+                    "hp": 28,
+                    "fixedArmor": 17
+                },
+                "dustCost": 15,
+                "goldCost": 150
+            },
+            {
+                "stats": {
+                    "hp": 34,
+                    "fixedArmor": 20
+                },
+                "dustCost": 20,
+                "goldCost": 200
+            },
+            {
+                "stats": {
+                    "hp": 39,
+                    "fixedArmor": 23
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            }
+        ],
+        "allowedFactions": ["Tyranids", "Genestealers"]
+    },
+    "I_Defensive_R006": {
+        "name": "Augmented Exoskeleton",
+        "itemType": "I_Defensive",
+        "nextInSeries": "I_Defensive_E006",
+        "rarity": "Rare",
+        "levels": [
+            {
+                "stats": {
+                    "hp": 46,
+                    "fixedArmor": 25
+                },
+                "dustCost": 60
+            },
+            {
+                "stats": {
+                    "hp": 56,
+                    "fixedArmor": 31
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            },
+            {
+                "stats": {
+                    "hp": 66,
+                    "fixedArmor": 36
+                },
+                "dustCost": 40,
+                "goldCost": 350
+            },
+            {
+                "stats": {
+                    "hp": 76,
+                    "fixedArmor": 41
+                },
+                "dustCost": 60,
+                "goldCost": 450
+            },
+            {
+                "stats": {
+                    "hp": 86,
+                    "fixedArmor": 47
+                },
+                "dustCost": 90,
+                "goldCost": 550
+            },
+            {
+                "stats": {
+                    "hp": 96,
+                    "fixedArmor": 52
+                },
+                "dustCost": 120,
+                "goldCost": 650
+            },
+            {
+                "stats": {
+                    "hp": 105,
+                    "fixedArmor": 57
+                },
+                "dustCost": 150,
+                "goldCost": 750
+            }
+        ],
+        "allowedFactions": ["Tyranids", "Genestealers"]
+    },
+    "I_Defensive_E006": {
+        "name": "Symbiotic Exoskeleton",
+        "itemType": "I_Defensive",
+        "nextInSeries": "I_Defensive_L006",
+        "rarity": "Epic",
+        "levels": [
+            {
+                "stats": {
+                    "hp": 111,
+                    "fixedArmor": 62
+                },
+                "dustCost": 150
+            },
+            {
+                "stats": {
+                    "hp": 139,
+                    "fixedArmor": 78
+                },
+                "dustCost": 90,
+                "goldCost": 750
+            },
+            {
+                "stats": {
+                    "hp": 167,
+                    "fixedArmor": 93
+                },
+                "dustCost": 120,
+                "goldCost": 1000
+            },
+            {
+                "stats": {
+                    "hp": 194,
+                    "fixedArmor": 109
+                },
+                "dustCost": 150,
+                "goldCost": 1250
+            },
+            {
+                "stats": {
+                    "hp": 222,
+                    "fixedArmor": 124
+                },
+                "dustCost": 200,
+                "goldCost": 1500
+            },
+            {
+                "stats": {
+                    "hp": 249,
+                    "fixedArmor": 139
+                },
+                "dustCost": 250,
+                "goldCost": 1750
+            },
+            {
+                "stats": {
+                    "hp": 277,
+                    "fixedArmor": 155
+                },
+                "dustCost": 300,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "hp": 304,
+                    "fixedArmor": 170
+                },
+                "dustCost": 350,
+                "goldCost": 2250
+            },
+            {
+                "stats": {
+                    "hp": 332,
+                    "fixedArmor": 186
+                },
+                "dustCost": 400,
+                "goldCost": 2500
+            }
+        ],
+        "allowedFactions": ["Tyranids", "Genestealers"]
+    },
+    "I_Defensive_L006": {
+        "name": "Monstrous Exoskeleton",
+        "itemType": "I_Defensive",
+        "nextInSeries": "I_Defensive_M006",
+        "rarity": "Legendary",
+        "levels": [
+            {
+                "stats": {
+                    "hp": 359,
+                    "fixedArmor": 201
+                },
+                "dustCost": 400
+            },
+            {
+                "stats": {
+                    "hp": 380,
+                    "fixedArmor": 213
+                },
+                "dustCost": 250,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "hp": 401,
+                    "fixedArmor": 225
+                },
+                "dustCost": 350,
+                "goldCost": 3000
+            },
+            {
+                "stats": {
+                    "hp": 422,
+                    "fixedArmor": 236
+                },
+                "dustCost": 450,
+                "goldCost": 4000
+            },
+            {
+                "stats": {
+                    "hp": 443,
+                    "fixedArmor": 248
+                },
+                "dustCost": 600,
+                "goldCost": 6000
+            },
+            {
+                "stats": {
+                    "hp": 464,
+                    "fixedArmor": 260
+                },
+                "dustCost": 800,
+                "goldCost": 8000
+            },
+            {
+                "stats": {
+                    "hp": 484,
+                    "fixedArmor": 271
+                },
+                "dustCost": 1000,
+                "goldCost": 10000
+            },
+            {
+                "stats": {
+                    "hp": 505,
+                    "fixedArmor": 283
+                },
+                "dustCost": 1250,
+                "goldCost": 15000
+            },
+            {
+                "stats": {
+                    "hp": 526,
+                    "fixedArmor": 295
+                },
+                "dustCost": 1500,
+                "goldCost": 20000
+            },
+            {
+                "stats": {
+                    "hp": 547,
+                    "fixedArmor": 306
+                },
+                "dustCost": 2000,
+                "goldCost": 30000
+            },
+            {
+                "stats": {
+                    "hp": 568,
+                    "fixedArmor": 318
+                },
+                "dustCost": 3000,
+                "goldCost": 50000
+            }
+        ],
+        "allowedFactions": ["Tyranids", "Genestealers"]
+    },
+    "I_Defensive_M006": {
+        "name": "Apex Symbiotic Exoskeleton",
+        "itemType": "I_Defensive",
+        "rarity": "Mythic",
+        "levels": [
+            {
+                "stats": {
+                    "hp": 600,
+                    "fixedArmor": 320
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "hp": 633,
+                    "fixedArmor": 338
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "hp": 665,
+                    "fixedArmor": 355
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "hp": 698,
+                    "fixedArmor": 372
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "hp": 730,
+                    "fixedArmor": 390
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "hp": 762,
+                    "fixedArmor": 407
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "hp": 795,
+                    "fixedArmor": 424
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "hp": 827,
+                    "fixedArmor": 441
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "hp": 860,
+                    "fixedArmor": 459
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "hp": 892,
+                    "fixedArmor": 476
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ],
+        "allowedFactions": ["Tyranids", "Genestealers"]
+    },
+    "I_Defensive_C007": {
+        "name": "Blooded Spiked Pauldron",
+        "itemType": "I_Defensive",
+        "nextInSeries": "I_Defensive_U007",
+        "rarity": "Common",
+        "levels": [
+            {
+                "stats": {
+                    "hp": 7,
+                    "fixedArmor": 4
+                },
+                "dustCost": 10
+            },
+            {
+                "stats": {
+                    "hp": 12,
+                    "fixedArmor": 7
+                },
+                "dustCost": 5,
+                "goldCost": 50
+            },
+            {
+                "stats": {
+                    "hp": 16,
+                    "fixedArmor": 10
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            }
+        ],
+        "allowedFactions": ["BlackLegion", "DeathGuard", "Orks", "ThousandSons", "WorldEaters", "EmperorsChildren"]
+    },
+    "I_Defensive_U007": {
+        "name": "Savage Spiked Pauldron",
+        "itemType": "I_Defensive",
+        "nextInSeries": "I_Defensive_R007",
+        "rarity": "Uncommon",
+        "levels": [
+            {
+                "stats": {
+                    "hp": 17,
+                    "fixedArmor": 10
+                },
+                "dustCost": 25
+            },
+            {
+                "stats": {
+                    "hp": 23,
+                    "fixedArmor": 14
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            },
+            {
+                "stats": {
+                    "hp": 28,
+                    "fixedArmor": 17
+                },
+                "dustCost": 15,
+                "goldCost": 150
+            },
+            {
+                "stats": {
+                    "hp": 34,
+                    "fixedArmor": 20
+                },
+                "dustCost": 20,
+                "goldCost": 200
+            },
+            {
+                "stats": {
+                    "hp": 39,
+                    "fixedArmor": 23
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            }
+        ],
+        "allowedFactions": ["BlackLegion", "DeathGuard", "Orks", "ThousandSons", "WorldEaters", "EmperorsChildren"]
+    },
+    "I_Defensive_R007": {
+        "name": "Brutal Spiked Pauldron",
+        "itemType": "I_Defensive",
+        "nextInSeries": "I_Defensive_E007",
+        "rarity": "Rare",
+        "levels": [
+            {
+                "stats": {
+                    "hp": 46,
+                    "fixedArmor": 25
+                },
+                "dustCost": 60
+            },
+            {
+                "stats": {
+                    "hp": 56,
+                    "fixedArmor": 31
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            },
+            {
+                "stats": {
+                    "hp": 66,
+                    "fixedArmor": 36
+                },
+                "dustCost": 40,
+                "goldCost": 350
+            },
+            {
+                "stats": {
+                    "hp": 76,
+                    "fixedArmor": 41
+                },
+                "dustCost": 60,
+                "goldCost": 450
+            },
+            {
+                "stats": {
+                    "hp": 86,
+                    "fixedArmor": 47
+                },
+                "dustCost": 90,
+                "goldCost": 550
+            },
+            {
+                "stats": {
+                    "hp": 96,
+                    "fixedArmor": 52
+                },
+                "dustCost": 120,
+                "goldCost": 650
+            },
+            {
+                "stats": {
+                    "hp": 105,
+                    "fixedArmor": 57
+                },
+                "dustCost": 150,
+                "goldCost": 750
+            }
+        ],
+        "allowedFactions": ["BlackLegion", "DeathGuard", "Orks", "ThousandSons", "WorldEaters", "EmperorsChildren"]
+    },
+    "I_Defensive_E007": {
+        "name": "Merciless Spiked Pauldron",
+        "itemType": "I_Defensive",
+        "nextInSeries": "I_Defensive_L007",
+        "rarity": "Epic",
+        "levels": [
+            {
+                "stats": {
+                    "hp": 111,
+                    "fixedArmor": 62
+                },
+                "dustCost": 150
+            },
+            {
+                "stats": {
+                    "hp": 139,
+                    "fixedArmor": 78
+                },
+                "dustCost": 90,
+                "goldCost": 750
+            },
+            {
+                "stats": {
+                    "hp": 167,
+                    "fixedArmor": 93
+                },
+                "dustCost": 120,
+                "goldCost": 1000
+            },
+            {
+                "stats": {
+                    "hp": 194,
+                    "fixedArmor": 109
+                },
+                "dustCost": 150,
+                "goldCost": 1250
+            },
+            {
+                "stats": {
+                    "hp": 222,
+                    "fixedArmor": 124
+                },
+                "dustCost": 200,
+                "goldCost": 1500
+            },
+            {
+                "stats": {
+                    "hp": 249,
+                    "fixedArmor": 139
+                },
+                "dustCost": 250,
+                "goldCost": 1750
+            },
+            {
+                "stats": {
+                    "hp": 277,
+                    "fixedArmor": 155
+                },
+                "dustCost": 300,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "hp": 304,
+                    "fixedArmor": 170
+                },
+                "dustCost": 350,
+                "goldCost": 2250
+            },
+            {
+                "stats": {
+                    "hp": 332,
+                    "fixedArmor": 186
+                },
+                "dustCost": 400,
+                "goldCost": 2500
+            }
+        ],
+        "allowedFactions": ["BlackLegion", "DeathGuard", "Orks", "ThousandSons", "WorldEaters", "EmperorsChildren"]
+    },
+    "I_Defensive_L007": {
+        "name": "Monstrous Spiked Pauldron",
+        "itemType": "I_Defensive",
+        "rarity": "Legendary",
+        "levels": [
+            {
+                "stats": {
+                    "hp": 359,
+                    "fixedArmor": 201
+                },
+                "dustCost": 400
+            },
+            {
+                "stats": {
+                    "hp": 380,
+                    "fixedArmor": 213
+                },
+                "dustCost": 250,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "hp": 401,
+                    "fixedArmor": 225
+                },
+                "dustCost": 350,
+                "goldCost": 3000
+            },
+            {
+                "stats": {
+                    "hp": 422,
+                    "fixedArmor": 236
+                },
+                "dustCost": 450,
+                "goldCost": 4000
+            },
+            {
+                "stats": {
+                    "hp": 443,
+                    "fixedArmor": 248
+                },
+                "dustCost": 600,
+                "goldCost": 6000
+            },
+            {
+                "stats": {
+                    "hp": 464,
+                    "fixedArmor": 260
+                },
+                "dustCost": 800,
+                "goldCost": 8000
+            },
+            {
+                "stats": {
+                    "hp": 484,
+                    "fixedArmor": 271
+                },
+                "dustCost": 1000,
+                "goldCost": 10000
+            },
+            {
+                "stats": {
+                    "hp": 505,
+                    "fixedArmor": 283
+                },
+                "dustCost": 1250,
+                "goldCost": 15000
+            },
+            {
+                "stats": {
+                    "hp": 526,
+                    "fixedArmor": 295
+                },
+                "dustCost": 1500,
+                "goldCost": 20000
+            },
+            {
+                "stats": {
+                    "hp": 547,
+                    "fixedArmor": 306
+                },
+                "dustCost": 2000,
+                "goldCost": 30000
+            },
+            {
+                "stats": {
+                    "hp": 568,
+                    "fixedArmor": 318
+                },
+                "dustCost": 3000,
+                "goldCost": 50000
+            }
+        ],
+        "allowedFactions": ["BlackLegion", "DeathGuard", "Orks", "ThousandSons", "WorldEaters", "EmperorsChildren"]
+    },
+    "I_Block_C002": {
+        "name": "Refractor Field",
+        "itemType": "I_Block",
+        "nextInSeries": "I_Block_U002",
+        "rarity": "Common",
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 23
+                },
+                "dustCost": 10
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 38
+                },
+                "dustCost": 5,
+                "goldCost": 50
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 53
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            }
+        ],
+        "allowedFactions": ["Sisterhood", "AstraMilitarum", "AdeptusMechanicus", "Custodes"]
+    },
+    "I_Block_U002": {
+        "name": "Battle-Hardened Refractor Field",
+        "itemType": "I_Block",
+        "nextInSeries": "I_Block_R002",
+        "rarity": "Uncommon",
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 55
+                },
+                "dustCost": 25
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 73
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 91
+                },
+                "dustCost": 15,
+                "goldCost": 150
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 109
+                },
+                "dustCost": 20,
+                "goldCost": 200
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 126
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            }
+        ],
+        "allowedFactions": ["Sisterhood", "AstraMilitarum", "AdeptusMechanicus", "Custodes"]
+    },
+    "I_Block_R002": {
+        "name": "Sanctified Field",
+        "itemType": "I_Block",
+        "nextInSeries": "I_Block_E002",
+        "rarity": "Rare",
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 138
+                },
+                "dustCost": 60
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 168
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 197
+                },
+                "dustCost": 40,
+                "goldCost": 350
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 227
+                },
+                "dustCost": 60,
+                "goldCost": 450
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 256
+                },
+                "dustCost": 90,
+                "goldCost": 550
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 286
+                },
+                "dustCost": 120,
+                "goldCost": 650
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 315
+                },
+                "dustCost": 150,
+                "goldCost": 750
+            }
+        ],
+        "allowedFactions": ["Sisterhood", "AstraMilitarum", "AdeptusMechanicus", "Custodes"]
+    },
+    "I_Block_E002": {
+        "name": "Master-Crafted Refractor Field",
+        "itemType": "I_Block",
+        "nextInSeries": "I_Block_L002",
+        "rarity": "Epic",
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 352
+                },
+                "dustCost": 150
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 440
+                },
+                "dustCost": 90,
+                "goldCost": 750
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 527
+                },
+                "dustCost": 120,
+                "goldCost": 1000
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 615
+                },
+                "dustCost": 150,
+                "goldCost": 1250
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 702
+                },
+                "dustCost": 200,
+                "goldCost": 1500
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 789
+                },
+                "dustCost": 250,
+                "goldCost": 1750
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 877
+                },
+                "dustCost": 300,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 964
+                },
+                "dustCost": 350,
+                "goldCost": 2250
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 1052
+                },
+                "dustCost": 400,
+                "goldCost": 2500
+            }
+        ],
+        "allowedFactions": ["Sisterhood", "AstraMilitarum", "AdeptusMechanicus", "Custodes"]
+    },
+    "I_Block_L002": {
+        "name": "Artificer Refractor Field",
+        "itemType": "I_Block",
+        "rarity": "Legendary",
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 1144
+                },
+                "dustCost": 400
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 1211
+                },
+                "dustCost": 250,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 1277
+                },
+                "dustCost": 350,
+                "goldCost": 3000
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 1344
+                },
+                "dustCost": 450,
+                "goldCost": 4000
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 1410
+                },
+                "dustCost": 600,
+                "goldCost": 6000
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 1476
+                },
+                "dustCost": 800,
+                "goldCost": 8000
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 1543
+                },
+                "dustCost": 1000,
+                "goldCost": 10000
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 1609
+                },
+                "dustCost": 1250,
+                "goldCost": 15000
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 1675
+                },
+                "dustCost": 1500,
+                "goldCost": 20000
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 1742
+                },
+                "dustCost": 2000,
+                "goldCost": 30000
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 1808
+                },
+                "dustCost": 3000,
+                "goldCost": 50000
+            }
+        ],
+        "allowedFactions": ["Sisterhood", "AstraMilitarum", "AdeptusMechanicus", "Custodes"]
+    },
+    "I_Block_C003": {
+        "name": "Force Field",
+        "itemType": "I_Block",
+        "nextInSeries": "I_Block_U003",
+        "rarity": "Common",
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 15
+                },
+                "dustCost": 10
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 25
+                },
+                "dustCost": 5,
+                "goldCost": 50
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 34
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "Necrons",
+            "Sisterhood",
+            "AstraMilitarum",
+            "BlackLegion",
+            "DeathGuard",
+            "Tyranids",
+            "Orks",
+            "BlackTemplars",
+            "Aeldari",
+            "Tau",
+            "SpaceWolves",
+            "ThousandSons",
+            "DarkAngels",
+            "AdeptusMechanicus",
+            "WorldEaters",
+            "BloodAngels",
+            "Genestealers",
+            "Custodes",
+            "EmperorsChildren",
+            "LeaguesOfVotann",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Block_U003": {
+        "name": "Improved Force Field",
+        "itemType": "I_Block",
+        "nextInSeries": "I_Block_R003",
+        "rarity": "Uncommon",
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 37
+                },
+                "dustCost": 25
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 49
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 61
+                },
+                "dustCost": 15,
+                "goldCost": 150
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 73
+                },
+                "dustCost": 20,
+                "goldCost": 200
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 85
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "Necrons",
+            "Sisterhood",
+            "AstraMilitarum",
+            "BlackLegion",
+            "DeathGuard",
+            "Tyranids",
+            "Orks",
+            "BlackTemplars",
+            "Aeldari",
+            "Tau",
+            "SpaceWolves",
+            "ThousandSons",
+            "DarkAngels",
+            "AdeptusMechanicus",
+            "WorldEaters",
+            "BloodAngels",
+            "Genestealers",
+            "Custodes",
+            "EmperorsChildren",
+            "LeaguesOfVotann",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Block_R003": {
+        "name": "Refined Force Field",
+        "itemType": "I_Block",
+        "nextInSeries": "I_Block_E003",
+        "rarity": "Rare",
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 93
+                },
+                "dustCost": 60
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 113
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 133
+                },
+                "dustCost": 40,
+                "goldCost": 350
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 153
+                },
+                "dustCost": 60,
+                "goldCost": 450
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 173
+                },
+                "dustCost": 90,
+                "goldCost": 550
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 193
+                },
+                "dustCost": 120,
+                "goldCost": 650
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 213
+                },
+                "dustCost": 150,
+                "goldCost": 750
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "Necrons",
+            "Sisterhood",
+            "AstraMilitarum",
+            "BlackLegion",
+            "DeathGuard",
+            "Tyranids",
+            "Orks",
+            "BlackTemplars",
+            "Aeldari",
+            "Tau",
+            "SpaceWolves",
+            "ThousandSons",
+            "DarkAngels",
+            "AdeptusMechanicus",
+            "WorldEaters",
+            "BloodAngels",
+            "Genestealers",
+            "Custodes",
+            "EmperorsChildren",
+            "LeaguesOfVotann",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Block_E003": {
+        "name": "Advanced Force Field",
+        "itemType": "I_Block",
+        "nextInSeries": "I_Block_L003",
+        "rarity": "Epic",
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 238
+                },
+                "dustCost": 150
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 298
+                },
+                "dustCost": 90,
+                "goldCost": 750
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 357
+                },
+                "dustCost": 120,
+                "goldCost": 1000
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 416
+                },
+                "dustCost": 150,
+                "goldCost": 1250
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 475
+                },
+                "dustCost": 200,
+                "goldCost": 1500
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 534
+                },
+                "dustCost": 250,
+                "goldCost": 1750
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 593
+                },
+                "dustCost": 300,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 652
+                },
+                "dustCost": 350,
+                "goldCost": 2250
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 711
+                },
+                "dustCost": 400,
+                "goldCost": 2500
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "Necrons",
+            "Sisterhood",
+            "AstraMilitarum",
+            "BlackLegion",
+            "DeathGuard",
+            "Tyranids",
+            "Orks",
+            "BlackTemplars",
+            "Aeldari",
+            "Tau",
+            "SpaceWolves",
+            "ThousandSons",
+            "DarkAngels",
+            "AdeptusMechanicus",
+            "WorldEaters",
+            "BloodAngels",
+            "Genestealers",
+            "Custodes",
+            "EmperorsChildren",
+            "LeaguesOfVotann",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Block_L003": {
+        "name": "Optimal Force Field",
+        "itemType": "I_Block",
+        "nextInSeries": "I_Block_M003",
+        "rarity": "Legendary",
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 762
+                },
+                "dustCost": 400
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 807
+                },
+                "dustCost": 250,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 851
+                },
+                "dustCost": 350,
+                "goldCost": 3000
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 895
+                },
+                "dustCost": 450,
+                "goldCost": 4000
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 939
+                },
+                "dustCost": 600,
+                "goldCost": 6000
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 983
+                },
+                "dustCost": 800,
+                "goldCost": 8000
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 1028
+                },
+                "dustCost": 1000,
+                "goldCost": 10000
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 1072
+                },
+                "dustCost": 1250,
+                "goldCost": 15000
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 1116
+                },
+                "dustCost": 1500,
+                "goldCost": 20000
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 1160
+                },
+                "dustCost": 2000,
+                "goldCost": 30000
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 1204
+                },
+                "dustCost": 3000,
+                "goldCost": 50000
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "Necrons",
+            "Sisterhood",
+            "AstraMilitarum",
+            "BlackLegion",
+            "DeathGuard",
+            "Tyranids",
+            "Orks",
+            "BlackTemplars",
+            "Aeldari",
+            "Tau",
+            "SpaceWolves",
+            "ThousandSons",
+            "DarkAngels",
+            "AdeptusMechanicus",
+            "WorldEaters",
+            "BloodAngels",
+            "Genestealers",
+            "Custodes",
+            "EmperorsChildren",
+            "LeaguesOfVotann",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Block_M003": {
+        "name": "Perfected Force Field",
+        "itemType": "I_Block",
+        "rarity": "Mythic",
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 1230
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 1297
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 1363
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 1430
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 1496
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 1562
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 1629
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 1695
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 1762
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 1828
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "Necrons",
+            "Sisterhood",
+            "AstraMilitarum",
+            "BlackLegion",
+            "DeathGuard",
+            "Tyranids",
+            "Orks",
+            "BlackTemplars",
+            "Aeldari",
+            "Tau",
+            "SpaceWolves",
+            "ThousandSons",
+            "DarkAngels",
+            "AdeptusMechanicus",
+            "WorldEaters",
+            "BloodAngels",
+            "Genestealers",
+            "Custodes",
+            "EmperorsChildren",
+            "LeaguesOfVotann",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Block_C004": {
+        "name": "Iron Halo",
+        "itemType": "I_Block",
+        "nextInSeries": "I_Block_U004",
+        "rarity": "Common",
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 13
+                },
+                "dustCost": 10
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 22
+                },
+                "dustCost": 5,
+                "goldCost": 50
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 30
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "BlackTemplars",
+            "SpaceWolves",
+            "DarkAngels",
+            "BloodAngels",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Block_U004": {
+        "name": "Battle-Hardened Iron Halo",
+        "itemType": "I_Block",
+        "nextInSeries": "I_Block_R004",
+        "rarity": "Uncommon",
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 32
+                },
+                "dustCost": 25
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 43
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 53
+                },
+                "dustCost": 15,
+                "goldCost": 150
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 63
+                },
+                "dustCost": 20,
+                "goldCost": 200
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 74
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "BlackTemplars",
+            "SpaceWolves",
+            "DarkAngels",
+            "BloodAngels",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Block_R004": {
+        "name": "Sanctified Iron Halo",
+        "itemType": "I_Block",
+        "nextInSeries": "I_Block_E004",
+        "rarity": "Rare",
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 80
+                },
+                "dustCost": 60
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 98
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 115
+                },
+                "dustCost": 40,
+                "goldCost": 350
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 132
+                },
+                "dustCost": 60,
+                "goldCost": 450
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 149
+                },
+                "dustCost": 90,
+                "goldCost": 550
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 166
+                },
+                "dustCost": 120,
+                "goldCost": 650
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 183
+                },
+                "dustCost": 150,
+                "goldCost": 750
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "BlackTemplars",
+            "SpaceWolves",
+            "DarkAngels",
+            "BloodAngels",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Block_E004": {
+        "name": "Master-Crafted Iron Halo",
+        "itemType": "I_Block",
+        "nextInSeries": "I_Block_L004",
+        "rarity": "Epic",
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 202
+                },
+                "dustCost": 150
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 253
+                },
+                "dustCost": 90,
+                "goldCost": 750
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 303
+                },
+                "dustCost": 120,
+                "goldCost": 1000
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 353
+                },
+                "dustCost": 150,
+                "goldCost": 1250
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 403
+                },
+                "dustCost": 200,
+                "goldCost": 1500
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 453
+                },
+                "dustCost": 250,
+                "goldCost": 1750
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 503
+                },
+                "dustCost": 300,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 554
+                },
+                "dustCost": 350,
+                "goldCost": 2250
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 604
+                },
+                "dustCost": 400,
+                "goldCost": 2500
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "BlackTemplars",
+            "SpaceWolves",
+            "DarkAngels",
+            "BloodAngels",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Block_L004": {
+        "name": "Artificer Iron Halo",
+        "itemType": "I_Block",
+        "rarity": "Legendary",
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 648
+                },
+                "dustCost": 400
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 686
+                },
+                "dustCost": 250,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 724
+                },
+                "dustCost": 350,
+                "goldCost": 3000
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 761
+                },
+                "dustCost": 450,
+                "goldCost": 4000
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 799
+                },
+                "dustCost": 600,
+                "goldCost": 6000
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 836
+                },
+                "dustCost": 800,
+                "goldCost": 8000
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 874
+                },
+                "dustCost": 1000,
+                "goldCost": 10000
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 912
+                },
+                "dustCost": 1250,
+                "goldCost": 15000
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 949
+                },
+                "dustCost": 1500,
+                "goldCost": 20000
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 987
+                },
+                "dustCost": 2000,
+                "goldCost": 30000
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 1024
+                },
+                "dustCost": 3000,
+                "goldCost": 50000
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "BlackTemplars",
+            "SpaceWolves",
+            "DarkAngels",
+            "BloodAngels",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Block_C005": {
+        "name": "_I_Block_C005",
+        "itemType": "I_Block",
+        "rarity": "Common",
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 25,
+                    "blockDmg": 18
+                },
+                "dustCost": 10
+            },
+            {
+                "stats": {
+                    "blockChance": 25,
+                    "blockDmg": 30
+                },
+                "dustCost": 5,
+                "goldCost": 50
+            },
+            {
+                "stats": {
+                    "blockChance": 25,
+                    "blockDmg": 41
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            }
+        ]
+    },
+    "I_Block_U005": {
+        "name": "_I_Block_U005",
+        "itemType": "I_Block",
+        "rarity": "Uncommon",
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 25,
+                    "blockDmg": 44
+                },
+                "dustCost": 25
+            },
+            {
+                "stats": {
+                    "blockChance": 25,
+                    "blockDmg": 59
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            },
+            {
+                "stats": {
+                    "blockChance": 25,
+                    "blockDmg": 73
+                },
+                "dustCost": 15,
+                "goldCost": 150
+            },
+            {
+                "stats": {
+                    "blockChance": 25,
+                    "blockDmg": 87
+                },
+                "dustCost": 20,
+                "goldCost": 200
+            },
+            {
+                "stats": {
+                    "blockChance": 25,
+                    "blockDmg": 101
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            }
+        ]
+    },
+    "I_Block_R005": {
+        "name": "Power Field",
+        "itemType": "I_Block",
+        "nextInSeries": "I_Block_E002",
+        "rarity": "Rare",
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 25,
+                    "blockDmg": 108
+                },
+                "dustCost": 60
+            },
+            {
+                "stats": {
+                    "blockChance": 25,
+                    "blockDmg": 132
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            },
+            {
+                "stats": {
+                    "blockChance": 25,
+                    "blockDmg": 155
+                },
+                "dustCost": 40,
+                "goldCost": 350
+            },
+            {
+                "stats": {
+                    "blockChance": 25,
+                    "blockDmg": 178
+                },
+                "dustCost": 60,
+                "goldCost": 450
+            },
+            {
+                "stats": {
+                    "blockChance": 25,
+                    "blockDmg": 201
+                },
+                "dustCost": 90,
+                "goldCost": 550
+            },
+            {
+                "stats": {
+                    "blockChance": 25,
+                    "blockDmg": 224
+                },
+                "dustCost": 120,
+                "goldCost": 650
+            },
+            {
+                "stats": {
+                    "blockChance": 25,
+                    "blockDmg": 247
+                },
+                "dustCost": 150,
+                "goldCost": 750
+            }
+        ],
+        "allowedFactions": ["AstraMilitarum"]
+    },
+    "I_Block_E005": {
+        "name": "Master-Crafted Power Field",
+        "itemType": "I_Block",
+        "rarity": "Epic",
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 25,
+                    "blockDmg": 287
+                },
+                "dustCost": 150
+            },
+            {
+                "stats": {
+                    "blockChance": 25,
+                    "blockDmg": 359
+                },
+                "dustCost": 90,
+                "goldCost": 750
+            },
+            {
+                "stats": {
+                    "blockChance": 25,
+                    "blockDmg": 430
+                },
+                "dustCost": 120,
+                "goldCost": 1000
+            },
+            {
+                "stats": {
+                    "blockChance": 25,
+                    "blockDmg": 501
+                },
+                "dustCost": 150,
+                "goldCost": 1250
+            },
+            {
+                "stats": {
+                    "blockChance": 25,
+                    "blockDmg": 573
+                },
+                "dustCost": 200,
+                "goldCost": 1500
+            },
+            {
+                "stats": {
+                    "blockChance": 25,
+                    "blockDmg": 644
+                },
+                "dustCost": 250,
+                "goldCost": 1750
+            },
+            {
+                "stats": {
+                    "blockChance": 25,
+                    "blockDmg": 715
+                },
+                "dustCost": 300,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "blockChance": 25,
+                    "blockDmg": 786
+                },
+                "dustCost": 350,
+                "goldCost": 2250
+            },
+            {
+                "stats": {
+                    "blockChance": 25,
+                    "blockDmg": 858
+                },
+                "dustCost": 400,
+                "goldCost": 2500
+            }
+        ]
+    },
+    "I_Block_L005": {
+        "name": "Artificer Power Field",
+        "itemType": "I_Block",
+        "rarity": "Legendary",
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 25,
+                    "blockDmg": 954
+                },
+                "dustCost": 400
+            },
+            {
+                "stats": {
+                    "blockChance": 25,
+                    "blockDmg": 1010
+                },
+                "dustCost": 250,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "blockChance": 25,
+                    "blockDmg": 1065
+                },
+                "dustCost": 350,
+                "goldCost": 3000
+            },
+            {
+                "stats": {
+                    "blockChance": 25,
+                    "blockDmg": 1121
+                },
+                "dustCost": 450,
+                "goldCost": 4000
+            },
+            {
+                "stats": {
+                    "blockChance": 25,
+                    "blockDmg": 1176
+                },
+                "dustCost": 600,
+                "goldCost": 6000
+            },
+            {
+                "stats": {
+                    "blockChance": 25,
+                    "blockDmg": 1231
+                },
+                "dustCost": 800,
+                "goldCost": 8000
+            },
+            {
+                "stats": {
+                    "blockChance": 25,
+                    "blockDmg": 1287
+                },
+                "dustCost": 1000,
+                "goldCost": 10000
+            },
+            {
+                "stats": {
+                    "blockChance": 25,
+                    "blockDmg": 1342
+                },
+                "dustCost": 1250,
+                "goldCost": 15000
+            },
+            {
+                "stats": {
+                    "blockChance": 25,
+                    "blockDmg": 1397
+                },
+                "dustCost": 1500,
+                "goldCost": 20000
+            },
+            {
+                "stats": {
+                    "blockChance": 25,
+                    "blockDmg": 1453
+                },
+                "dustCost": 2000,
+                "goldCost": 30000
+            },
+            {
+                "stats": {
+                    "blockChance": 25,
+                    "blockDmg": 1508
+                },
+                "dustCost": 3000,
+                "goldCost": 50000
+            }
+        ]
+    },
+    "I_Block_C006": {
+        "name": "Blemished Sigil of Corruption",
+        "itemType": "I_Block",
+        "nextInSeries": "I_Block_U006",
+        "rarity": "Common",
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 23
+                },
+                "dustCost": 10
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 38
+                },
+                "dustCost": 5,
+                "goldCost": 50
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 53
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            }
+        ],
+        "allowedFactions": ["BlackLegion", "DeathGuard", "ThousandSons", "WorldEaters", "EmperorsChildren"]
+    },
+    "I_Block_U006": {
+        "name": "Twisted Sigil of Corruption",
+        "itemType": "I_Block",
+        "nextInSeries": "I_Block_R006",
+        "rarity": "Uncommon",
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 55
+                },
+                "dustCost": 25
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 73
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 91
+                },
+                "dustCost": 15,
+                "goldCost": 150
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 109
+                },
+                "dustCost": 20,
+                "goldCost": 200
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 126
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            }
+        ],
+        "allowedFactions": ["BlackLegion", "DeathGuard", "ThousandSons", "WorldEaters", "EmperorsChildren"]
+    },
+    "I_Block_R006": {
+        "name": "Heretical Sigil of Corruption",
+        "itemType": "I_Block",
+        "nextInSeries": "I_Block_E006",
+        "rarity": "Rare",
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 138
+                },
+                "dustCost": 60
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 168
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 197
+                },
+                "dustCost": 40,
+                "goldCost": 350
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 227
+                },
+                "dustCost": 60,
+                "goldCost": 450
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 256
+                },
+                "dustCost": 90,
+                "goldCost": 550
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 286
+                },
+                "dustCost": 120,
+                "goldCost": 650
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 315
+                },
+                "dustCost": 150,
+                "goldCost": 750
+            }
+        ],
+        "allowedFactions": ["BlackLegion", "DeathGuard", "ThousandSons", "WorldEaters", "EmperorsChildren"]
+    },
+    "I_Block_E006": {
+        "name": "Malefic Sigil of Corruption",
+        "itemType": "I_Block",
+        "nextInSeries": "I_Block_L006",
+        "rarity": "Epic",
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 352
+                },
+                "dustCost": 150
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 440
+                },
+                "dustCost": 90,
+                "goldCost": 750
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 527
+                },
+                "dustCost": 120,
+                "goldCost": 1000
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 615
+                },
+                "dustCost": 150,
+                "goldCost": 1250
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 702
+                },
+                "dustCost": 200,
+                "goldCost": 1500
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 789
+                },
+                "dustCost": 250,
+                "goldCost": 1750
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 877
+                },
+                "dustCost": 300,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 964
+                },
+                "dustCost": 350,
+                "goldCost": 2250
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 1052
+                },
+                "dustCost": 400,
+                "goldCost": 2500
+            }
+        ],
+        "allowedFactions": ["BlackLegion", "DeathGuard", "ThousandSons", "WorldEaters", "EmperorsChildren"]
+    },
+    "I_Block_L006": {
+        "name": "Warpforged Sigil of Corruption",
+        "itemType": "I_Block",
+        "rarity": "Legendary",
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 1144
+                },
+                "dustCost": 400
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 1211
+                },
+                "dustCost": 250,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 1277
+                },
+                "dustCost": 350,
+                "goldCost": 3000
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 1344
+                },
+                "dustCost": 450,
+                "goldCost": 4000
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 1410
+                },
+                "dustCost": 600,
+                "goldCost": 6000
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 1476
+                },
+                "dustCost": 800,
+                "goldCost": 8000
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 1543
+                },
+                "dustCost": 1000,
+                "goldCost": 10000
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 1609
+                },
+                "dustCost": 1250,
+                "goldCost": 15000
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 1675
+                },
+                "dustCost": 1500,
+                "goldCost": 20000
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 1742
+                },
+                "dustCost": 2000,
+                "goldCost": 30000
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 1808
+                },
+                "dustCost": 3000,
+                "goldCost": 50000
+            }
+        ],
+        "allowedFactions": ["BlackLegion", "DeathGuard", "ThousandSons", "WorldEaters", "EmperorsChildren"]
+    },
+    "I_Block_C007": {
+        "name": "Quantum Shield",
+        "itemType": "I_Block",
+        "nextInSeries": "I_Block_U007",
+        "rarity": "Common",
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 13
+                },
+                "dustCost": 10
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 22
+                },
+                "dustCost": 5,
+                "goldCost": 50
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 30
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            }
+        ]
+    },
+    "I_Block_U007": {
+        "name": "Royal Quantum Shield",
+        "itemType": "I_Block",
+        "nextInSeries": "I_Block_R007",
+        "rarity": "Uncommon",
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 32
+                },
+                "dustCost": 25
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 43
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 53
+                },
+                "dustCost": 15,
+                "goldCost": 150
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 63
+                },
+                "dustCost": 20,
+                "goldCost": 200
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 74
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            }
+        ]
+    },
+    "I_Block_R007": {
+        "name": "Phasing Quantum Shield",
+        "itemType": "I_Block",
+        "nextInSeries": "I_Block_E007",
+        "rarity": "Rare",
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 80
+                },
+                "dustCost": 60
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 98
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 115
+                },
+                "dustCost": 40,
+                "goldCost": 350
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 132
+                },
+                "dustCost": 60,
+                "goldCost": 450
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 149
+                },
+                "dustCost": 90,
+                "goldCost": 550
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 166
+                },
+                "dustCost": 120,
+                "goldCost": 650
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 183
+                },
+                "dustCost": 150,
+                "goldCost": 750
+            }
+        ]
+    },
+    "I_Block_E007": {
+        "name": "Ancient Quantum Shield",
+        "itemType": "I_Block",
+        "nextInSeries": "I_Block_L007",
+        "rarity": "Epic",
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 202
+                },
+                "dustCost": 150
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 253
+                },
+                "dustCost": 90,
+                "goldCost": 750
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 303
+                },
+                "dustCost": 120,
+                "goldCost": 1000
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 353
+                },
+                "dustCost": 150,
+                "goldCost": 1250
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 403
+                },
+                "dustCost": 200,
+                "goldCost": 1500
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 453
+                },
+                "dustCost": 250,
+                "goldCost": 1750
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 503
+                },
+                "dustCost": 300,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 554
+                },
+                "dustCost": 350,
+                "goldCost": 2250
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 604
+                },
+                "dustCost": 400,
+                "goldCost": 2500
+            }
+        ]
+    },
+    "I_Block_L007": {
+        "name": "Transdimensional Quantum Shield",
+        "itemType": "I_Block",
+        "rarity": "Legendary",
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 648
+                },
+                "dustCost": 400
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 686
+                },
+                "dustCost": 250,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 724
+                },
+                "dustCost": 350,
+                "goldCost": 3000
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 761
+                },
+                "dustCost": 450,
+                "goldCost": 4000
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 799
+                },
+                "dustCost": 600,
+                "goldCost": 6000
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 836
+                },
+                "dustCost": 800,
+                "goldCost": 8000
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 874
+                },
+                "dustCost": 1000,
+                "goldCost": 10000
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 912
+                },
+                "dustCost": 1250,
+                "goldCost": 15000
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 949
+                },
+                "dustCost": 1500,
+                "goldCost": 20000
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 987
+                },
+                "dustCost": 2000,
+                "goldCost": 30000
+            },
+            {
+                "stats": {
+                    "blockChance": 35,
+                    "blockDmg": 1024
+                },
+                "dustCost": 3000,
+                "goldCost": 50000
+            }
+        ]
+    },
+    "I_Block_C008": {
+        "name": "Illusion Imagafier",
+        "itemType": "I_Block",
+        "nextInSeries": "I_Block_U008",
+        "rarity": "Common",
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 23
+                },
+                "dustCost": 10
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 38
+                },
+                "dustCost": 5,
+                "goldCost": 50
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 53
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            }
+        ],
+        "allowedFactions": ["Necrons", "Aeldari", "Tau"]
+    },
+    "I_Block_U008": {
+        "name": "Improved Illusion Imagafier",
+        "itemType": "I_Block",
+        "nextInSeries": "I_Block_R008",
+        "rarity": "Uncommon",
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 55
+                },
+                "dustCost": 25
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 73
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 91
+                },
+                "dustCost": 15,
+                "goldCost": 150
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 109
+                },
+                "dustCost": 20,
+                "goldCost": 200
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 126
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            }
+        ],
+        "allowedFactions": ["Necrons", "Aeldari", "Tau"]
+    },
+    "I_Block_R008": {
+        "name": "Refined Illusion Imagafier",
+        "itemType": "I_Block",
+        "nextInSeries": "I_Block_E008",
+        "rarity": "Rare",
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 138
+                },
+                "dustCost": 60
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 168
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 197
+                },
+                "dustCost": 40,
+                "goldCost": 350
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 227
+                },
+                "dustCost": 60,
+                "goldCost": 450
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 256
+                },
+                "dustCost": 90,
+                "goldCost": 550
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 286
+                },
+                "dustCost": 120,
+                "goldCost": 650
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 315
+                },
+                "dustCost": 150,
+                "goldCost": 750
+            }
+        ],
+        "allowedFactions": ["Necrons", "Aeldari", "Tau"]
+    },
+    "I_Block_E008": {
+        "name": "Advanced Illusion Imagafier",
+        "itemType": "I_Block",
+        "nextInSeries": "I_Block_L008",
+        "rarity": "Epic",
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 352
+                },
+                "dustCost": 150
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 440
+                },
+                "dustCost": 90,
+                "goldCost": 750
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 527
+                },
+                "dustCost": 120,
+                "goldCost": 1000
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 615
+                },
+                "dustCost": 150,
+                "goldCost": 1250
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 702
+                },
+                "dustCost": 200,
+                "goldCost": 1500
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 789
+                },
+                "dustCost": 250,
+                "goldCost": 1750
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 877
+                },
+                "dustCost": 300,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 964
+                },
+                "dustCost": 350,
+                "goldCost": 2250
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 1052
+                },
+                "dustCost": 400,
+                "goldCost": 2500
+            }
+        ],
+        "allowedFactions": ["Necrons", "Aeldari", "Tau"]
+    },
+    "I_Block_L008": {
+        "name": "Optimal Illusion Imagafier",
+        "itemType": "I_Block",
+        "rarity": "Legendary",
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 1144
+                },
+                "dustCost": 400
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 1211
+                },
+                "dustCost": 250,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 1277
+                },
+                "dustCost": 350,
+                "goldCost": 3000
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 1344
+                },
+                "dustCost": 450,
+                "goldCost": 4000
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 1410
+                },
+                "dustCost": 600,
+                "goldCost": 6000
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 1476
+                },
+                "dustCost": 800,
+                "goldCost": 8000
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 1543
+                },
+                "dustCost": 1000,
+                "goldCost": 10000
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 1609
+                },
+                "dustCost": 1250,
+                "goldCost": 15000
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 1675
+                },
+                "dustCost": 1500,
+                "goldCost": 20000
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 1742
+                },
+                "dustCost": 2000,
+                "goldCost": 30000
+            },
+            {
+                "stats": {
+                    "blockChance": 20,
+                    "blockDmg": 1808
+                },
+                "dustCost": 3000,
+                "goldCost": 50000
+            }
+        ],
+        "allowedFactions": ["Necrons", "Aeldari", "Tau"]
+    },
+    "I_Booster_Block_C001": {
+        "name": "_I_Booster_Block_C001",
+        "itemType": "I_Booster_Block",
+        "rarity": "Common",
+        "levels": [
+            {
+                "stats": {
+                    "blockChanceBonus": 1,
+                    "blockDmgBonus": 5
+                },
+                "dustCost": 10
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 1,
+                    "blockDmgBonus": 9
+                },
+                "dustCost": 5,
+                "goldCost": 50
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 1,
+                    "blockDmgBonus": 12
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            }
+        ]
+    },
+    "I_Booster_Block_U001": {
+        "name": "_I_Booster_Block_U001",
+        "itemType": "I_Booster_Block",
+        "rarity": "Uncommon",
+        "levels": [
+            {
+                "stats": {
+                    "blockChanceBonus": 2,
+                    "blockDmgBonus": 13
+                },
+                "dustCost": 25
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 2,
+                    "blockDmgBonus": 18
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 2,
+                    "blockDmgBonus": 22
+                },
+                "dustCost": 15,
+                "goldCost": 150
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 2,
+                    "blockDmgBonus": 26
+                },
+                "dustCost": 20,
+                "goldCost": 200
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 2,
+                    "blockDmgBonus": 30
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            }
+        ]
+    },
+    "I_Booster_Block_R001": {
+        "name": "_I_Booster_Block_R001",
+        "itemType": "I_Booster_Block",
+        "rarity": "Rare",
+        "levels": [
+            {
+                "stats": {
+                    "blockChanceBonus": 3,
+                    "blockDmgBonus": 31
+                },
+                "dustCost": 60
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 3,
+                    "blockDmgBonus": 38
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 3,
+                    "blockDmgBonus": 45
+                },
+                "dustCost": 40,
+                "goldCost": 350
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 3,
+                    "blockDmgBonus": 51
+                },
+                "dustCost": 60,
+                "goldCost": 450
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 3,
+                    "blockDmgBonus": 58
+                },
+                "dustCost": 90,
+                "goldCost": 550
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 3,
+                    "blockDmgBonus": 65
+                },
+                "dustCost": 120,
+                "goldCost": 650
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 3,
+                    "blockDmgBonus": 71
+                },
+                "dustCost": 150,
+                "goldCost": 750
+            }
+        ]
+    },
+    "I_Booster_Block_E001": {
+        "name": "_I_Booster_Block_E001",
+        "itemType": "I_Booster_Block",
+        "rarity": "Epic",
+        "levels": [
+            {
+                "stats": {
+                    "blockChanceBonus": 4,
+                    "blockDmgBonus": 69
+                },
+                "dustCost": 150
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 4,
+                    "blockDmgBonus": 87
+                },
+                "dustCost": 90,
+                "goldCost": 750
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 4,
+                    "blockDmgBonus": 104
+                },
+                "dustCost": 120,
+                "goldCost": 1000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 4,
+                    "blockDmgBonus": 121
+                },
+                "dustCost": 150,
+                "goldCost": 1250
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 4,
+                    "blockDmgBonus": 138
+                },
+                "dustCost": 200,
+                "goldCost": 1500
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 4,
+                    "blockDmgBonus": 155
+                },
+                "dustCost": 250,
+                "goldCost": 1750
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 4,
+                    "blockDmgBonus": 172
+                },
+                "dustCost": 300,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 4,
+                    "blockDmgBonus": 189
+                },
+                "dustCost": 350,
+                "goldCost": 2250
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 4,
+                    "blockDmgBonus": 207
+                },
+                "dustCost": 400,
+                "goldCost": 2500
+            }
+        ]
+    },
+    "I_Booster_Block_L001": {
+        "name": "_I_Booster_Block_L001",
+        "itemType": "I_Booster_Block",
+        "rarity": "Legendary",
+        "levels": [
+            {
+                "stats": {
+                    "blockChanceBonus": 5,
+                    "blockDmgBonus": 210
+                },
+                "dustCost": 400
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 5,
+                    "blockDmgBonus": 223
+                },
+                "dustCost": 250,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 5,
+                    "blockDmgBonus": 235
+                },
+                "dustCost": 350,
+                "goldCost": 3000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 5,
+                    "blockDmgBonus": 247
+                },
+                "dustCost": 450,
+                "goldCost": 4000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 5,
+                    "blockDmgBonus": 259
+                },
+                "dustCost": 600,
+                "goldCost": 6000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 5,
+                    "blockDmgBonus": 271
+                },
+                "dustCost": 800,
+                "goldCost": 8000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 5,
+                    "blockDmgBonus": 284
+                },
+                "dustCost": 1000,
+                "goldCost": 10000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 5,
+                    "blockDmgBonus": 296
+                },
+                "dustCost": 1250,
+                "goldCost": 15000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 5,
+                    "blockDmgBonus": 308
+                },
+                "dustCost": 1500,
+                "goldCost": 20000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 5,
+                    "blockDmgBonus": 320
+                },
+                "dustCost": 2000,
+                "goldCost": 30000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 5,
+                    "blockDmgBonus": 332
+                },
+                "dustCost": 3000,
+                "goldCost": 50000
+            }
+        ]
+    },
+    "I_Booster_Block_C002": {
+        "name": "Basic Forcefield Amplifier",
+        "itemType": "I_Booster_Block",
+        "nextInSeries": "I_Booster_Block_U002",
+        "rarity": "Common",
+        "levels": [
+            {
+                "stats": {
+                    "blockChanceBonus": 1,
+                    "blockDmgBonus": 5
+                },
+                "dustCost": 10
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 1,
+                    "blockDmgBonus": 9
+                },
+                "dustCost": 5,
+                "goldCost": 50
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 1,
+                    "blockDmgBonus": 12
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "Necrons",
+            "Sisterhood",
+            "AstraMilitarum",
+            "BlackLegion",
+            "DeathGuard",
+            "Tyranids",
+            "Orks",
+            "BlackTemplars",
+            "Aeldari",
+            "Tau",
+            "SpaceWolves",
+            "ThousandSons",
+            "DarkAngels",
+            "AdeptusMechanicus",
+            "WorldEaters",
+            "BloodAngels",
+            "Genestealers",
+            "Custodes",
+            "EmperorsChildren",
+            "LeaguesOfVotann",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Booster_Block_U002": {
+        "name": "Improved Force Field Amplifier",
+        "itemType": "I_Booster_Block",
+        "nextInSeries": "I_Booster_Block_R002",
+        "rarity": "Uncommon",
+        "levels": [
+            {
+                "stats": {
+                    "blockChanceBonus": 2,
+                    "blockDmgBonus": 13
+                },
+                "dustCost": 25
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 2,
+                    "blockDmgBonus": 18
+                },
+                "dustCost": 10,
+                "goldCost": 100
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 2,
+                    "blockDmgBonus": 22
+                },
+                "dustCost": 15,
+                "goldCost": 150
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 2,
+                    "blockDmgBonus": 26
+                },
+                "dustCost": 20,
+                "goldCost": 200
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 2,
+                    "blockDmgBonus": 30
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "Necrons",
+            "Sisterhood",
+            "AstraMilitarum",
+            "BlackLegion",
+            "DeathGuard",
+            "Tyranids",
+            "Orks",
+            "BlackTemplars",
+            "Aeldari",
+            "Tau",
+            "SpaceWolves",
+            "ThousandSons",
+            "DarkAngels",
+            "AdeptusMechanicus",
+            "WorldEaters",
+            "BloodAngels",
+            "Genestealers",
+            "Custodes",
+            "EmperorsChildren",
+            "LeaguesOfVotann",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Booster_Block_R002": {
+        "name": "Refined Force Field Amplifier",
+        "itemType": "I_Booster_Block",
+        "nextInSeries": "I_Booster_Block_E002",
+        "rarity": "Rare",
+        "levels": [
+            {
+                "stats": {
+                    "blockChanceBonus": 3,
+                    "blockDmgBonus": 31
+                },
+                "dustCost": 60
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 3,
+                    "blockDmgBonus": 38
+                },
+                "dustCost": 30,
+                "goldCost": 250
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 3,
+                    "blockDmgBonus": 45
+                },
+                "dustCost": 40,
+                "goldCost": 350
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 3,
+                    "blockDmgBonus": 51
+                },
+                "dustCost": 60,
+                "goldCost": 450
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 3,
+                    "blockDmgBonus": 58
+                },
+                "dustCost": 90,
+                "goldCost": 550
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 3,
+                    "blockDmgBonus": 65
+                },
+                "dustCost": 120,
+                "goldCost": 650
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 3,
+                    "blockDmgBonus": 71
+                },
+                "dustCost": 150,
+                "goldCost": 750
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "Necrons",
+            "Sisterhood",
+            "AstraMilitarum",
+            "BlackLegion",
+            "DeathGuard",
+            "Tyranids",
+            "Orks",
+            "BlackTemplars",
+            "Aeldari",
+            "Tau",
+            "SpaceWolves",
+            "ThousandSons",
+            "DarkAngels",
+            "AdeptusMechanicus",
+            "WorldEaters",
+            "BloodAngels",
+            "Genestealers",
+            "Custodes",
+            "EmperorsChildren",
+            "LeaguesOfVotann",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Booster_Block_E002": {
+        "name": "Advanced Force Field Amplifier",
+        "itemType": "I_Booster_Block",
+        "nextInSeries": "I_Booster_Block_L002",
+        "rarity": "Epic",
+        "levels": [
+            {
+                "stats": {
+                    "blockChanceBonus": 4,
+                    "blockDmgBonus": 69
+                },
+                "dustCost": 150
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 4,
+                    "blockDmgBonus": 87
+                },
+                "dustCost": 90,
+                "goldCost": 750
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 4,
+                    "blockDmgBonus": 104
+                },
+                "dustCost": 120,
+                "goldCost": 1000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 4,
+                    "blockDmgBonus": 121
+                },
+                "dustCost": 150,
+                "goldCost": 1250
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 4,
+                    "blockDmgBonus": 138
+                },
+                "dustCost": 200,
+                "goldCost": 1500
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 4,
+                    "blockDmgBonus": 155
+                },
+                "dustCost": 250,
+                "goldCost": 1750
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 4,
+                    "blockDmgBonus": 172
+                },
+                "dustCost": 300,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 4,
+                    "blockDmgBonus": 189
+                },
+                "dustCost": 350,
+                "goldCost": 2250
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 4,
+                    "blockDmgBonus": 207
+                },
+                "dustCost": 400,
+                "goldCost": 2500
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "Necrons",
+            "Sisterhood",
+            "AstraMilitarum",
+            "BlackLegion",
+            "DeathGuard",
+            "Tyranids",
+            "Orks",
+            "BlackTemplars",
+            "Aeldari",
+            "Tau",
+            "SpaceWolves",
+            "ThousandSons",
+            "DarkAngels",
+            "AdeptusMechanicus",
+            "WorldEaters",
+            "BloodAngels",
+            "Genestealers",
+            "Custodes",
+            "EmperorsChildren",
+            "LeaguesOfVotann",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Booster_Block_L002": {
+        "name": "Optimal Force Field Amplifier",
+        "itemType": "I_Booster_Block",
+        "nextInSeries": "I_Booster_Block_M002",
+        "rarity": "Legendary",
+        "levels": [
+            {
+                "stats": {
+                    "blockChanceBonus": 5,
+                    "blockDmgBonus": 210
+                },
+                "dustCost": 400
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 5,
+                    "blockDmgBonus": 223
+                },
+                "dustCost": 250,
+                "goldCost": 2000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 5,
+                    "blockDmgBonus": 235
+                },
+                "dustCost": 350,
+                "goldCost": 3000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 5,
+                    "blockDmgBonus": 247
+                },
+                "dustCost": 450,
+                "goldCost": 4000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 5,
+                    "blockDmgBonus": 259
+                },
+                "dustCost": 600,
+                "goldCost": 6000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 5,
+                    "blockDmgBonus": 271
+                },
+                "dustCost": 800,
+                "goldCost": 8000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 5,
+                    "blockDmgBonus": 284
+                },
+                "dustCost": 1000,
+                "goldCost": 10000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 5,
+                    "blockDmgBonus": 296
+                },
+                "dustCost": 1250,
+                "goldCost": 15000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 5,
+                    "blockDmgBonus": 308
+                },
+                "dustCost": 1500,
+                "goldCost": 20000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 5,
+                    "blockDmgBonus": 320
+                },
+                "dustCost": 2000,
+                "goldCost": 30000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 5,
+                    "blockDmgBonus": 332
+                },
+                "dustCost": 3000,
+                "goldCost": 50000
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "Necrons",
+            "Sisterhood",
+            "AstraMilitarum",
+            "BlackLegion",
+            "DeathGuard",
+            "Tyranids",
+            "Orks",
+            "BlackTemplars",
+            "Aeldari",
+            "Tau",
+            "SpaceWolves",
+            "ThousandSons",
+            "DarkAngels",
+            "AdeptusMechanicus",
+            "WorldEaters",
+            "BloodAngels",
+            "Genestealers",
+            "Custodes",
+            "EmperorsChildren",
+            "LeaguesOfVotann",
+            "AdeptusAstartes"
+        ]
+    },
+    "I_Booster_Block_M002": {
+        "name": "Perfected Force Field Amplifier",
+        "itemType": "I_Booster_Block",
+        "rarity": "Mythic",
+        "levels": [
+            {
+                "stats": {
+                    "blockChanceBonus": 6,
+                    "blockDmgBonus": 350
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 6,
+                    "blockDmgBonus": 369
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 6,
+                    "blockDmgBonus": 388
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 6,
+                    "blockDmgBonus": 407
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 6,
+                    "blockDmgBonus": 426
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 6,
+                    "blockDmgBonus": 445
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 6,
+                    "blockDmgBonus": 464
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 6,
+                    "blockDmgBonus": 483
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 6,
+                    "blockDmgBonus": 502
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 6,
+                    "blockDmgBonus": 521
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ],
+        "allowedFactions": [
+            "Ultramarines",
+            "Necrons",
+            "Sisterhood",
+            "AstraMilitarum",
+            "BlackLegion",
+            "DeathGuard",
+            "Tyranids",
+            "Orks",
+            "BlackTemplars",
+            "Aeldari",
+            "Tau",
+            "SpaceWolves",
+            "ThousandSons",
+            "DarkAngels",
+            "AdeptusMechanicus",
+            "WorldEaters",
+            "BloodAngels",
+            "Genestealers",
+            "Custodes",
+            "EmperorsChildren",
+            "LeaguesOfVotann",
+            "AdeptusAstartes"
+        ]
+    },
+    "R_Crit_RelicBoltPistol": {
+        "name": "Relic Bolt Pistol",
+        "itemType": "I_Crit",
+        "rarity": "Mythic",
+        "isRelic": true,
+        "isUniqueRelic": false,
+        "abilityId": "RelicBoltPistol",
+        "allowedUnits": [
+            "ultraInceptorSgt",
+            "ultraTitus",
+            "templSwordBrother",
+            "darkaHellblaster",
+            "spaceHound",
+            "astarCyrus",
+            "darkaSternguard"
+        ],
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1050
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1107
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1164
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1221
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1277
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1334
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1391
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1447
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1504
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1561
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ]
+    },
+    "R_Crit_RelicPowerFist": {
+        "name": "Relic Power Fist",
+        "itemType": "I_Crit",
+        "rarity": "Mythic",
+        "isRelic": true,
+        "isUniqueRelic": false,
+        "abilityId": "RelicPowerFist",
+        "allowedUnits": ["templAggressor", "bloodIntercessor", "darkaTerminator"],
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1050
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1107
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1164
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1221
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1277
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1334
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1391
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1447
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1504
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1561
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ]
+    },
+    "R_Crit_MawClawsOfThyrax": {
+        "name": "Maw-Claws of Thyrax",
+        "itemType": "I_Crit",
+        "rarity": "Mythic",
+        "isRelic": true,
+        "isUniqueRelic": false,
+        "abilityId": "MawClawsOfThyrax",
+        "allowedUnits": ["tyranTyrantGuard", "tyranWingedPrime", "tyranParasite", "genesPatriarch"],
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1050
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1107
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1164
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1221
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1277
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1334
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1391
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1447
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1504
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1561
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ]
+    },
+    "R_Crit_Vitarus": {
+        "name": "Vitarus",
+        "itemType": "I_Crit",
+        "rarity": "Mythic",
+        "isRelic": true,
+        "isUniqueRelic": true,
+        "abilityId": "Vitarus",
+        "allowedUnits": ["bloodMephiston"],
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1050
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1107
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1164
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1221
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1277
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1334
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1391
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1447
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1504
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1561
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ]
+    },
+    "R_Crit_TheArdentBlade": {
+        "name": "The Ardent Blade",
+        "itemType": "I_Crit",
+        "rarity": "Mythic",
+        "isRelic": true,
+        "isUniqueRelic": true,
+        "abilityId": "TheArdentBlade",
+        "allowedUnits": ["adeptCelestine"],
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1050
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1107
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1164
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1221
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1277
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1334
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1391
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1447
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1504
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1561
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ]
+    },
+    "R_Crit_Dw02AdvancedBurstCannon": {
+        "name": "DW-02 Advanced Burst Cannon",
+        "itemType": "I_Crit",
+        "rarity": "Mythic",
+        "isRelic": true,
+        "isUniqueRelic": true,
+        "abilityId": "Dw02AdvancedBurstCannon",
+        "allowedUnits": ["tauCrisis"],
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1050
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1107
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1164
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1221
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1277
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1334
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1391
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1447
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1504
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1561
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ]
+    },
+    "R_Crit_TalonOfHorus": {
+        "name": "Talon of Horus",
+        "itemType": "I_Crit",
+        "rarity": "Mythic",
+        "isRelic": true,
+        "isUniqueRelic": true,
+        "abilityId": "TalonOfHorus",
+        "allowedUnits": ["blackAbaddon"],
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1050
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1107
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1164
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1221
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1277
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1334
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1391
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1447
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1504
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1561
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ]
+    },
+    "R_Crit_Maugetar": {
+        "name": "Maugetar",
+        "itemType": "I_Crit",
+        "rarity": "Mythic",
+        "isRelic": true,
+        "isUniqueRelic": true,
+        "abilityId": "Maugetar",
+        "allowedUnits": ["eldarMauganRa"],
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1050
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1107
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1164
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1221
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1277
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1334
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1391
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1447
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1504
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1561
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ]
+    },
+    "R_Crit_ParagonSpear": {
+        "name": "Paragon Spear",
+        "itemType": "I_Crit",
+        "rarity": "Mythic",
+        "isRelic": true,
+        "isUniqueRelic": true,
+        "abilityId": "ParagonSpear",
+        "allowedUnits": ["custoKyrus"],
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1470
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1550
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1629
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1709
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1788
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1867
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1947
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 2026
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 2105
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 2185
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ]
+    },
+    "R_Crit_DawnBlade": {
+        "name": "Dawn Blade",
+        "itemType": "I_Crit",
+        "rarity": "Mythic",
+        "isRelic": true,
+        "isUniqueRelic": true,
+        "abilityId": "DawnBlade",
+        "allowedUnits": ["tauFarsight"],
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1050
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1107
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1164
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1221
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1277
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1334
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1391
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1447
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1504
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1561
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ]
+    },
+    "R_Crit_BladeOfTheAncestors": {
+        "name": "Blade of the Ancestors",
+        "itemType": "I_Crit",
+        "rarity": "Mythic",
+        "isRelic": true,
+        "isUniqueRelic": true,
+        "abilityId": "BladeOfTheAncestors",
+        "allowedUnits": ["votanUthar"],
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1470
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1550
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1629
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1709
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1788
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1867
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1947
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 2026
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 2105
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 2185
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ]
+    },
+    "R_Crit_VolummsMasterArtifice": {
+        "name": "Volumm's Master Artifice",
+        "itemType": "I_Crit",
+        "rarity": "Mythic",
+        "isRelic": true,
+        "isUniqueRelic": true,
+        "abilityId": "VolummsMasterArtifice",
+        "allowedUnits": ["votanIronmaster"],
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1470
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1550
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1629
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1709
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1788
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1867
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 1947
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 2026
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 2105
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChance": 25,
+                    "critDmg": 2185
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ]
+    },
+    "R_Crit_MonsterSlayerOfCaliban": {
+        "name": "Monster Slayer of Caliban",
+        "itemType": "I_Crit",
+        "rarity": "Mythic",
+        "isRelic": true,
+        "isUniqueRelic": true,
+        "abilityId": "MonsterSlayerOfCaliban",
+        "allowedUnits": ["darkaCompanion"],
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 40,
+                    "critDmg": 920
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 40,
+                    "critDmg": 970
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChance": 40,
+                    "critDmg": 1020
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChance": 40,
+                    "critDmg": 1069
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChance": 40,
+                    "critDmg": 1119
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChance": 40,
+                    "critDmg": 1169
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChance": 40,
+                    "critDmg": 1218
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChance": 40,
+                    "critDmg": 1268
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChance": 40,
+                    "critDmg": 1318
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChance": 40,
+                    "critDmg": 1367
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ]
+    },
+    "R_Crit_SabreOfSacrifice": {
+        "name": "Sabre of Sacrifice",
+        "itemType": "I_Crit",
+        "rarity": "Mythic",
+        "isRelic": true,
+        "isUniqueRelic": true,
+        "abilityId": "SabreOfSacrifice",
+        "allowedUnits": ["astraDreir"],
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1050
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1107
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1164
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1221
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1277
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1334
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1391
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1447
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1504
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1561
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ]
+    },
+    "R_Crit_Lakrimae": {
+        "name": "Lakrimae",
+        "itemType": "I_Crit",
+        "rarity": "Mythic",
+        "isRelic": true,
+        "isUniqueRelic": true,
+        "abilityId": "Lakrimae",
+        "allowedUnits": ["deathTyphus"],
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1050
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1107
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1164
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1221
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1277
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1334
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1391
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1447
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1504
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1561
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ]
+    },
+    "R_Crit_HeadwoppasKillchoppa": {
+        "name": "Headwoppa's Killchoppa",
+        "itemType": "I_Crit",
+        "rarity": "Mythic",
+        "isRelic": true,
+        "isUniqueRelic": true,
+        "abilityId": "HeadwoppasKillchoppa",
+        "allowedUnits": ["orksWarboss"],
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1050
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1107
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1164
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1221
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1277
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1334
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1391
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1447
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1504
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1561
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ]
+    },
+    "R_Crit_Helspear": {
+        "name": "Helspear",
+        "itemType": "I_Crit",
+        "rarity": "Mythic",
+        "isRelic": true,
+        "isUniqueRelic": true,
+        "abilityId": "Helspear",
+        "allowedUnits": ["blackHaarken"],
+        "levels": [
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1050
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1107
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1164
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1221
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1277
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1334
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1391
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1447
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1504
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChance": 35,
+                    "critDmg": 1561
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ]
+    },
+    "R_Booster_Crit_KardiocoreGalvanus": {
+        "name": "Kardiocore Galvanus",
+        "itemType": "I_Booster_Crit",
+        "rarity": "Mythic",
+        "isRelic": true,
+        "isUniqueRelic": false,
+        "abilityId": "KardiocoreGalvanus",
+        "allowedUnits": ["admecDestroyer", "admecRuststalker", "admecMarshall"],
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 350
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 369
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 388
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 407
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 426
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 445
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 464
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 483
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 502
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 521
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ]
+    },
+    "R_Booster_Crit_AmuletOfTheVoidwyrm": {
+        "name": "Amulet of the Voidwyrm",
+        "itemType": "I_Booster_Crit",
+        "rarity": "Mythic",
+        "isRelic": true,
+        "isUniqueRelic": false,
+        "abilityId": "AmuletOfTheVoidwyrm",
+        "allowedUnits": ["genesBiophagus", "genesPrimus", "genesKelermorph"],
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 350
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 369
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 388
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 407
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 426
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 445
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 464
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 483
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 502
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 521
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ]
+    },
+    "R_Booster_Crit_BookOfFate": {
+        "name": "Book of Fate",
+        "itemType": "I_Booster_Crit",
+        "rarity": "Mythic",
+        "isRelic": true,
+        "isUniqueRelic": false,
+        "abilityId": "BookOfFate",
+        "allowedUnits": ["blackPossession", "thousInfernalMaster", "thousSorcerer"],
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 350
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 369
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 388
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 407
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 426
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 445
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 464
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 483
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 502
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 521
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ]
+    },
+    "R_Booster_Crit_TalismanOfRage": {
+        "name": "Talisman of Rage",
+        "itemType": "I_Booster_Crit",
+        "rarity": "Mythic",
+        "isRelic": true,
+        "isUniqueRelic": false,
+        "abilityId": "TalismanOfRage",
+        "allowedUnits": ["worldJakhal", "worldEightbound", "worldExecutions"],
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 350
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 369
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 388
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 407
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 426
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 445
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 464
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 483
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 502
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 521
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ]
+    },
+    "R_Booster_Crit_NetherRealmCasket": {
+        "name": "Nether-Realm Casket",
+        "itemType": "I_Booster_Crit",
+        "rarity": "Mythic",
+        "isRelic": true,
+        "isUniqueRelic": false,
+        "abilityId": "NetherRealmCasket",
+        "allowedUnits": ["necroWarden", "necroSpyder", "necroDestroyer"],
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 350
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 369
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 388
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 407
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 426
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 445
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 464
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 483
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 502
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 521
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ]
+    },
+    "R_Booster_Crit_IntoxicatingElixir": {
+        "name": "Intoxicating Elixir",
+        "itemType": "I_Booster_Crit",
+        "rarity": "Mythic",
+        "isRelic": true,
+        "isUniqueRelic": false,
+        "abilityId": "IntoxicatingElixir",
+        "allowedUnits": ["emperNoiseMarine", "emperKakophonist", "emperFlawlessBlade", "emperExultant"],
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 350
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 369
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 388
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 407
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 426
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 445
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 464
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 483
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 502
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 521
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ]
+    },
+    "R_Booster_Crit_OrbsOfDecay": {
+        "name": "Orbs of Decay",
+        "itemType": "I_Booster_Crit",
+        "rarity": "Mythic",
+        "isRelic": true,
+        "isUniqueRelic": false,
+        "abilityId": "OrbsOfDecay",
+        "allowedUnits": ["deathRotbone", "deathPutrifier", "deathBlightbringer"],
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 350
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 369
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 388
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 407
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 426
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 445
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 464
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 483
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 502
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 521
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ]
+    },
+    "R_Booster_Crit_WyrdmakersHelm": {
+        "name": "Wyrdmaker's Helm",
+        "itemType": "I_Booster_Crit",
+        "rarity": "Mythic",
+        "isRelic": true,
+        "isUniqueRelic": true,
+        "abilityId": "WyrdmakersHelm",
+        "allowedUnits": ["spaceWolfPriest"],
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 350
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 369
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 388
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 407
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 426
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 445
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 464
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 483
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 502
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 521
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ]
+    },
+    "R_Booster_Crit_ChaliceOfBaal": {
+        "name": "Chalice of Baal",
+        "itemType": "I_Booster_Crit",
+        "rarity": "Mythic",
+        "isRelic": true,
+        "isUniqueRelic": true,
+        "abilityId": "ChaliceOfBaal",
+        "allowedUnits": ["bloodSanguinary"],
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 350
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 369
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 388
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 407
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 426
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 445
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 464
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 483
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 502
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 521
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ]
+    },
+    "R_Booster_Crit_PhasalSubjugator": {
+        "name": "Phasal Subjugator",
+        "itemType": "I_Booster_Crit",
+        "rarity": "Mythic",
+        "isRelic": true,
+        "isUniqueRelic": true,
+        "abilityId": "PhasalSubjugator",
+        "allowedUnits": ["necroOverlord"],
+        "levels": [
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 350
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 369
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 388
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 407
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 426
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 445
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 464
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 483
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 502
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "critChanceBonus": 6,
+                    "critDmgBonus": 521
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ]
+    },
+    "R_Defensive_RelicOfLostCadia": {
+        "name": "Relic of Lost Cadia",
+        "itemType": "I_Defensive",
+        "rarity": "Mythic",
+        "isRelic": true,
+        "isUniqueRelic": false,
+        "abilityId": "RelicOfLostCadia",
+        "allowedUnits": ["astraPrimarisPsy", "astraBullgryn", "astraOrdnance"],
+        "levels": [
+            {
+                "stats": {
+                    "hp": 600,
+                    "fixedArmor": 320
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "hp": 633,
+                    "fixedArmor": 338
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "hp": 665,
+                    "fixedArmor": 355
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "hp": 698,
+                    "fixedArmor": 372
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "hp": 730,
+                    "fixedArmor": 390
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "hp": 762,
+                    "fixedArmor": 407
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "hp": 795,
+                    "fixedArmor": 424
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "hp": 827,
+                    "fixedArmor": 441
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "hp": 860,
+                    "fixedArmor": 459
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "hp": 892,
+                    "fixedArmor": 476
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ]
+    },
+    "R_Defensive_SupaCyborkBody": {
+        "name": "Supa-Cybork Body",
+        "itemType": "I_Defensive",
+        "rarity": "Mythic",
+        "isRelic": true,
+        "isUniqueRelic": false,
+        "abilityId": "SupaCyborkBody",
+        "allowedUnits": ["orksRuntherd", "orksBigMek", "orksNob"],
+        "levels": [
+            {
+                "stats": {
+                    "hp": 600,
+                    "fixedArmor": 320
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "hp": 633,
+                    "fixedArmor": 338
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "hp": 665,
+                    "fixedArmor": 355
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "hp": 698,
+                    "fixedArmor": 372
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "hp": 730,
+                    "fixedArmor": 390
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "hp": 762,
+                    "fixedArmor": 407
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "hp": 795,
+                    "fixedArmor": 424
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "hp": 827,
+                    "fixedArmor": 441
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "hp": 860,
+                    "fixedArmor": 459
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "hp": 892,
+                    "fixedArmor": 476
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ]
+    },
+    "R_Block_DaemonfleshPlate": {
+        "name": "Daemonflesh Plate",
+        "itemType": "I_Block",
+        "rarity": "Mythic",
+        "isRelic": true,
+        "isUniqueRelic": false,
+        "abilityId": "DaemonfleshPlate",
+        "allowedUnits": ["blackTerminator", "deathBlightlord", "thousTerminator", "worldTerminator"],
+        "levels": [
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 1230
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 1297
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 1363
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 1430
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 1496
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 1562
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 1629
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 1695
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 1762
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "blockChance": 30,
+                    "blockDmg": 1828
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ]
+    },
+    "R_Booster_Block_PhoenixGem": {
+        "name": "Phoenix Gem",
+        "itemType": "I_Booster_Block",
+        "rarity": "Mythic",
+        "isRelic": true,
+        "isUniqueRelic": true,
+        "abilityId": "PhoenixGem",
+        "allowedUnits": ["eldarAutarch"],
+        "levels": [
+            {
+                "stats": {
+                    "blockChanceBonus": 6,
+                    "blockDmgBonus": 350
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 6,
+                    "blockDmgBonus": 369
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 6,
+                    "blockDmgBonus": 388
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 6,
+                    "blockDmgBonus": 407
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 6,
+                    "blockDmgBonus": 426
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 6,
+                    "blockDmgBonus": 445
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 6,
+                    "blockDmgBonus": 464
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 6,
+                    "blockDmgBonus": 483
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 6,
+                    "blockDmgBonus": 502
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 6,
+                    "blockDmgBonus": 521
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ]
+    },
+    "R_Booster_Block_NornCrown": {
+        "name": "Norn Crown",
+        "itemType": "I_Booster_Block",
+        "rarity": "Mythic",
+        "isRelic": true,
+        "isUniqueRelic": true,
+        "abilityId": "NornCrown",
+        "allowedUnits": ["tyranNeurothrope"],
+        "levels": [
+            {
+                "stats": {
+                    "blockChanceBonus": 6,
+                    "blockDmgBonus": 350
+                },
+                "mythicDustCost": 100
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 6,
+                    "blockDmgBonus": 369
+                },
+                "mythicDustCost": 50,
+                "goldCost": 50000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 6,
+                    "blockDmgBonus": 388
+                },
+                "mythicDustCost": 75,
+                "goldCost": 60000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 6,
+                    "blockDmgBonus": 407
+                },
+                "mythicDustCost": 100,
+                "goldCost": 70000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 6,
+                    "blockDmgBonus": 426
+                },
+                "mythicDustCost": 125,
+                "goldCost": 85000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 6,
+                    "blockDmgBonus": 445
+                },
+                "mythicDustCost": 150,
+                "goldCost": 100000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 6,
+                    "blockDmgBonus": 464
+                },
+                "mythicDustCost": 200,
+                "goldCost": 125000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 6,
+                    "blockDmgBonus": 483
+                },
+                "mythicDustCost": 300,
+                "goldCost": 150000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 6,
+                    "blockDmgBonus": 502
+                },
+                "mythicDustCost": 500,
+                "goldCost": 175000
+            },
+            {
+                "stats": {
+                    "blockChanceBonus": 6,
+                    "blockDmgBonus": 521
+                },
+                "mythicDustCost": 1000,
+                "goldCost": 200000
+            }
+        ]
+    }
+}

--- a/src/fsd/4-entities/unit/character-power/data/character-power-units.json
+++ b/src/fsd/4-entities/unit/character-power/data/character-power-units.json
@@ -1,0 +1,15341 @@
+{
+    "lineup": {
+        "ultraTigurius": {
+            "name": "Tigurius",
+            "FactionId": "Ultramarines",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Uncommon",
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 1,
+                    "DamageProfile": "Physical"
+                },
+                {
+                    "hits": 1,
+                    "DamageProfile": "Psychic",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 65,
+                "Damage": 30,
+                "FixedArmor": 14,
+                "ProgressionIndex": 3
+            },
+            "traits": ["Hero", "Psyker"],
+            "activeAbilities": ["StormOfWrath"],
+            "passiveAbilities": ["PsychicFortress"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "upgrades": [
+                ["upgHpC003", "upgHpU001", "upgDmgC010", "upgDmgC009", "upgArmC001", "upgArmC002"],
+                ["upgHpC001", "upgHpU002", "upgDmgC005", "upgDmgU006", "upgArmC002", "upgArmU002"],
+                ["upgHpU006", "upgHpU004C", "upgDmgC007", "upgDmgU005", "upgArmC003", "upgArmU005"],
+                ["upgHpU002", "upgHpU006", "upgDmgU007C", "upgDmgU012", "upgArmU003C", "upgArmU001"],
+                ["upgHpU006", "upgHpR005", "upgDmgU002C", "upgDmgR008C", "upgArmU002", "upgArmR001C"],
+                ["upgHpU004C", "upgHpE003", "upgDmgR001C", "upgDmgR007", "upgArmU002", "upgArmE001C"],
+                ["upgHpR003C", "upgHpR007", "upgDmgR004C", "upgDmgR007", "upgArmR001C", "upgArmR003C"],
+                ["upgHpR005", "upgHpE002C", "upgDmgR001C", "upgDmgE008C", "upgArmR005", "upgArmE001C"],
+                ["upgHpR005", "upgHpE001C", "upgDmgR010C", "upgDmgL005C", "upgArmE001C", "upgArmE004C"],
+                ["upgHpE001C", "upgHpE002C", "upgDmgE002C", "upgDmgL005C", "upgArmE001C", "upgArmE013"],
+                ["upgHpE003", "upgHpE001C", "upgDmgE007C", "upgDmgL004C", "upgArmE004C", "upgArmE001C"],
+                ["upgHpL009C", "upgHpL002C", "upgDmgL015C", "upgDmgL004C", "upgArmL004C", "upgArmL011C"],
+                ["upgHpL120C", "upgHpL011C", "upgDmgL005C", "upgDmgL004C", "upgArmL004C", "upgArmL010C"],
+                ["upgHpL009C", "upgHpL011C", "upgDmgL005C", "upgDmgL120C", "upgArmL120C", "upgArmL011C"],
+                ["upgHpL120C", "upgHpL002C", "upgDmgL015C", "upgDmgL120C", "upgArmL120C", "upgArmL010C"],
+                ["upgHpL120C", "upgHpL011C", "upgDmgL120C", "upgDmgL006C", "upgArmL120C", "upgArmL004C"],
+                ["upgHpL120C", "upgHpL212C", "upgDmgL120C", "upgDmgL212C", "upgArmL120C", "upgArmL212C"],
+                ["upgHpL120C", "upgHpL212C", "upgDmgM214C", "upgDmgL212C", "upgArmM211C", "upgArmL212C"],
+                ["upgHpM120C", "upgHpL212C", "upgDmgM214C", "upgDmgL212C", "upgArmM213C", "upgArmL212C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [5, 12, 3, 6, 2, 2],
+                [3, 18, 5, 7, 1, 3],
+                [10, 15, 3, 5, 2, 3],
+                [16, 16, 9, 6, 4, 3],
+                [16, 24, 8, 10, 3, 6],
+                [21, 29, 14, 10, 3, 8],
+                [36, 27, 17, 12, 7, 7],
+                [30, 49, 16, 20, 6, 11],
+                [37, 62, 18, 28, 11, 11],
+                [62, 62, 26, 31, 14, 11],
+                [69, 86, 32, 39, 17, 17],
+                [97, 97, 45, 45, 21, 21],
+                [122, 122, 56, 56, 26, 26],
+                [152, 152, 71, 71, 33, 33],
+                [190, 190, 87, 87, 41, 41],
+                [239, 239, 110, 110, 51, 51],
+                [298, 298, 138, 138, 65, 65],
+                [163, 163, 81, 69, 37, 32],
+                [174, 150, 81, 69, 38, 32],
+                [144, 181, 67, 83, 31, 39]
+            ]
+        },
+        "ultraEliminatorSgt": {
+            "name": "Certus",
+            "FactionId": "Ultramarines",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Common",
+            "Movement": 2,
+            "weapons": [
+                {
+                    "hits": 1,
+                    "DamageProfile": "Physical"
+                },
+                {
+                    "hits": 1,
+                    "DamageProfile": "Bolter",
+                    "Range": 3
+                }
+            ],
+            "stats": {
+                "Health": 60,
+                "Damage": 55,
+                "FixedArmor": 18,
+                "ProgressionIndex": 0
+            },
+            "traits": ["Hero", "Overwatch", "HeavyWeapon", "Infiltrate"],
+            "activeAbilities": ["MortisRound"],
+            "passiveAbilities": ["CamoCloak"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "upgrades": [
+                ["upgHpC001", "upgHpU001", "upgDmgC002", "upgDmgC011", "upgArmC001", "upgArmC004"],
+                ["upgHpC003", "upgHpU003", "upgDmgC010", "upgDmgU006", "upgArmC002", "upgArmU001"],
+                ["upgHpC007", "upgHpU003", "upgDmgR003", "upgDmgR004C", "upgArmU006", "upgArmU006"],
+                ["upgHpU004C", "upgHpU005C", "upgDmgR002", "upgDmgR004C", "upgArmU005", "upgArmU006"],
+                ["upgHpU002", "upgHpR002", "upgDmgR004C", "upgDmgU004", "upgArmU005", "upgArmR001C"],
+                ["upgHpU003", "upgHpR003C", "upgDmgR006", "upgDmgR010C", "upgArmU003C", "upgArmE001C"],
+                ["upgHpR004C", "upgHpE003", "upgDmgR005", "upgDmgE007C", "upgArmR003C", "upgArmE004C"],
+                ["upgHpE001C", "upgHpR018", "upgDmgR010C", "upgDmgE007C", "upgArmE001C", "upgArmE004C"],
+                ["upgHpL002C", "upgHpR020C", "upgDmgR005", "upgDmgL005C", "upgArmE001C", "upgArmE002C"],
+                ["upgHpE001C", "upgHpE006C", "upgDmgE007C", "upgDmgL006C", "upgArmE002C", "upgArmE013"],
+                ["upgHpE003", "upgHpE001C", "upgDmgE007C", "upgDmgL004C", "upgArmE004C", "upgArmE001C"],
+                ["upgHpL009C", "upgHpL002C", "upgDmgL015C", "upgDmgL004C", "upgArmL004C", "upgArmL011C"],
+                ["upgHpL120C", "upgHpL001C", "upgDmgL007C", "upgDmgL004C", "upgArmL004C", "upgArmL010C"],
+                ["upgHpL009C", "upgHpL001C", "upgDmgL007C", "upgDmgL120C", "upgArmL120C", "upgArmL011C"],
+                ["upgHpL120C", "upgHpL002C", "upgDmgL015C", "upgDmgL120C", "upgArmL120C", "upgArmL010C"],
+                ["upgHpL120C", "upgHpL002C", "upgDmgL120C", "upgDmgL006C", "upgArmL120C", "upgArmL004C"],
+                ["upgHpL120C", "upgHpL213C", "upgDmgL120C", "upgDmgL213C", "upgArmL120C", "upgArmL213C"],
+                ["upgHpL120C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM211C", "upgArmL213C"],
+                ["upgHpM120C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM213C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [5, 10, 7, 7, 3, 3],
+                [6, 13, 6, 11, 1, 3],
+                [8, 16, 9, 13, 4, 4],
+                [15, 15, 12, 15, 4, 4],
+                [15, 22, 23, 11, 4, 7],
+                [15, 31, 18, 25, 5, 9],
+                [29, 29, 20, 33, 8, 10],
+                [46, 27, 30, 37, 11, 11],
+                [55, 37, 28, 56, 14, 14],
+                [57, 57, 47, 57, 18, 15],
+                [64, 79, 60, 72, 22, 22],
+                [90, 90, 82, 82, 27, 27],
+                [112, 112, 103, 103, 33, 33],
+                [140, 140, 129, 129, 43, 43],
+                [176, 176, 161, 161, 52, 52],
+                [220, 220, 202, 202, 66, 66],
+                [276, 276, 252, 252, 83, 83],
+                [150, 150, 148, 127, 48, 41],
+                [161, 138, 148, 127, 48, 42],
+                [133, 167, 122, 152, 40, 50]
+            ]
+        },
+        "ultraInceptorSgt": {
+            "name": "Bellator",
+            "FactionId": "Ultramarines",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Common",
+            "Movement": 4,
+            "weapons": [
+                {
+                    "hits": 6,
+                    "DamageProfile": "Bolter"
+                }
+            ],
+            "stats": {
+                "Health": 85,
+                "Damage": 10,
+                "FixedArmor": 13,
+                "ProgressionIndex": 0
+            },
+            "traits": ["Hero", "Flying", "MkXGravis"],
+            "activeAbilities": ["DeathFromAbove"],
+            "passiveAbilities": ["ShockAssault"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "upgrades": [
+                ["upgHpC001", "upgHpU002", "upgDmgC001", "upgDmgC006", "upgArmC001", "upgArmC003"],
+                ["upgHpC007", "upgHpU003", "upgDmgC002", "upgDmgU003", "upgArmC003", "upgArmU002"],
+                ["upgHpU002", "upgHpU005C", "upgDmgC001", "upgDmgR002", "upgArmU005", "upgArmU006"],
+                ["upgHpU005C", "upgHpR002", "upgDmgU003", "upgDmgR002", "upgArmU003C", "upgArmU001"],
+                ["upgHpR005", "upgHpR007", "upgDmgU007C", "upgDmgU013C", "upgArmU001", "upgArmU002"],
+                ["upgHpU004C", "upgHpE002C", "upgDmgR006", "upgDmgE001", "upgArmU001", "upgArmE001C"],
+                ["upgHpR003C", "upgHpR006C", "upgDmgR002", "upgDmgR011C", "upgArmU008", "upgArmE001C"],
+                ["upgHpR007", "upgHpE001C", "upgDmgR011C", "upgDmgE006C", "upgArmR001C", "upgArmR003C"],
+                ["upgHpR005", "upgHpL001C", "upgDmgR011C", "upgDmgE006C", "upgArmR001C", "upgArmE004C"],
+                ["upgHpE002C", "upgHpL001C", "upgDmgE006C", "upgDmgL004C", "upgArmE001C", "upgArmE013"],
+                ["upgHpE003", "upgHpE001C", "upgDmgE007C", "upgDmgL004C", "upgArmE004C", "upgArmE001C"],
+                ["upgHpL009C", "upgHpL002C", "upgDmgL015C", "upgDmgL004C", "upgArmL004C", "upgArmL006C"],
+                ["upgHpL120C", "upgHpL001C", "upgDmgL007C", "upgDmgL004C", "upgArmL004C", "upgArmL010C"],
+                ["upgHpL009C", "upgHpL001C", "upgDmgL007C", "upgDmgL120C", "upgArmL120C", "upgArmL006C"],
+                ["upgHpL120C", "upgHpL002C", "upgDmgL015C", "upgDmgL120C", "upgArmL120C", "upgArmL010C"],
+                ["upgHpL120C", "upgHpL002C", "upgDmgL120C", "upgDmgL006C", "upgArmL120C", "upgArmL004C"],
+                ["upgHpL120C", "upgHpL213C", "upgDmgL120C", "upgDmgL213C", "upgArmL120C", "upgArmL213C"],
+                ["upgHpL120C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM211C", "upgArmL213C"],
+                ["upgHpM120C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [7, 14, 2, 2, 2, 2],
+                [9, 18, 1, 1, 1, 2],
+                [14, 20, 1, 3, 3, 3],
+                [21, 21, 2, 3, 4, 2],
+                [26, 26, 3, 3, 4, 4],
+                [25, 41, 3, 5, 3, 7],
+                [42, 42, 4, 5, 4, 9],
+                [38, 64, 5, 7, 8, 8],
+                [43, 86, 7, 9, 8, 11],
+                [74, 88, 9, 10, 14, 11],
+                [90, 113, 10, 13, 16, 16],
+                [127, 127, 15, 15, 19, 19],
+                [159, 159, 19, 19, 24, 24],
+                [199, 199, 24, 24, 31, 31],
+                [249, 249, 29, 29, 38, 38],
+                [312, 312, 36, 36, 48, 48],
+                [390, 390, 46, 46, 59, 59],
+                [213, 213, 27, 23, 35, 30],
+                [228, 196, 27, 23, 35, 30],
+                [188, 236, 22, 28, 29, 36]
+            ]
+        },
+        "ultraApothecary": {
+            "name": "Incisus",
+            "FactionId": "Ultramarines",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Common",
+            "powerMultiplier": 125,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 1,
+                    "DamageProfile": "Piercing"
+                }
+            ],
+            "stats": {
+                "Health": 100,
+                "Damage": 46,
+                "FixedArmor": 22,
+                "ProgressionIndex": 0
+            },
+            "traits": ["Hero", "Healer"],
+            "activeAbilities": ["CombatRestoratives"],
+            "passiveAbilities": ["Narthecium"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "upgrades": [
+                ["upgHpC004", "upgHpU001", "upgDmgC002", "upgDmgC005", "upgArmC001", "upgArmC002"],
+                ["upgHpC006", "upgHpU003", "upgDmgC003", "upgDmgU005", "upgArmC002", "upgArmU002"],
+                ["upgHpU001", "upgHpU005C", "upgDmgC011", "upgDmgR003", "upgArmU005", "upgArmU006"],
+                ["upgHpU002", "upgHpU005C", "upgDmgU011", "upgDmgR003", "upgArmU003C", "upgArmU008"],
+                ["upgHpU004C", "upgHpU006", "upgDmgU006", "upgDmgR001C", "upgArmU002", "upgArmR001C"],
+                ["upgHpU002", "upgHpE003", "upgDmgR007", "upgDmgE008C", "upgArmU008", "upgArmE001C"],
+                ["upgHpR004C", "upgHpE002C", "upgDmgE002C", "upgDmgE004", "upgArmR001C", "upgArmE001C"],
+                ["upgHpR006C", "upgHpE003", "upgDmgR001C", "upgDmgE002C", "upgArmE001C", "upgArmE004C"],
+                ["upgHpE001C", "upgHpE003", "upgDmgE002C", "upgDmgL005C", "upgArmR003C", "upgArmE002C"],
+                ["upgHpE003", "upgHpL001C", "upgDmgE007C", "upgDmgL005C", "upgArmE002C", "upgArmE013"],
+                ["upgHpE003", "upgHpE001C", "upgDmgE007C", "upgDmgL004C", "upgArmE004C", "upgArmE001C"],
+                ["upgHpL009C", "upgHpL002C", "upgDmgL015C", "upgDmgL004C", "upgArmL004C", "upgArmL006C"],
+                ["upgHpL120C", "upgHpL001C", "upgDmgL005C", "upgDmgL004C", "upgArmL004C", "upgArmL010C"],
+                ["upgHpL009C", "upgHpL001C", "upgDmgL005C", "upgDmgL120C", "upgArmL120C", "upgArmL006C"],
+                ["upgHpL120C", "upgHpL002C", "upgDmgL015C", "upgDmgL120C", "upgArmL120C", "upgArmL010C"],
+                ["upgHpL120C", "upgHpL002C", "upgDmgL120C", "upgDmgL002C", "upgArmL120C", "upgArmL004C"],
+                ["upgHpL120C", "upgHpL213C", "upgDmgL120C", "upgDmgL213C", "upgArmL120C", "upgArmL213C"],
+                ["upgHpL120C", "upgHpL213C", "upgDmgM211C", "upgDmgL213C", "upgArmM211C", "upgArmL213C"],
+                ["upgHpM120C", "upgHpL213C", "upgDmgM211C", "upgDmgL213C", "upgArmM213C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [8, 17, 6, 6, 3, 3],
+                [11, 21, 5, 9, 2, 4],
+                [16, 23, 5, 14, 5, 5],
+                [20, 30, 9, 13, 6, 4],
+                [37, 25, 10, 19, 5, 9],
+                [26, 51, 13, 22, 5, 12],
+                [43, 54, 25, 20, 9, 12],
+                [61, 61, 25, 31, 14, 14],
+                [84, 68, 32, 38, 14, 18],
+                [76, 114, 40, 47, 23, 19],
+                [106, 133, 50, 60, 27, 27],
+                [149, 149, 69, 69, 32, 32],
+                [187, 187, 86, 86, 42, 42],
+                [234, 234, 108, 108, 51, 51],
+                [293, 293, 134, 134, 64, 64],
+                [367, 367, 169, 169, 81, 81],
+                [459, 459, 211, 211, 101, 101],
+                [250, 250, 124, 106, 59, 51],
+                [269, 231, 124, 106, 59, 51],
+                [222, 278, 102, 128, 49, 61]
+            ]
+        },
+        "ultraCalgar": {
+            "name": "Calgar",
+            "FactionId": "Ultramarines",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Legendary",
+            "powerMultiplier": 109,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 2,
+                    "DamageProfile": "Power"
+                }
+            ],
+            "stats": {
+                "Health": 95,
+                "Damage": 28,
+                "FixedArmor": 20,
+                "ProgressionIndex": 12
+            },
+            "traits": ["Hero", "CrushingStrike", "FinalJustice", "MkXGravis"],
+            "activeAbilities": ["GauntletsOfUltramar"],
+            "passiveAbilities": ["RitesOfBattle"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Block"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "campaign": {
+                    "campaignType": "Mirror",
+                    "campaignId": "mirror1",
+                    "level": 75
+                }
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_ultraCalgar_01"],
+            "upgrades": [
+                ["upgHpC015", "upgHpC017", "upgDmgC013", "upgDmgC011", "upgArmC004", "upgArmC001"],
+                ["upgHpC015", "upgHpC003", "upgDmgC009", "upgDmgU006", "upgArmC013", "upgArmU009"],
+                ["upgHpC005", "upgHpU002", "upgDmgU013C", "upgDmgR007", "upgArmC013", "upgArmU013"],
+                ["upgHpU006", "upgHpU017", "upgDmgU012", "upgDmgU015C", "upgArmU003C", "upgArmU001"],
+                ["upgHpU008", "upgHpU002", "upgDmgU001C", "upgDmgR13C", "upgArmU005", "upgArmR003C"],
+                ["upgHpR018", "upgHpR012C", "upgDmgR007", "upgDmgU015C", "upgArmU005", "upgArmR013C"],
+                ["upgHpR005", "upgHpR017C", "upgDmgR006", "upgDmgR012C", "upgArmR012C", "upgArmR001C"],
+                ["upgHpE003", "upgHpR020C", "upgDmgE008C", "upgDmgR004C", "upgArmR003C", "upgArmR007C"],
+                ["upgHpE003", "upgHpR004C", "upgDmgL004C", "upgDmgR015C", "upgArmE004C", "upgArmE001C"],
+                ["upgHpL009C", "upgHpE002C", "upgDmgL004C", "upgDmgE004", "upgArmE004C", "upgArmE006C"],
+                ["upgHpE007C", "upgHpE001C", "upgDmgE001", "upgDmgE007C", "upgArmE004C", "upgArmE001C"],
+                ["upgHpL009C", "upgHpL002C", "upgDmgL004C", "upgDmgL015C", "upgArmL001", "upgArmL006C"],
+                ["upgHpL120C", "upgHpL009C", "upgDmgL004C", "upgDmgL008C", "upgArmL004C", "upgArmL010C"],
+                ["upgHpL009C", "upgHpL001C", "upgDmgL120C", "upgDmgL008C", "upgArmL120C", "upgArmL006C"],
+                ["upgHpL120C", "upgHpL002C", "upgDmgL120C", "upgDmgL015C", "upgArmL120C", "upgArmL010C"],
+                ["upgHpL120C", "upgHpL002C", "upgDmgL120C", "upgDmgL006C", "upgArmL120C", "upgArmL004C"],
+                ["upgHpL120C", "upgHpL213C", "upgDmgL120C", "upgDmgL213C", "upgArmL120C", "upgArmL213C"],
+                ["upgHpL120C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM211C", "upgArmL213C"],
+                ["upgHpM120C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 4, 4, 3, 3],
+                [15, 15, 3, 5, 2, 3],
+                [12, 25, 6, 6, 3, 5],
+                [24, 24, 5, 8, 6, 4],
+                [29, 29, 7, 10, 4, 9],
+                [32, 42, 11, 11, 5, 10],
+                [39, 53, 12, 15, 10, 10],
+                [58, 58, 19, 15, 12, 12],
+                [72, 72, 26, 17, 15, 15],
+                [99, 82, 32, 21, 19, 19],
+                [114, 114, 30, 37, 24, 24],
+                [141, 141, 42, 42, 27, 33],
+                [178, 178, 52, 52, 37, 37],
+                [222, 222, 66, 66, 47, 47],
+                [279, 279, 82, 82, 59, 59],
+                [348, 348, 103, 103, 73, 73],
+                [436, 436, 128, 128, 92, 92],
+                [238, 238, 75, 65, 54, 46],
+                [255, 219, 75, 65, 54, 46],
+                [211, 263, 62, 78, 44, 56]
+            ]
+        },
+        "ultraTitus": {
+            "name": "Titus",
+            "FactionId": "Ultramarines",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Epic",
+            "powerMultiplier": 101,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 4,
+                    "DamageProfile": "Chain"
+                }
+            ],
+            "stats": {
+                "Health": 95,
+                "Damage": 26,
+                "FixedArmor": 23,
+                "ProgressionIndex": 9
+            },
+            "traits": ["Hero", "BeastSlayer", "FinalJustice"],
+            "activeAbilities": ["TacticalPrecision"],
+            "passiveAbilities": ["FuelledByFury"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "timestampIfHeroUnlocked": 1728172800000,
+                "timestampIfHeroNotUnlocked": 1731196800000
+            },
+            "releaseStatus": "1725148800000",
+            "unlockQuestIds": ["hero_ultraTitus_01"],
+            "upgrades": [
+                ["upgHpC015", "upgHpC004", "upgDmgC003", "upgDmgC011", "upgArmC013", "upgArmC002"],
+                ["upgHpC003", "upgHpC002", "upgDmgU005", "upgDmgU015C", "upgArmC001", "upgArmC001"],
+                ["upgHpU002", "upgHpU004C", "upgDmgC001", "upgDmgC010", "upgArmU009", "upgArmU001"],
+                ["upgHpU018C", "upgHpU017", "upgDmgU005", "upgDmgU010", "upgArmU001", "upgArmU010C"],
+                ["upgHpU002", "upgHpR017C", "upgDmgU001C", "upgDmgU011", "upgArmR015", "upgArmU001"],
+                ["upgHpR020C", "upgHpU006", "upgDmgR007", "upgDmgR010C", "upgArmR005", "upgArmU003C"],
+                ["upgHpR019", "upgHpR005", "upgDmgR001C", "upgDmgR005", "upgArmR001C", "upgArmR003C"],
+                ["upgHpE002C", "upgHpR004C", "upgDmgR002", "upgDmgE006C", "upgArmR015", "upgArmR001C"],
+                ["upgHpR018", "upgHpE001C", "upgDmgE002C", "upgDmgR015C", "upgArmE006C", "upgArmE013"],
+                ["upgHpE002C", "upgHpE015", "upgDmgE011", "upgDmgE009C", "upgArmE006C", "upgArmE004C"],
+                ["upgHpL100", "upgHpE001C", "upgDmgL004C", "upgDmgE006C", "upgArmE006C", "upgArmE001C"],
+                ["upgHpE002C", "upgHpL017C", "upgDmgE002C", "upgDmgL015C", "upgArmL001", "upgArmL004C"],
+                ["upgHpL002C", "upgHpL001C", "upgDmgL001", "upgDmgL005C", "upgArmL006C", "upgArmL010C"],
+                ["upgHpL120C", "upgHpL009C", "upgDmgL004C", "upgDmgL015C", "upgArmL006C", "upgArmL010C"],
+                ["upgHpL002C", "upgHpL009C", "upgDmgL120C", "upgDmgL007C", "upgArmL120C", "upgArmL010C"],
+                ["upgHpL120C", "upgHpL017C", "upgDmgL120C", "upgDmgL009C", "upgArmL120C", "upgArmL004C"],
+                ["upgHpL120C", "upgHpL213C", "upgDmgL120C", "upgDmgL213C", "upgArmL120C", "upgArmL213C"],
+                ["upgHpL120C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM211C", "upgArmL213C"],
+                ["upgHpM120C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 4, 4, 3, 3],
+                [15, 15, 3, 4, 4, 4],
+                [15, 22, 5, 5, 4, 4],
+                [28, 19, 7, 7, 5, 7],
+                [20, 39, 9, 6, 8, 6],
+                [49, 25, 9, 11, 9, 9],
+                [46, 46, 14, 11, 11, 11],
+                [64, 52, 12, 20, 12, 16],
+                [54, 90, 22, 18, 19, 16],
+                [101, 80, 22, 27, 22, 22],
+                [114, 114, 34, 28, 28, 28],
+                [128, 154, 35, 43, 30, 37],
+                [178, 178, 44, 53, 43, 43],
+                [222, 222, 61, 61, 54, 54],
+                [279, 279, 76, 76, 68, 68],
+                [348, 348, 96, 96, 84, 84],
+                [436, 436, 119, 119, 106, 106],
+                [238, 238, 69, 60, 61, 53],
+                [255, 219, 70, 60, 62, 53],
+                [211, 263, 58, 72, 51, 63]
+            ]
+        },
+        "ultraDreadnought": {
+            "name": "Galatian",
+            "FactionId": "Ultramarines",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Common",
+            "stats": {
+                "Health": 0,
+                "Damage": 0,
+                "FixedArmor": 0,
+                "ProgressionIndex": 0
+            },
+            "traits": ["MachineOfWar"],
+            "activeAbilities": ["DutyEternal", "MacroPlasmaIncinerator"],
+            "mythicAbilities": ["WisdomOfTheAncients"],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "timestampIfHeroUnlocked": 1724486400000,
+                "timestampIfHeroNotUnlocked": 1727510400000
+            },
+            "releaseStatus": "1723795200000",
+            "unlockQuestIds": ["hero_ultraDreadnought_01"],
+            "upgrades": null,
+            "upgradesStatIncrease": null
+        },
+        "adeptRetributor": {
+            "name": "Vindicta",
+            "FactionId": "Sisterhood",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Common",
+            "powerMultiplier": 96,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 1,
+                    "DamageProfile": "Physical"
+                },
+                {
+                    "hits": 4,
+                    "DamageProfile": "Flame",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 75,
+                "Damage": 20,
+                "FixedArmor": 18,
+                "ProgressionIndex": 0
+            },
+            "traits": ["Hero", "ActOfFaith", "HeavyWeapon"],
+            "activeAbilities": ["ArmoriumCherub"],
+            "passiveAbilities": ["FireOfAbsolution"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "upgrades": [
+                ["upgHpC002", "upgHpU002", "upgDmgC004", "upgDmgC003", "upgArmC003", "upgArmC004"],
+                ["upgHpC004", "upgHpU002", "upgDmgC003", "upgDmgU004", "upgArmC003", "upgArmU001"],
+                ["upgHpC001", "upgHpR002", "upgDmgC006", "upgDmgU007C", "upgArmC006", "upgArmU002"],
+                ["upgHpU005C", "upgHpU006", "upgDmgC011", "upgDmgU001C", "upgArmC006", "upgArmU005"],
+                ["upgHpU008", "upgHpR003C", "upgDmgU002C", "upgDmgU005", "upgArmU003C", "upgArmU005"],
+                ["upgHpU006", "upgHpE006C", "upgDmgU006", "upgDmgR012C", "upgArmU002", "upgArmR003C"],
+                ["upgHpR004C", "upgHpR006C", "upgDmgR006", "upgDmgR008C", "upgArmR012C", "upgArmE004C"],
+                ["upgHpR003C", "upgHpR006C", "upgDmgE001", "upgDmgE008C", "upgArmR003C", "upgArmR003C"],
+                ["upgHpR004C", "upgHpL002C", "upgDmgR006", "upgDmgE002C", "upgArmR003C", "upgArmE004C"],
+                ["upgHpE006C", "upgHpL002C", "upgDmgL004C", "upgDmgL005C", "upgArmE004C", "upgArmE004C"],
+                ["upgHpE022C", "upgHpE012", "upgDmgL022C", "upgDmgE006C", "upgArmL022C", "upgArmE001C"],
+                ["upgHpL022C", "upgHpL002C", "upgDmgE022C", "upgDmgL015C", "upgArmE022C", "upgArmL011C"],
+                ["upgHpL122C", "upgHpL009C", "upgDmgL022C", "upgDmgL002C", "upgArmL022C", "upgArmL010C"],
+                ["upgHpL022C", "upgHpL009C", "upgDmgL122C", "upgDmgL002C", "upgArmL122C", "upgArmL004C"],
+                ["upgHpL122C", "upgHpL002C", "upgDmgL122C", "upgDmgL015C", "upgArmL122C", "upgArmL010C"],
+                ["upgHpL122C", "upgHpL002C", "upgDmgL122C", "upgDmgL002C", "upgArmL122C", "upgArmL004C"],
+                ["upgHpL122C", "upgHpL213C", "upgDmgL122C", "upgDmgL213C", "upgArmL122C", "upgArmL213C"],
+                ["upgHpL122C", "upgHpL213C", "upgDmgM211C", "upgDmgL213C", "upgArmM211C", "upgArmL213C"],
+                ["upgHpM122C", "upgHpL213C", "upgDmgM211C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [2, 18, 2, 4, 3, 3],
+                [6, 18, 4, 3, 1, 3],
+                [7, 21, 2, 5, 2, 5],
+                [22, 15, 2, 7, 3, 6],
+                [16, 31, 8, 5, 7, 4],
+                [17, 41, 5, 10, 5, 9],
+                [37, 37, 8, 11, 8, 10],
+                [45, 45, 11, 14, 11, 11],
+                [46, 68, 11, 19, 12, 15],
+                [65, 78, 19, 19, 17, 17],
+                [99, 80, 26, 22, 23, 20],
+                [112, 112, 27, 33, 25, 29],
+                [140, 140, 37, 37, 34, 34],
+                [176, 176, 47, 47, 42, 42],
+                [219, 219, 59, 59, 53, 53],
+                [276, 276, 73, 73, 66, 66],
+                [344, 344, 92, 92, 82, 82],
+                [187, 187, 54, 46, 48, 42],
+                [202, 173, 54, 46, 48, 42],
+                [167, 208, 44, 56, 40, 50]
+            ]
+        },
+        "adeptHospitaller": {
+            "name": "Isabella",
+            "FactionId": "Sisterhood",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Rare",
+            "powerMultiplier": 130,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 3,
+                    "DamageProfile": "Bolter"
+                }
+            ],
+            "stats": {
+                "Health": 85,
+                "Damage": 20,
+                "FixedArmor": 18,
+                "ProgressionIndex": 6
+            },
+            "traits": ["Hero", "ActOfFaith", "Healer"],
+            "activeAbilities": ["RitesOfRestoration"],
+            "passiveAbilities": ["MedicusMinistorum"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Block"],
+            "itemSlotsRelic": [1],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_adeptHospitaller_01"],
+            "upgrades": [
+                ["upgHpC006", "upgHpC007", "upgDmgC013", "upgDmgC011", "upgArmC006", "upgArmC001"],
+                ["upgHpC016", "upgHpC003", "upgDmgC001", "upgDmgU003", "upgArmC013", "upgArmU013"],
+                ["upgHpC016", "upgHpU002", "upgDmgU001C", "upgDmgU010", "upgArmC006", "upgArmU013"],
+                ["upgHpU016", "upgHpR005", "upgDmgU004", "upgDmgU015C", "upgArmU003C", "upgArmU001"],
+                ["upgHpU015", "upgHpU002", "upgDmgU013C", "upgDmgR13C", "upgArmU008", "upgArmR013C"],
+                ["upgHpR002", "upgHpU005C", "upgDmgR022", "upgDmgU015C", "upgArmU005", "upgArmR003C"],
+                ["upgHpR022", "upgHpR006C", "upgDmgR005", "upgDmgR010C", "upgArmR012C", "upgArmR001C"],
+                ["upgHpE022C", "upgHpR020C", "upgDmgR011C", "upgDmgE006C", "upgArmR022", "upgArmR013C"],
+                ["upgHpE012", "upgHpR006C", "upgDmgE022C", "upgDmgR015C", "upgArmE022C", "upgArmE001C"],
+                ["upgHpE022C", "upgHpE002C", "upgDmgE022C", "upgDmgE003", "upgArmE022C", "upgArmE011C"],
+                ["upgHpE022C", "upgHpE006C", "upgDmgL022C", "upgDmgE003", "upgArmL022C", "upgArmE001C"],
+                ["upgHpL022C", "upgHpL002C", "upgDmgE022C", "upgDmgL015C", "upgArmE022C", "upgArmL011C"],
+                ["upgHpL122C", "upgHpL001C", "upgDmgL022C", "upgDmgL002C", "upgArmL022C", "upgArmL010C"],
+                ["upgHpL022C", "upgHpL009C", "upgDmgL122C", "upgDmgL002C", "upgArmL122C", "upgArmL011C"],
+                ["upgHpL122C", "upgHpL002C", "upgDmgL122C", "upgDmgL015C", "upgArmL122C", "upgArmL010C"],
+                ["upgHpL122C", "upgHpL002C", "upgDmgL122C", "upgDmgL002C", "upgArmL122C", "upgArmL004C"],
+                ["upgHpL122C", "upgHpL213C", "upgDmgL122C", "upgDmgL213C", "upgArmL122C", "upgArmL213C"],
+                ["upgHpL122C", "upgHpL213C", "upgDmgM211C", "upgDmgL213C", "upgArmM213C", "upgArmL213C"],
+                ["upgHpM122C", "upgHpL213C", "upgDmgM211C", "upgDmgL213C", "upgArmM211C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [11, 11, 3, 3, 3, 3],
+                [13, 13, 2, 3, 1, 3],
+                [11, 23, 5, 3, 2, 5],
+                [17, 25, 4, 6, 5, 4],
+                [26, 26, 6, 7, 4, 7],
+                [33, 33, 8, 8, 5, 9],
+                [36, 47, 8, 10, 9, 9],
+                [57, 46, 11, 14, 9, 13],
+                [65, 65, 17, 13, 14, 14],
+                [81, 81, 21, 17, 17, 17],
+                [101, 101, 29, 19, 23, 19],
+                [127, 127, 27, 33, 25, 29],
+                [159, 159, 37, 37, 34, 34],
+                [199, 199, 47, 47, 42, 42],
+                [249, 249, 59, 59, 53, 53],
+                [312, 312, 73, 73, 66, 66],
+                [390, 390, 92, 92, 82, 82],
+                [213, 213, 54, 46, 48, 42],
+                [228, 196, 54, 46, 48, 42],
+                [188, 236, 44, 56, 40, 50]
+            ]
+        },
+        "adeptMorvenn": {
+            "name": "Morvenn Vahl",
+            "FactionId": "Sisterhood",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Legendary",
+            "powerMultiplier": 91,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 2,
+                    "DamageProfile": "Power"
+                },
+                {
+                    "hits": 3,
+                    "DamageProfile": "Bolter",
+                    "Range": 3
+                }
+            ],
+            "stats": {
+                "Health": 95,
+                "Damage": 24,
+                "FixedArmor": 24,
+                "ProgressionIndex": 12
+            },
+            "traits": ["Hero", "ActOfFaith", "BigTarget", "Explodes", "Mechanical"],
+            "activeAbilities": ["SanctorumMissile"],
+            "passiveAbilities": ["RighteousRepugnance"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Block"],
+            "itemSlotsRelic": [1],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_adeptMorvenn_01"],
+            "upgrades": [
+                ["upgHpC004", "upgHpC002", "upgDmgC013", "upgDmgC011", "upgArmC013", "upgArmC001"],
+                ["upgHpC014", "upgHpC003", "upgDmgC001", "upgDmgU009", "upgArmC012", "upgArmU013"],
+                ["upgHpC015", "upgHpU002", "upgDmgU001C", "upgDmgU009", "upgArmC013", "upgArmU009"],
+                ["upgHpU014", "upgHpU017", "upgDmgU004", "upgDmgU015C", "upgArmU003C", "upgArmU001"],
+                ["upgHpU008", "upgHpU002", "upgDmgU013C", "upgDmgR13C", "upgArmU005", "upgArmR007C"],
+                ["upgHpR002", "upgHpR017C", "upgDmgR022", "upgDmgU015C", "upgArmU005", "upgArmR003C"],
+                ["upgHpR022", "upgHpR012C", "upgDmgR005", "upgDmgR004C", "upgArmR012C", "upgArmR001C"],
+                ["upgHpE022C", "upgHpR020C", "upgDmgR011C", "upgDmgE007C", "upgArmR022", "upgArmR007C"],
+                ["upgHpE012", "upgHpR004C", "upgDmgE022C", "upgDmgR015C", "upgArmE022C", "upgArmE001C"],
+                ["upgHpE022C", "upgHpE002C", "upgDmgE022C", "upgDmgE004", "upgArmE022C", "upgArmE002C"],
+                ["upgHpE022C", "upgHpE001C", "upgDmgL022C", "upgDmgE004", "upgArmL022C", "upgArmE001C"],
+                ["upgHpL022C", "upgHpL002C", "upgDmgE022C", "upgDmgL015C", "upgArmE022C", "upgArmL002C"],
+                ["upgHpL122C", "upgHpL001C", "upgDmgL022C", "upgDmgL008C", "upgArmL022C", "upgArmL010C"],
+                ["upgHpL022C", "upgHpL001C", "upgDmgL122C", "upgDmgL008C", "upgArmL122C", "upgArmL002C"],
+                ["upgHpL122C", "upgHpL002C", "upgDmgL122C", "upgDmgL015C", "upgArmL122C", "upgArmL010C"],
+                ["upgHpL122C", "upgHpL002C", "upgDmgL122C", "upgDmgL005C", "upgArmL122C", "upgArmL004C"],
+                ["upgHpL122C", "upgHpL214C", "upgDmgL122C", "upgDmgL214C", "upgArmL122C", "upgArmL214C"],
+                ["upgHpL122C", "upgHpL214C", "upgDmgM214C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpM122C", "upgHpL214C", "upgDmgM214C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 3, 3, 3, 3],
+                [15, 15, 3, 5, 3, 5],
+                [12, 25, 5, 4, 3, 6],
+                [24, 24, 5, 7, 7, 5],
+                [29, 29, 6, 9, 5, 10],
+                [32, 42, 9, 9, 6, 12],
+                [39, 53, 10, 14, 12, 12],
+                [64, 52, 13, 16, 12, 17],
+                [72, 72, 20, 16, 18, 18],
+                [91, 91, 26, 20, 23, 23],
+                [113, 113, 34, 23, 31, 26],
+                [142, 142, 33, 39, 33, 39],
+                [177, 177, 45, 45, 45, 45],
+                [223, 223, 56, 56, 56, 56],
+                [278, 278, 71, 71, 71, 71],
+                [349, 349, 88, 88, 88, 88],
+                [436, 436, 110, 110, 110, 110],
+                [237, 237, 64, 55, 64, 55],
+                [256, 219, 65, 55, 65, 55],
+                [211, 263, 53, 67, 53, 67]
+            ]
+        },
+        "adeptCanoness": {
+            "name": "Roswitha",
+            "FactionId": "Sisterhood",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Uncommon",
+            "powerMultiplier": 128,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 3,
+                    "DamageProfile": "Chain"
+                },
+                {
+                    "hits": 2,
+                    "DamageProfile": "Bolter",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 85,
+                "Damage": 30,
+                "FixedArmor": 17,
+                "ProgressionIndex": 3
+            },
+            "traits": ["Hero", "ActOfFaith"],
+            "activeAbilities": ["BrazierOfHolyFire"],
+            "passiveAbilities": ["CondemnorStake"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Block"],
+            "itemSlotsRelic": [1],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_adeptCanoness_01"],
+            "upgrades": [
+                ["upgHpC004", "upgHpC017", "upgDmgC013", "upgDmgC011", "upgArmC006", "upgArmC001"],
+                ["upgHpC006", "upgHpC003", "upgDmgC002", "upgDmgU003", "upgArmC006", "upgArmU013"],
+                ["upgHpC015", "upgHpU002", "upgDmgU002C", "upgDmgU003", "upgArmC013", "upgArmU009"],
+                ["upgHpU016", "upgHpU017", "upgDmgU004", "upgDmgU015C", "upgArmU003C", "upgArmU001"],
+                ["upgHpU008", "upgHpU002", "upgDmgU013C", "upgDmgR13C", "upgArmU005", "upgArmR003C"],
+                ["upgHpR018", "upgHpR017C", "upgDmgR022", "upgDmgU015C", "upgArmU008", "upgArmR013C"],
+                ["upgHpR022", "upgHpR017C", "upgDmgR002", "upgDmgR010C", "upgArmR012C", "upgArmR001C"],
+                ["upgHpE022C", "upgHpR020C", "upgDmgE002C", "upgDmgR010C", "upgArmR022", "upgArmR007C"],
+                ["upgHpE012", "upgHpR004C", "upgDmgE022C", "upgDmgR015C", "upgArmE022C", "upgArmE001C"],
+                ["upgHpE022C", "upgHpE002C", "upgDmgE022C", "upgDmgE003", "upgArmE022C", "upgArmE011C"],
+                ["upgHpE022C", "upgHpE001C", "upgDmgL022C", "upgDmgE003", "upgArmL022C", "upgArmE001C"],
+                ["upgHpL022C", "upgHpL002C", "upgDmgE022C", "upgDmgL015C", "upgArmE022C", "upgArmL011C"],
+                ["upgHpL122C", "upgHpL009C", "upgDmgL022C", "upgDmgL002C", "upgArmL022C", "upgArmL010C"],
+                ["upgHpL022C", "upgHpL001C", "upgDmgL122C", "upgDmgL002C", "upgArmL122C", "upgArmL011C"],
+                ["upgHpL122C", "upgHpL002C", "upgDmgL122C", "upgDmgL015C", "upgArmL122C", "upgArmL010C"],
+                ["upgHpL122C", "upgHpL002C", "upgDmgL122C", "upgDmgL002C", "upgArmL122C", "upgArmL004C"],
+                ["upgHpL122C", "upgHpL213C", "upgDmgL122C", "upgDmgL213C", "upgArmL122C", "upgArmL213C"],
+                ["upgHpL122C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpM122C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM213C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [11, 11, 4, 4, 2, 2],
+                [13, 13, 3, 6, 2, 4],
+                [11, 23, 7, 5, 2, 4],
+                [21, 21, 6, 9, 5, 4],
+                [26, 26, 8, 10, 3, 7],
+                [28, 38, 12, 12, 4, 9],
+                [36, 47, 12, 17, 9, 9],
+                [57, 46, 20, 16, 9, 11],
+                [65, 65, 26, 20, 13, 13],
+                [81, 81, 32, 25, 16, 16],
+                [101, 101, 43, 28, 22, 18],
+                [127, 127, 41, 49, 23, 28],
+                [159, 159, 56, 56, 32, 32],
+                [199, 199, 71, 71, 40, 40],
+                [249, 249, 87, 87, 50, 50],
+                [312, 312, 110, 110, 62, 62],
+                [390, 390, 138, 138, 78, 78],
+                [213, 213, 81, 69, 46, 39],
+                [228, 196, 81, 69, 46, 39],
+                [188, 236, 67, 83, 38, 47]
+            ]
+        },
+        "adeptCelestine": {
+            "name": "Celestine",
+            "FactionId": "Sisterhood",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Legendary",
+            "powerMultiplier": 106,
+            "Movement": 4,
+            "weapons": [
+                {
+                    "hits": 3,
+                    "DamageProfile": "Power"
+                }
+            ],
+            "stats": {
+                "Health": 60,
+                "Damage": 25,
+                "FixedArmor": 20,
+                "ProgressionIndex": 12
+            },
+            "traits": ["Hero", "ActOfFaith", "Flying"],
+            "activeAbilities": ["SkyStrike"],
+            "passiveAbilities": ["GeminaeSuperia"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "campaign": {
+                    "campaignType": "Standard",
+                    "campaignId": "campaign2",
+                    "level": 60
+                }
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_adeptCelestine_01"],
+            "upgrades": [
+                ["upgHpC016", "upgHpC005", "upgDmgC003", "upgDmgC011", "upgArmC013", "upgArmC001"],
+                ["upgHpC016", "upgHpC003", "upgDmgC004", "upgDmgU011", "upgArmC004", "upgArmU009"],
+                ["upgHpC015", "upgHpU002", "upgDmgU013C", "upgDmgU010", "upgArmC013", "upgArmU013"],
+                ["upgHpU016", "upgHpU017", "upgDmgU003", "upgDmgU015C", "upgArmU003C", "upgArmU001"],
+                ["upgHpU008", "upgHpU002", "upgDmgU013C", "upgDmgR14C", "upgArmU006", "upgArmR013C"],
+                ["upgHpR002", "upgHpR017C", "upgDmgR022", "upgDmgU015C", "upgArmU006", "upgArmR003C"],
+                ["upgHpR022", "upgHpR017C", "upgDmgR003", "upgDmgR010C", "upgArmR012C", "upgArmR001C"],
+                ["upgHpR002", "upgHpR020C", "upgDmgL002C", "upgDmgR010C", "upgArmR022", "upgArmR013C"],
+                ["upgHpR022", "upgHpR020C", "upgDmgE022C", "upgDmgR015C", "upgArmE022C", "upgArmE001C"],
+                ["upgHpE022C", "upgHpE002C", "upgDmgE022C", "upgDmgE003", "upgArmE022C", "upgArmE011C"],
+                ["upgHpE022C", "upgHpE012", "upgDmgL022C", "upgDmgE006C", "upgArmL022C", "upgArmE001C"],
+                ["upgHpL022C", "upgHpL002C", "upgDmgE022C", "upgDmgL015C", "upgArmE022C", "upgArmL011C"],
+                ["upgHpL122C", "upgHpL009C", "upgDmgL022C", "upgDmgL008C", "upgArmL022C", "upgArmL010C"],
+                ["upgHpL022C", "upgHpL009C", "upgDmgL122C", "upgDmgL008C", "upgArmL122C", "upgArmL011C"],
+                ["upgHpL122C", "upgHpL002C", "upgDmgL122C", "upgDmgL015C", "upgArmL122C", "upgArmL010C"],
+                ["upgHpL122C", "upgHpL002C", "upgDmgL122C", "upgDmgL002C", "upgArmL122C", "upgArmL004C"],
+                ["upgHpL122C", "upgHpL212C", "upgDmgL122C", "upgDmgL212C", "upgArmL122C", "upgArmL212C"],
+                ["upgHpL122C", "upgHpL212C", "upgDmgM213C", "upgDmgL212C", "upgArmM213C", "upgArmL212C"],
+                ["upgHpM122C", "upgHpL212C", "upgDmgM213C", "upgDmgL212C", "upgArmM211C", "upgArmL212C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [8, 8, 3, 3, 3, 3],
+                [9, 9, 3, 5, 2, 3],
+                [8, 16, 6, 4, 3, 5],
+                [15, 15, 5, 7, 6, 4],
+                [19, 19, 7, 9, 4, 9],
+                [19, 26, 10, 10, 5, 10],
+                [25, 33, 10, 14, 10, 10],
+                [31, 42, 18, 12, 10, 14],
+                [39, 53, 21, 17, 15, 15],
+                [57, 57, 27, 21, 19, 19],
+                [79, 64, 32, 27, 26, 22],
+                [90, 90, 34, 41, 27, 33],
+                [112, 112, 47, 47, 37, 37],
+                [140, 140, 58, 58, 47, 47],
+                [176, 176, 74, 74, 59, 59],
+                [220, 220, 91, 91, 73, 73],
+                [276, 276, 115, 115, 92, 92],
+                [150, 150, 67, 58, 54, 46],
+                [161, 138, 67, 58, 54, 46],
+                [133, 167, 56, 69, 44, 56]
+            ]
+        },
+        "adeptExorcist": {
+            "name": "Exorcist",
+            "FactionId": "Sisterhood",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Common",
+            "stats": {
+                "Health": 0,
+                "Damage": 0,
+                "FixedArmor": 0,
+                "ProgressionIndex": 0
+            },
+            "traits": ["MachineOfWar"],
+            "activeAbilities": ["ThriceBlessedConflagration", "DevastatingRefrain"],
+            "mythicAbilities": ["ShieldOfFaith"],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "timestampIfHeroUnlocked": 1751702400000,
+                "timestampIfHeroNotUnlocked": 1754726400000
+            },
+            "releaseStatus": "1750982400000",
+            "unlockQuestIds": ["hero_adeptExorcist_01"],
+            "upgrades": null,
+            "upgradesStatIncrease": null
+        },
+        "necroWarden": {
+            "name": "Makhotep",
+            "FactionId": "Necrons",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Common",
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 1,
+                    "DamageProfile": "Physical"
+                },
+                {
+                    "hits": 2,
+                    "DamageProfile": "Gauss",
+                    "Range": 3
+                }
+            ],
+            "stats": {
+                "Health": 85,
+                "Damage": 18,
+                "FixedArmor": 20,
+                "ProgressionIndex": 0
+            },
+            "traits": ["Hero", "LivingMetal", "Mechanical"],
+            "activeAbilities": ["AdaptiveStrategy"],
+            "passiveAbilities": ["RelentlessMarch"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [2],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "campaign": {
+                    "campaignType": "Standard",
+                    "campaignId": "campaign1",
+                    "level": 15
+                }
+            },
+            "releaseStatus": "released",
+            "upgrades": [
+                ["upgHpC008", "upgHpU001", "upgDmgC001", "upgDmgC008", "upgArmC004", "upgArmC003"],
+                ["upgHpC008", "upgHpU007", "upgDmgU003", "upgDmgC003", "upgArmC004", "upgArmC005"],
+                ["upgHpU007", "upgHpU001", "upgDmgR002", "upgDmgU001C", "upgArmC005", "upgArmU002"],
+                ["upgHpU007", "upgHpR002", "upgDmgU010", "upgDmgR002", "upgArmU003C", "upgArmU004C"],
+                ["upgHpU010C", "upgHpR009C", "upgDmgU003", "upgDmgR003", "upgArmU004C", "upgArmR002C"],
+                ["upgHpR009C", "upgHpE004C", "upgDmgR009", "upgDmgU017C", "upgArmU003C", "upgArmR002C"],
+                ["upgHpR011", "upgHpR009C", "upgDmgR009", "upgDmgR010C", "upgArmR002C", "upgArmR008C"],
+                ["upgHpE009C", "upgHpE004C", "upgDmgR011C", "upgDmgR004C", "upgArmR002C", "upgArmR006"],
+                ["upgHpL010", "upgHpR012C", "upgDmgE008C", "upgDmgR017C", "upgArmE003C", "upgArmE012C"],
+                ["upgHpE009C", "upgHpE014C", "upgDmgE008C", "upgDmgE006C", "upgArmE008", "upgArmE002C"],
+                ["upgHpE009C", "upgHpE013C", "upgDmgL006C", "upgDmgE007C", "upgArmE008", "upgArmE012C"],
+                ["upgHpL007C", "upgHpL014C", "upgDmgE008C", "upgDmgL017C", "upgArmE003C", "upgArmL002C"],
+                ["upgHpL008C", "upgHpL013C", "upgDmgL006C", "upgDmgL005C", "upgArmL003C", "upgArmL009C"],
+                ["upgHpL007C", "upgHpL013C", "upgDmgL130C", "upgDmgL005C", "upgArmL130C", "upgArmL002C"],
+                ["upgHpL008C", "upgHpL014C", "upgDmgL130C", "upgDmgL017C", "upgArmL130C", "upgArmL009C"],
+                ["upgHpL008C", "upgHpL017C", "upgDmgL130C", "upgDmgL005C", "upgArmL130C", "upgArmL003C"],
+                ["upgHpL007C", "upgHpL214C", "upgDmgL130C", "upgDmgL214C", "upgArmL130C", "upgArmL214C"],
+                ["upgHpL007C", "upgHpL214C", "upgDmgM214C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpM130C", "upgHpL214C", "upgDmgM214C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [7, 14, 3, 3, 3, 3],
+                [9, 18, 3, 1, 3, 3],
+                [17, 17, 4, 4, 2, 5],
+                [17, 25, 3, 5, 5, 5],
+                [22, 30, 4, 7, 6, 7],
+                [29, 37, 7, 7, 6, 9],
+                [36, 47, 8, 10, 10, 10],
+                [52, 52, 11, 11, 14, 10],
+                [71, 57, 15, 12, 15, 15],
+                [81, 81, 17, 17, 17, 21],
+                [102, 102, 23, 20, 21, 27],
+                [127, 127, 25, 29, 27, 33],
+                [159, 159, 34, 34, 37, 37],
+                [198, 198, 42, 42, 47, 47],
+                [249, 249, 53, 53, 59, 59],
+                [312, 312, 66, 66, 73, 73],
+                [391, 391, 82, 82, 92, 92],
+                [212, 212, 48, 42, 54, 46],
+                [229, 196, 48, 42, 54, 46],
+                [188, 236, 40, 50, 44, 56]
+            ]
+        },
+        "necroDestroyer": {
+            "name": "Imospekh",
+            "FactionId": "Necrons",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Common",
+            "powerMultiplier": 80,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 6,
+                    "DamageProfile": "Gauss"
+                },
+                {
+                    "hits": 6,
+                    "DamageProfile": "Gauss",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 80,
+                "Damage": 9,
+                "FixedArmor": 20,
+                "ProgressionIndex": 0
+            },
+            "traits": ["Hero", "Overwatch", "LivingMetal", "Mechanical"],
+            "activeAbilities": ["MultiThreatEliminator"],
+            "passiveAbilities": ["InescapableDeath"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [2],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "campaign": {
+                    "campaignType": "Standard",
+                    "campaignId": "campaign1",
+                    "level": 30
+                }
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_necroDestroyer_01"],
+            "upgrades": [
+                ["upgHpC009", "upgHpU001", "upgDmgC001", "upgDmgU003", "upgArmC004", "upgArmU002"],
+                ["upgHpC008", "upgHpU001", "upgDmgU003", "upgDmgC004", "upgArmC003", "upgArmC004"],
+                ["upgHpC008", "upgHpR002", "upgDmgC001", "upgDmgU009", "upgArmC004", "upgArmU003C"],
+                ["upgHpU001", "upgHpR011", "upgDmgU001C", "upgDmgU003", "upgArmU002", "upgArmU004C"],
+                ["upgHpU001", "upgHpU010C", "upgDmgU001C", "upgDmgU009", "upgArmU002", "upgArmU003C"],
+                ["upgHpU010C", "upgHpR002", "upgDmgR009", "upgDmgU017C", "upgArmU002", "upgArmR002C"],
+                ["upgHpR011", "upgHpR009C", "upgDmgR009", "upgDmgR010C", "upgArmR002C", "upgArmR008C"],
+                ["upgHpE009C", "upgHpE004C", "upgDmgR011C", "upgDmgR004C", "upgArmR002C", "upgArmR006"],
+                ["upgHpL010", "upgHpR012C", "upgDmgE008C", "upgDmgR017C", "upgArmE003C", "upgArmE012C"],
+                ["upgHpE009C", "upgHpE014C", "upgDmgE008C", "upgDmgE006C", "upgArmE008", "upgArmE002C"],
+                ["upgHpE009C", "upgHpE013C", "upgDmgL006C", "upgDmgE007C", "upgArmE008", "upgArmE012C"],
+                ["upgHpL007C", "upgHpL014C", "upgDmgE008C", "upgDmgL017C", "upgArmE003C", "upgArmL002C"],
+                ["upgHpL008C", "upgHpL013C", "upgDmgL006C", "upgDmgL005C", "upgArmL003C", "upgArmL009C"],
+                ["upgHpL007C", "upgHpL013C", "upgDmgL130C", "upgDmgL005C", "upgArmL130C", "upgArmL002C"],
+                ["upgHpL008C", "upgHpL014C", "upgDmgL130C", "upgDmgL017C", "upgArmL130C", "upgArmL009C"],
+                ["upgHpL008C", "upgHpL017C", "upgDmgL130C", "upgDmgL005C", "upgArmL130C", "upgArmL003C"],
+                ["upgHpL007C", "upgHpL214C", "upgDmgL130C", "upgDmgL214C", "upgArmL130C", "upgArmL214C"],
+                ["upgHpL007C", "upgHpL214C", "upgDmgM214C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpM130C", "upgHpL214C", "upgDmgM214C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [7, 13, 1, 1, 2, 3],
+                [8, 17, 2, 1, 3, 3],
+                [8, 24, 1, 3, 2, 6],
+                [16, 24, 2, 2, 4, 6],
+                [20, 29, 4, 2, 5, 8],
+                [31, 31, 4, 4, 5, 10],
+                [33, 45, 3, 4, 10, 10],
+                [49, 49, 6, 6, 14, 10],
+                [67, 54, 7, 6, 15, 15],
+                [76, 76, 9, 9, 17, 21],
+                [96, 96, 11, 10, 21, 27],
+                [119, 119, 12, 15, 27, 33],
+                [150, 150, 17, 17, 37, 37],
+                [187, 187, 21, 21, 47, 47],
+                [234, 234, 26, 26, 59, 59],
+                [294, 294, 33, 33, 73, 73],
+                [367, 367, 42, 42, 92, 92],
+                [200, 200, 24, 20, 54, 46],
+                [215, 185, 24, 21, 54, 46],
+                [177, 222, 20, 25, 44, 56]
+            ]
+        },
+        "necroSpyder": {
+            "name": "Aleph-Null",
+            "FactionId": "Necrons",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Uncommon",
+            "powerMultiplier": 103,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 5,
+                    "DamageProfile": "Particle"
+                }
+            ],
+            "stats": {
+                "Health": 90,
+                "Damage": 12,
+                "FixedArmor": 22,
+                "ProgressionIndex": 3
+            },
+            "traits": ["Hero", "LivingMetal", "Explodes", "Mechanical", "Flying", "Mechanic"],
+            "activeAbilities": ["ScarabHive"],
+            "passiveAbilities": ["FabricatorClawArray"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [2],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "campaign": {
+                    "campaignType": "Standard",
+                    "campaignId": "campaign1",
+                    "level": 45
+                }
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_necroSpyder_01"],
+            "upgrades": [
+                ["upgHpC008", "upgHpU001", "upgDmgU003", "upgDmgC004", "upgArmC004", "upgArmC005"],
+                ["upgHpC008", "upgHpU007", "upgDmgC007", "upgDmgU003", "upgArmC004", "upgArmC005"],
+                ["upgHpU001", "upgHpR011", "upgDmgC007", "upgDmgU009", "upgArmC003", "upgArmU003C"],
+                ["upgHpU001", "upgHpU010C", "upgDmgU003", "upgDmgU010", "upgArmU004C", "upgArmR002C"],
+                ["upgHpU007", "upgHpU010C", "upgDmgU010", "upgDmgR002", "upgArmU003C", "upgArmR002C"],
+                ["upgHpU007", "upgHpR009C", "upgDmgR009", "upgDmgU017C", "upgArmR002C", "upgArmE002C"],
+                ["upgHpR011", "upgHpR009C", "upgDmgR009", "upgDmgR010C", "upgArmR002C", "upgArmR008C"],
+                ["upgHpE009C", "upgHpE004C", "upgDmgR011C", "upgDmgR004C", "upgArmR002C", "upgArmR006"],
+                ["upgHpL010", "upgHpR012C", "upgDmgE008C", "upgDmgR017C", "upgArmE003C", "upgArmE012C"],
+                ["upgHpE009C", "upgHpE014C", "upgDmgE008C", "upgDmgE006C", "upgArmE008", "upgArmE002C"],
+                ["upgHpE009C", "upgHpE013C", "upgDmgL006C", "upgDmgE007C", "upgArmE008", "upgArmE012C"],
+                ["upgHpL007C", "upgHpL014C", "upgDmgE008C", "upgDmgL017C", "upgArmE003C", "upgArmL002C"],
+                ["upgHpL008C", "upgHpL013C", "upgDmgL006C", "upgDmgL005C", "upgArmL003C", "upgArmL009C"],
+                ["upgHpL007C", "upgHpL013C", "upgDmgL130C", "upgDmgL005C", "upgArmL130C", "upgArmL002C"],
+                ["upgHpL008C", "upgHpL014C", "upgDmgL130C", "upgDmgL017C", "upgArmL130C", "upgArmL009C"],
+                ["upgHpL008C", "upgHpL017C", "upgDmgL130C", "upgDmgL005C", "upgArmL130C", "upgArmL003C"],
+                ["upgHpL007C", "upgHpL214C", "upgDmgL130C", "upgDmgL214C", "upgArmL130C", "upgArmL214C"],
+                ["upgHpL007C", "upgHpL214C", "upgDmgM214C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpM130C", "upgHpL214C", "upgDmgM214C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [8, 15, 2, 1, 3, 3],
+                [9, 19, 1, 3, 3, 3],
+                [14, 22, 2, 3, 2, 7],
+                [18, 26, 3, 3, 5, 6],
+                [22, 34, 3, 4, 6, 8],
+                [23, 47, 5, 5, 8, 9],
+                [37, 50, 5, 6, 11, 11],
+                [55, 55, 7, 7, 15, 11],
+                [76, 60, 11, 8, 17, 17],
+                [86, 86, 12, 12, 18, 23],
+                [107, 107, 15, 12, 24, 29],
+                [135, 135, 16, 20, 30, 35],
+                [168, 168, 23, 23, 42, 42],
+                [211, 211, 28, 28, 51, 51],
+                [263, 263, 35, 35, 64, 64],
+                [330, 330, 44, 44, 81, 81],
+                [414, 414, 55, 55, 101, 101],
+                [225, 225, 32, 28, 59, 51],
+                [242, 207, 32, 28, 59, 51],
+                [200, 249, 27, 33, 49, 61]
+            ]
+        },
+        "necroPlasmancer": {
+            "name": "Thutmose",
+            "FactionId": "Necrons",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Rare",
+            "powerMultiplier": 88,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 2,
+                    "DamageProfile": "Plasma"
+                },
+                {
+                    "hits": 2,
+                    "DamageProfile": "Plasma",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 75,
+                "Damage": 36,
+                "FixedArmor": 18,
+                "ProgressionIndex": 6
+            },
+            "traits": ["Hero", "LivingMetal", "Mechanical", "Flying"],
+            "activeAbilities": ["HarbingerOfDestruction"],
+            "passiveAbilities": ["LivingLightning"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [2],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "campaign": {
+                    "campaignType": "Standard",
+                    "campaignId": "campaign1",
+                    "level": 60
+                }
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_necroPlasmancer_01"],
+            "upgrades": [
+                ["upgHpC014", "upgHpC009", "upgDmgC008", "upgDmgC015", "upgArmC005", "upgArmC004"],
+                ["upgHpC014", "upgHpC008", "upgDmgC008", "upgDmgU009", "upgArmC012", "upgArmU002"],
+                ["upgHpC015", "upgHpU007", "upgDmgU008C", "upgDmgU009", "upgArmC012", "upgArmU012"],
+                ["upgHpU014", "upgHpU013", "upgDmgU004", "upgDmgU017C", "upgArmU004C", "upgArmU012"],
+                ["upgHpU014", "upgHpR014", "upgDmgU008C", "upgDmgR004C", "upgArmU002", "upgArmR008C"],
+                ["upgHpR002", "upgHpU010C", "upgDmgR009", "upgDmgU017C", "upgArmU002", "upgArmR007C"],
+                ["upgHpR011", "upgHpR009C", "upgDmgR009", "upgDmgR004C", "upgArmR002C", "upgArmR008C"],
+                ["upgHpE009C", "upgHpE004C", "upgDmgR011C", "upgDmgR004C", "upgArmR002C", "upgArmR006"],
+                ["upgHpL010", "upgHpR012C", "upgDmgE008C", "upgDmgR017C", "upgArmE003C", "upgArmE012C"],
+                ["upgHpE009C", "upgHpE014C", "upgDmgE008C", "upgDmgE007C", "upgArmE008", "upgArmE002C"],
+                ["upgHpE009C", "upgHpE013C", "upgDmgL006C", "upgDmgE007C", "upgArmE008", "upgArmE012C"],
+                ["upgHpL007C", "upgHpL014C", "upgDmgE008C", "upgDmgL017C", "upgArmE003C", "upgArmL002C"],
+                ["upgHpL008C", "upgHpL013C", "upgDmgL006C", "upgDmgL005C", "upgArmL003C", "upgArmL009C"],
+                ["upgHpL007C", "upgHpL013C", "upgDmgL130C", "upgDmgL005C", "upgArmL130C", "upgArmL002C"],
+                ["upgHpL008C", "upgHpL014C", "upgDmgL130C", "upgDmgL017C", "upgArmL130C", "upgArmL009C"],
+                ["upgHpL008C", "upgHpL017C", "upgDmgL130C", "upgDmgL005C", "upgArmL130C", "upgArmL003C"],
+                ["upgHpL007C", "upgHpL214C", "upgDmgL130C", "upgDmgL214C", "upgArmL130C", "upgArmL214C"],
+                ["upgHpL007C", "upgHpL214C", "upgDmgM214C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpM130C", "upgHpL214C", "upgDmgM214C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [10, 10, 5, 5, 3, 3],
+                [12, 12, 3, 7, 1, 3],
+                [9, 19, 9, 6, 2, 5],
+                [19, 19, 7, 10, 5, 4],
+                [18, 28, 10, 13, 4, 7],
+                [29, 29, 14, 14, 5, 9],
+                [31, 42, 15, 20, 9, 9],
+                [46, 46, 22, 22, 13, 9],
+                [63, 50, 30, 24, 14, 14],
+                [72, 72, 35, 35, 15, 18],
+                [89, 89, 46, 39, 19, 24],
+                [112, 112, 49, 58, 25, 29],
+                [140, 140, 68, 68, 34, 34],
+                [176, 176, 84, 84, 42, 42],
+                [219, 219, 105, 105, 53, 53],
+                [276, 276, 132, 132, 66, 66],
+                [344, 344, 166, 166, 82, 82],
+                [187, 187, 96, 83, 48, 42],
+                [202, 173, 97, 83, 48, 42],
+                [167, 208, 80, 100, 40, 50]
+            ]
+        },
+        "necroOverlord": {
+            "name": "Anuphet",
+            "FactionId": "Necrons",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Epic",
+            "powerMultiplier": 70,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 4,
+                    "DamageProfile": "Energy"
+                },
+                {
+                    "hits": 3,
+                    "DamageProfile": "Energy",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 90,
+                "Damage": 25,
+                "FixedArmor": 21,
+                "ProgressionIndex": 9
+            },
+            "traits": ["Hero", "LivingMetal", "Mechanical", "Resilient"],
+            "activeAbilities": ["ResurrectionOrb"],
+            "passiveAbilities": ["MyWillBeDoneOverlord"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [2],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "campaign": {
+                    "campaignType": "Standard",
+                    "campaignId": "campaign1",
+                    "level": 75
+                }
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_necroOverlord_01"],
+            "upgrades": [
+                ["upgHpC014", "upgHpC009", "upgDmgC012", "upgDmgC015", "upgArmC005", "upgArmC004"],
+                ["upgHpC015", "upgHpC008", "upgDmgC005", "upgDmgU010", "upgArmC012", "upgArmU002"],
+                ["upgHpC017", "upgHpU007", "upgDmgU008C", "upgDmgU009", "upgArmC012", "upgArmU012"],
+                ["upgHpU014", "upgHpU013", "upgDmgU004", "upgDmgU017C", "upgArmU004C", "upgArmU012"],
+                ["upgHpU017", "upgHpR014", "upgDmgU008C", "upgDmgR010C", "upgArmU002", "upgArmR008C"],
+                ["upgHpR002", "upgHpU010C", "upgDmgR009", "upgDmgU017C", "upgArmU002", "upgArmR007C"],
+                ["upgHpR011", "upgHpR009C", "upgDmgR005", "upgDmgR004C", "upgArmR002C", "upgArmR008C"],
+                ["upgHpE009C", "upgHpE004C", "upgDmgR011C", "upgDmgR004C", "upgArmR002C", "upgArmR006"],
+                ["upgHpL010", "upgHpR012C", "upgDmgE008C", "upgDmgR017C", "upgArmE003C", "upgArmE012C"],
+                ["upgHpE009C", "upgHpE014C", "upgDmgE008C", "upgDmgE007C", "upgArmE008", "upgArmE002C"],
+                ["upgHpE009C", "upgHpE013C", "upgDmgL006C", "upgDmgE006C", "upgArmE008", "upgArmE012C"],
+                ["upgHpL007C", "upgHpL014C", "upgDmgE008C", "upgDmgL017C", "upgArmE003C", "upgArmL002C"],
+                ["upgHpL008C", "upgHpL013C", "upgDmgL006C", "upgDmgL005C", "upgArmL003C", "upgArmL009C"],
+                ["upgHpL007C", "upgHpL013C", "upgDmgL130C", "upgDmgL005C", "upgArmL130C", "upgArmL002C"],
+                ["upgHpL008C", "upgHpL014C", "upgDmgL130C", "upgDmgL017C", "upgArmL130C", "upgArmL009C"],
+                ["upgHpL008C", "upgHpL013C", "upgDmgL130C", "upgDmgL005C", "upgArmL130C", "upgArmL003C"],
+                ["upgHpL007C", "upgHpL214C", "upgDmgL130C", "upgDmgL214C", "upgArmL130C", "upgArmL214C"],
+                ["upgHpL007C", "upgHpL214C", "upgDmgM214C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpM130C", "upgHpL214C", "upgDmgM214C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 3, 3, 3, 3],
+                [14, 14, 3, 5, 2, 4],
+                [12, 23, 6, 4, 3, 5],
+                [22, 22, 5, 7, 7, 4],
+                [22, 34, 7, 9, 4, 9],
+                [35, 35, 10, 10, 5, 11],
+                [37, 50, 10, 14, 10, 10],
+                [55, 55, 15, 15, 15, 11],
+                [76, 60, 21, 17, 16, 16],
+                [86, 86, 24, 24, 18, 22],
+                [107, 107, 32, 27, 22, 28],
+                [135, 135, 34, 41, 29, 34],
+                [168, 168, 47, 47, 39, 39],
+                [211, 211, 58, 58, 49, 49],
+                [263, 263, 74, 74, 62, 62],
+                [330, 330, 91, 91, 77, 77],
+                [414, 414, 115, 115, 96, 96],
+                [225, 225, 67, 58, 57, 48],
+                [242, 207, 67, 58, 57, 48],
+                [200, 249, 56, 69, 47, 58]
+            ]
+        },
+        "necroChronomancer": {
+            "name": "Thothmek",
+            "FactionId": "Necrons",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Rare",
+            "powerMultiplier": 110,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 1,
+                    "DamageProfile": "Physical"
+                },
+                {
+                    "hits": 2,
+                    "DamageProfile": "Energy",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 75,
+                "Damage": 36,
+                "FixedArmor": 18,
+                "ProgressionIndex": 6
+            },
+            "traits": ["Hero", "LivingMetal", "Mechanical", "Flying", "SuppressiveFire"],
+            "activeAbilities": ["Chronometron"],
+            "passiveAbilities": ["TimesplinterMantle"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Block"],
+            "itemSlotsRelic": [2],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "1779379200000",
+            "unlockQuestIds": ["hero_necroChronomancer_01"],
+            "upgrades": [
+                ["upgHpC009", "upgHpC008", "upgDmgC010", "upgDmgC015", "upgArmC005", "upgArmC012"],
+                ["upgHpC017", "upgHpC009", "upgDmgU010", "upgDmgU017C", "upgArmC012", "upgArmC011"],
+                ["upgHpU017", "upgHpU010C", "upgDmgC007", "upgDmgC009", "upgArmU006", "upgArmU002"],
+                ["upgHpU010C", "upgHpU014", "upgDmgU010", "upgDmgU012", "upgArmU002", "upgArmU004C"],
+                ["upgHpU017", "upgHpR012C", "upgDmgU007C", "upgDmgU004", "upgArmR006", "upgArmU014"],
+                ["upgHpR017C", "upgHpU007", "upgDmgR009", "upgDmgR011C", "upgArmU004C", "upgArmR010"],
+                ["upgHpR011", "upgHpR014", "upgDmgR008C", "upgDmgR005", "upgArmR002C", "upgArmR008C"],
+                ["upgHpE009C", "upgHpR009C", "upgDmgR005", "upgDmgE008C", "upgArmR030", "upgArmR014C"],
+                ["upgHpR002", "upgHpE004C", "upgDmgE030C", "upgDmgR017C", "upgArmE030C", "upgArmE008"],
+                ["upgHpE009C", "upgHpE017", "upgDmgE030C", "upgDmgE004", "upgArmE030C", "upgArmE003C"],
+                ["upgHpL010", "upgHpE014C", "upgDmgL030C", "upgDmgE008C", "upgArmE030C", "upgArmE012C"],
+                ["upgHpE009C", "upgHpL013C", "upgDmgE030C", "upgDmgL017C", "upgArmL203", "upgArmL003C"],
+                ["upgHpL008C", "upgHpL005C", "upgDmgL003", "upgDmgL006C", "upgArmL030C", "upgArmL008C"],
+                ["upgHpL007C", "upgHpL014C", "upgDmgL030C", "upgDmgL017C", "upgArmL030C", "upgArmL009C"],
+                ["upgHpL008C", "upgHpL005C", "upgDmgL130C", "upgDmgL012C", "upgArmL130C", "upgArmL008C"],
+                ["upgHpL007C", "upgHpL017C", "upgDmgL130C", "upgDmgL005C", "upgArmL130C", "upgArmL003C"],
+                ["upgHpL007C", "upgHpL214C", "upgDmgL130C", "upgDmgL214C", "upgArmL130C", "upgArmL214C"],
+                ["upgHpL007C", "upgHpL214C", "upgDmgM214C", "upgDmgL214C", "upgArmM213C", "upgArmL214C"],
+                ["upgHpM130C", "upgHpL214C", "upgDmgM214C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [10, 10, 5, 5, 3, 3],
+                [12, 12, 4, 6, 2, 2],
+                [11, 17, 8, 8, 4, 4],
+                [22, 15, 8, 8, 3, 5],
+                [16, 31, 14, 9, 7, 4],
+                [39, 19, 12, 16, 7, 7],
+                [37, 37, 20, 15, 9, 9],
+                [50, 40, 16, 27, 9, 13],
+                [43, 71, 31, 24, 15, 12],
+                [79, 64, 38, 31, 17, 17],
+                [90, 90, 47, 39, 22, 22],
+                [101, 122, 49, 58, 24, 29],
+                [140, 140, 61, 74, 34, 34],
+                [176, 176, 84, 84, 42, 42],
+                [219, 219, 106, 106, 53, 53],
+                [276, 276, 132, 132, 66, 66],
+                [344, 344, 165, 165, 82, 82],
+                [187, 187, 97, 83, 48, 42],
+                [202, 173, 97, 83, 48, 42],
+                [167, 208, 80, 100, 40, 50]
+            ]
+        },
+        "necroReanimator": {
+            "name": "Reanimator",
+            "FactionId": "Necrons",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Common",
+            "stats": {
+                "Health": 0,
+                "Damage": 0,
+                "FixedArmor": 0,
+                "ProgressionIndex": 0
+            },
+            "traits": ["MachineOfWar"],
+            "activeAbilities": ["ReanimationBeam", "NanoscarabRepairProtocols"],
+            "mythicAbilities": ["GuardianConstruct"],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "timestampIfHeroUnlocked": 1781942400000,
+                "timestampIfHeroNotUnlocked": 1784966400000
+            },
+            "releaseStatus": "1781280000000",
+            "unlockQuestIds": ["hero_necroReanimator_01"],
+            "upgrades": null,
+            "upgradesStatIncrease": null
+        },
+        "astraPrimarisPsy": {
+            "name": "Sibyll",
+            "FactionId": "AstraMilitarum",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Common",
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 1,
+                    "DamageProfile": "Psychic"
+                },
+                {
+                    "hits": 1,
+                    "DamageProfile": "Psychic",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 55,
+                "Damage": 30,
+                "FixedArmor": 20,
+                "ProgressionIndex": 0
+            },
+            "traits": ["Hero", "Psyker"],
+            "activeAbilities": ["PsychicMaelstrom"],
+            "passiveAbilities": ["Nightshroud"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [1],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "campaign": {
+                    "campaignType": "Standard",
+                    "campaignId": "campaign2",
+                    "level": 30
+                }
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_astraPrimarisPsy_01"],
+            "upgrades": [
+                ["upgHpC004", "upgHpC007", "upgDmgC010", "upgDmgC011", "upgArmC006", "upgArmC001"],
+                ["upgHpC016", "upgHpC003", "upgDmgC007", "upgDmgU010", "upgArmC006", "upgArmU013"],
+                ["upgHpC015", "upgHpU002", "upgDmgU007C", "upgDmgU010", "upgArmC013", "upgArmU002"],
+                ["upgHpU016", "upgHpU017", "upgDmgU011", "upgDmgU015C", "upgArmU003C", "upgArmU001"],
+                ["upgHpU015", "upgHpU002", "upgDmgU013C", "upgDmgR008C", "upgArmU008", "upgArmR013C"],
+                ["upgHpR002", "upgHpR004C", "upgDmgR025", "upgDmgU015C", "upgArmU008", "upgArmR013C"],
+                ["upgHpR007", "upgHpR006C", "upgDmgR005", "upgDmgR010C", "upgArmR003C", "upgArmR001C"],
+                ["upgHpE025C", "upgHpR020C", "upgDmgE008C", "upgDmgR010C", "upgArmR025", "upgArmR013C"],
+                ["upgHpR002", "upgHpR017C", "upgDmgE025C", "upgDmgR015C", "upgArmE025C", "upgArmE001C"],
+                ["upgHpE025C", "upgHpE002C", "upgDmgE025C", "upgDmgE004", "upgArmE025C", "upgArmE011C"],
+                ["upgHpE025C", "upgHpE012", "upgDmgL025C", "upgDmgE006C", "upgArmL025C", "upgArmE001C"],
+                ["upgHpL025C", "upgHpL002C", "upgDmgE025C", "upgDmgL015C", "upgArmE025C", "upgArmL011C"],
+                ["upgHpL125C", "upgHpL011C", "upgDmgL025C", "upgDmgL005C", "upgArmL025C", "upgArmL010C"],
+                ["upgHpL025C", "upgHpL001C", "upgDmgL125C", "upgDmgL005C", "upgArmL125C", "upgArmL011C"],
+                ["upgHpL125C", "upgHpL002C", "upgDmgL125C", "upgDmgL015C", "upgArmL125C", "upgArmL010C"],
+                ["upgHpL125C", "upgHpL011C", "upgDmgL125C", "upgDmgL005C", "upgArmL125C", "upgArmL002C"],
+                ["upgHpL125C", "upgHpL212C", "upgDmgL125C", "upgDmgL212C", "upgArmL125C", "upgArmL212C"],
+                ["upgHpL125C", "upgHpL212C", "upgDmgM211C", "upgDmgL212C", "upgArmM214C", "upgArmL212C"],
+                ["upgHpM125C", "upgHpL212C", "upgDmgM211C", "upgDmgL212C", "upgArmM213C", "upgArmL212C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [7, 7, 4, 4, 3, 3],
+                [9, 9, 3, 6, 2, 3],
+                [7, 14, 7, 5, 3, 5],
+                [14, 14, 6, 9, 6, 4],
+                [17, 17, 8, 10, 4, 9],
+                [18, 24, 12, 12, 5, 10],
+                [23, 30, 12, 17, 10, 10],
+                [37, 30, 20, 16, 10, 14],
+                [36, 48, 26, 20, 15, 15],
+                [52, 52, 32, 25, 19, 19],
+                [73, 59, 39, 32, 26, 22],
+                [82, 82, 41, 49, 27, 33],
+                [103, 103, 56, 56, 37, 37],
+                [129, 129, 71, 71, 47, 47],
+                [161, 161, 87, 87, 59, 59],
+                [202, 202, 110, 110, 73, 73],
+                [252, 252, 138, 138, 92, 92],
+                [138, 138, 81, 69, 54, 46],
+                [148, 126, 81, 69, 54, 46],
+                [122, 152, 67, 83, 44, 56]
+            ]
+        },
+        "astraYarrick": {
+            "name": "Yarrick",
+            "FactionId": "AstraMilitarum",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Rare",
+            "powerMultiplier": 99,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 3,
+                    "DamageProfile": "Power"
+                },
+                {
+                    "hits": 2,
+                    "DamageProfile": "Bolter",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 75,
+                "Damage": 30,
+                "FixedArmor": 17,
+                "ProgressionIndex": 6
+            },
+            "traits": ["Hero", "Resilient"],
+            "activeAbilities": ["SendInTheNextWave"],
+            "passiveAbilities": ["SummaryExecution"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Block"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_astraYarrick_01"],
+            "upgrades": [
+                ["upgHpC005", "upgHpC002", "upgDmgC013", "upgDmgC011", "upgArmC011", "upgArmC001"],
+                ["upgHpC015", "upgHpC003", "upgDmgC001", "upgDmgU004", "upgArmC012", "upgArmU002"],
+                ["upgHpC004", "upgHpU002", "upgDmgU013C", "upgDmgR005", "upgArmC013", "upgArmU013"],
+                ["upgHpU006", "upgHpU017", "upgDmgU012", "upgDmgU015C", "upgArmU003C", "upgArmU001"],
+                ["upgHpU015", "upgHpU002", "upgDmgU001C", "upgDmgR008C", "upgArmU005", "upgArmR013C"],
+                ["upgHpR019", "upgHpR004C", "upgDmgR025", "upgDmgU015C", "upgArmU005", "upgArmR003C"],
+                ["upgHpR007", "upgHpR017C", "upgDmgR006", "upgDmgR012C", "upgArmR012C", "upgArmR001C"],
+                ["upgHpE025C", "upgHpR020C", "upgDmgE008C", "upgDmgR008C", "upgArmR025", "upgArmR013C"],
+                ["upgHpR019", "upgHpR004C", "upgDmgE025C", "upgDmgR015C", "upgArmE025C", "upgArmE001C"],
+                ["upgHpE025C", "upgHpE002C", "upgDmgE025C", "upgDmgE004", "upgArmE025C", "upgArmE011C"],
+                ["upgHpE025C", "upgHpE012", "upgDmgL025C", "upgDmgE009C", "upgArmL025C", "upgArmE001C"],
+                ["upgHpL025C", "upgHpL002C", "upgDmgE025C", "upgDmgL015C", "upgArmE025C", "upgArmL011C"],
+                ["upgHpL125C", "upgHpL001C", "upgDmgL025C", "upgDmgL008C", "upgArmL025C", "upgArmL010C"],
+                ["upgHpL025C", "upgHpL001C", "upgDmgL125C", "upgDmgL008C", "upgArmL125C", "upgArmL011C"],
+                ["upgHpL125C", "upgHpL002C", "upgDmgL125C", "upgDmgL015C", "upgArmL125C", "upgArmL010C"],
+                ["upgHpL125C", "upgHpL017C", "upgDmgL125C", "upgDmgL005C", "upgArmL125C", "upgArmL006C"],
+                ["upgHpL125C", "upgHpL213C", "upgDmgL125C", "upgDmgL213C", "upgArmL125C", "upgArmL213C"],
+                ["upgHpL125C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpM125C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [10, 10, 4, 4, 2, 2],
+                [12, 12, 3, 6, 2, 4],
+                [9, 19, 6, 6, 2, 4],
+                [19, 19, 6, 9, 5, 4],
+                [23, 23, 8, 10, 3, 7],
+                [25, 33, 12, 12, 4, 9],
+                [31, 42, 12, 17, 9, 9],
+                [51, 40, 20, 16, 9, 11],
+                [49, 65, 26, 20, 13, 13],
+                [72, 72, 32, 25, 16, 16],
+                [99, 79, 39, 32, 22, 18],
+                [112, 112, 41, 49, 23, 28],
+                [140, 140, 56, 56, 32, 32],
+                [176, 176, 71, 71, 40, 40],
+                [219, 219, 87, 87, 50, 50],
+                [276, 276, 110, 110, 62, 62],
+                [344, 344, 138, 138, 78, 78],
+                [187, 187, 81, 69, 46, 39],
+                [202, 173, 81, 69, 46, 39],
+                [167, 208, 67, 83, 38, 47]
+            ]
+        },
+        "astraBullgryn": {
+            "name": "Kut",
+            "FactionId": "AstraMilitarum",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Uncommon",
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 4,
+                    "DamageProfile": "Physical"
+                }
+            ],
+            "stats": {
+                "Health": 95,
+                "Damage": 30,
+                "FixedArmor": 35,
+                "ProgressionIndex": 3
+            },
+            "traits": ["Hero", "BigTarget"],
+            "activeAbilities": ["FragBomb"],
+            "passiveAbilities": ["AvalancheOfMuscle"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Defensive"],
+            "itemSlotsRelic": [1],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "campaign": {
+                    "campaignType": "Standard",
+                    "campaignId": "campaign2",
+                    "level": 15
+                }
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_astraBullgryn_01"],
+            "upgrades": [
+                ["upgHpC004", "upgHpC001", "upgDmgC012", "upgDmgC011", "upgArmC011", "upgArmC001"],
+                ["upgHpC004", "upgHpC003", "upgDmgC002", "upgDmgU014", "upgArmC011", "upgArmU008"],
+                ["upgHpC013", "upgHpU002", "upgDmgU002C", "upgDmgU014", "upgArmC006", "upgArmU008"],
+                ["upgHpU003", "upgHpU001", "upgDmgU003", "upgDmgU015C", "upgArmU003C", "upgArmU001"],
+                ["upgHpU008", "upgHpU002", "upgDmgU002C", "upgDmgR008C", "upgArmU006", "upgArmR007C"],
+                ["upgHpR019", "upgHpR003C", "upgDmgR025", "upgDmgU015C", "upgArmU006", "upgArmR007C"],
+                ["upgHpR007", "upgHpR003C", "upgDmgR003", "upgDmgR012C", "upgArmR003C", "upgArmR001C"],
+                ["upgHpE025C", "upgHpR020C", "upgDmgL002C", "upgDmgR012C", "upgArmR025", "upgArmR007C"],
+                ["upgHpR019", "upgHpR004C", "upgDmgE025C", "upgDmgR015C", "upgArmE025C", "upgArmE001C"],
+                ["upgHpE025C", "upgHpE002C", "upgDmgE025C", "upgDmgE003", "upgArmE025C", "upgArmE002C"],
+                ["upgHpE025C", "upgHpE012", "upgDmgL025C", "upgDmgE009C", "upgArmL025C", "upgArmE001C"],
+                ["upgHpL025C", "upgHpL002C", "upgDmgE025C", "upgDmgL015C", "upgArmE025C", "upgArmL002C"],
+                ["upgHpL125C", "upgHpL001C", "upgDmgL025C", "upgDmgL002C", "upgArmL025C", "upgArmL010C"],
+                ["upgHpL025C", "upgHpL001C", "upgDmgL125C", "upgDmgL008C", "upgArmL125C", "upgArmL002C"],
+                ["upgHpL125C", "upgHpL002C", "upgDmgL125C", "upgDmgL015C", "upgArmL125C", "upgArmL010C"],
+                ["upgHpL125C", "upgHpL017C", "upgDmgL125C", "upgDmgL002C", "upgArmL125C", "upgArmL002C"],
+                ["upgHpL125C", "upgHpL211C", "upgDmgL125C", "upgDmgL211C", "upgArmL125C", "upgArmL211C"],
+                ["upgHpL125C", "upgHpL211C", "upgDmgM212C", "upgDmgL211C", "upgArmM214C", "upgArmL211C"],
+                ["upgHpM125C", "upgHpL211C", "upgDmgM212C", "upgDmgL211C", "upgArmM214C", "upgArmL211C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 4, 4, 5, 5],
+                [15, 15, 3, 6, 3, 7],
+                [12, 25, 7, 5, 5, 9],
+                [24, 24, 6, 9, 10, 7],
+                [29, 29, 8, 10, 7, 15],
+                [32, 42, 12, 12, 9, 18],
+                [39, 53, 12, 17, 17, 17],
+                [64, 52, 22, 14, 18, 24],
+                [62, 82, 26, 20, 27, 27],
+                [91, 91, 32, 25, 33, 33],
+                [126, 100, 39, 32, 46, 38],
+                [142, 142, 41, 49, 47, 57],
+                [177, 177, 56, 56, 66, 66],
+                [223, 223, 71, 71, 82, 82],
+                [278, 278, 87, 87, 102, 102],
+                [349, 349, 110, 110, 129, 129],
+                [436, 436, 138, 138, 160, 160],
+                [237, 237, 81, 69, 94, 81],
+                [256, 219, 81, 69, 94, 81],
+                [211, 263, 67, 83, 78, 97]
+            ]
+        },
+        "astraOrdnance": {
+            "name": "Thaddeus",
+            "FactionId": "AstraMilitarum",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Rare",
+            "powerMultiplier": 110,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 1,
+                    "DamageProfile": "Las"
+                },
+                {
+                    "hits": 3,
+                    "DamageProfile": "Blast",
+                    "Range": 3
+                }
+            ],
+            "stats": {
+                "Health": 65,
+                "Damage": 38,
+                "FixedArmor": 15,
+                "ProgressionIndex": 6
+            },
+            "traits": ["Hero", "SuppressiveFire", "IndirectFire"],
+            "activeAbilities": ["BasiliskBarrage"],
+            "passiveAbilities": ["SpotterReworked"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [1],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "campaign": {
+                    "campaignType": "Standard",
+                    "campaignId": "campaign2",
+                    "level": 45
+                }
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_astraOrdnance_01"],
+            "upgrades": [
+                ["upgHpC015", "upgHpC001", "upgDmgC013", "upgDmgC011", "upgArmC006", "upgArmC001"],
+                ["upgHpC005", "upgHpC003", "upgDmgC005", "upgDmgU012", "upgArmC006", "upgArmU002"],
+                ["upgHpC004", "upgHpU002", "upgDmgU013C", "upgDmgU011", "upgArmC013", "upgArmU013"],
+                ["upgHpU015", "upgHpU001", "upgDmgU004", "upgDmgU015C", "upgArmU003C", "upgArmU001"],
+                ["upgHpU003", "upgHpU002", "upgDmgU013C", "upgDmgR011C", "upgArmU008", "upgArmR013C"],
+                ["upgHpR002", "upgHpR017C", "upgDmgR025", "upgDmgU015C", "upgArmU008", "upgArmR013C"],
+                ["upgHpR007", "upgHpR003C", "upgDmgR005", "upgDmgR008C", "upgArmR012C", "upgArmR001C"],
+                ["upgHpE025C", "upgHpR020C", "upgDmgE008C", "upgDmgR008C", "upgArmR025", "upgArmR013C"],
+                ["upgHpR002", "upgHpR017C", "upgDmgE025C", "upgDmgR015C", "upgArmE025C", "upgArmE001C"],
+                ["upgHpE025C", "upgHpE002C", "upgDmgE025C", "upgDmgE004", "upgArmE025C", "upgArmE011C"],
+                ["upgHpE025C", "upgHpE012", "upgDmgL025C", "upgDmgE008C", "upgArmL025C", "upgArmE001C"],
+                ["upgHpL025C", "upgHpL002C", "upgDmgE025C", "upgDmgL015C", "upgArmE025C", "upgArmL011C"],
+                ["upgHpL125C", "upgHpL009C", "upgDmgL025C", "upgDmgL006C", "upgArmL025C", "upgArmL010C"],
+                ["upgHpL025C", "upgHpL009C", "upgDmgL125C", "upgDmgL006C", "upgArmL125C", "upgArmL011C"],
+                ["upgHpL125C", "upgHpL002C", "upgDmgL125C", "upgDmgL015C", "upgArmL125C", "upgArmL010C"],
+                ["upgHpL125C", "upgHpL017C", "upgDmgL125C", "upgDmgL005C", "upgArmL125C", "upgArmL006C"],
+                ["upgHpL125C", "upgHpL214C", "upgDmgL125C", "upgDmgL214C", "upgArmL125C", "upgArmL214C"],
+                ["upgHpL125C", "upgHpL214C", "upgDmgM213C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpM125C", "upgHpL214C", "upgDmgM213C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [8, 8, 5, 5, 2, 2],
+                [11, 11, 4, 8, 2, 3],
+                [8, 17, 9, 6, 2, 3],
+                [16, 16, 7, 11, 5, 3],
+                [20, 20, 10, 14, 3, 6],
+                [21, 29, 15, 15, 4, 8],
+                [27, 36, 15, 21, 7, 7],
+                [44, 35, 26, 20, 8, 11],
+                [42, 57, 32, 26, 11, 11],
+                [62, 62, 41, 32, 15, 15],
+                [86, 69, 49, 41, 19, 16],
+                [97, 97, 52, 62, 20, 25],
+                [122, 122, 71, 71, 28, 28],
+                [152, 152, 89, 89, 35, 35],
+                [190, 190, 111, 111, 44, 44],
+                [239, 239, 140, 140, 55, 55],
+                [298, 298, 174, 174, 69, 69],
+                [163, 163, 102, 88, 40, 34],
+                [174, 150, 102, 88, 40, 35],
+                [144, 181, 84, 106, 33, 42]
+            ]
+        },
+        "astraCreed": {
+            "name": "Creed",
+            "FactionId": "AstraMilitarum",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Legendary",
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 2,
+                    "DamageProfile": "Las"
+                }
+            ],
+            "stats": {
+                "Health": 90,
+                "Damage": 38,
+                "FixedArmor": 21,
+                "ProgressionIndex": 12
+            },
+            "traits": ["Hero"],
+            "activeAbilities": ["SupremeCommander"],
+            "passiveAbilities": ["SwornProtector"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Block"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "campaign": {
+                    "campaignType": "Standard",
+                    "campaignId": "campaign2",
+                    "level": 75
+                }
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_astraCreed_01"],
+            "upgrades": [
+                ["upgHpC004", "upgHpC017", "upgDmgC013", "upgDmgC011", "upgArmC011", "upgArmC001"],
+                ["upgHpC005", "upgHpC003", "upgDmgC005", "upgDmgU012", "upgArmC013", "upgArmU013"],
+                ["upgHpC015", "upgHpU002", "upgDmgU007C", "upgDmgU011", "upgArmC011", "upgArmU002"],
+                ["upgHpU006", "upgHpU017", "upgDmgU004", "upgDmgU015C", "upgArmU003C", "upgArmU001"],
+                ["upgHpU003", "upgHpU002", "upgDmgU007C", "upgDmgR008C", "upgArmU005", "upgArmR013C"],
+                ["upgHpR005", "upgHpR017C", "upgDmgR025", "upgDmgU015C", "upgArmU005", "upgArmR003C"],
+                ["upgHpR007", "upgHpR012C", "upgDmgR005", "upgDmgR010C", "upgArmR012C", "upgArmR001C"],
+                ["upgHpE025C", "upgHpR020C", "upgDmgE008C", "upgDmgR010C", "upgArmR025", "upgArmR013C"],
+                ["upgHpR019", "upgHpE001C", "upgDmgE025C", "upgDmgR015C", "upgArmE025C", "upgArmE001C"],
+                ["upgHpE025C", "upgHpE002C", "upgDmgE025C", "upgDmgE004", "upgArmE025C", "upgArmE011C"],
+                ["upgHpE025C", "upgHpE012", "upgDmgL025C", "upgDmgE006C", "upgArmL025C", "upgArmE001C"],
+                ["upgHpL025C", "upgHpL002C", "upgDmgE025C", "upgDmgL015C", "upgArmE025C", "upgArmL011C"],
+                ["upgHpL125C", "upgHpL009C", "upgDmgL025C", "upgDmgL005C", "upgArmL025C", "upgArmL010C"],
+                ["upgHpL025C", "upgHpL009C", "upgDmgL125C", "upgDmgL005C", "upgArmL125C", "upgArmL011C"],
+                ["upgHpL125C", "upgHpL002C", "upgDmgL125C", "upgDmgL015C", "upgArmL125C", "upgArmL010C"],
+                ["upgHpL125C", "upgHpL017C", "upgDmgL125C", "upgDmgL005C", "upgArmL125C", "upgArmL006C"],
+                ["upgHpL125C", "upgHpL214C", "upgDmgL125C", "upgDmgL214C", "upgArmL125C", "upgArmL214C"],
+                ["upgHpL125C", "upgHpL214C", "upgDmgM213C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpM125C", "upgHpL214C", "upgDmgM213C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 5, 5, 3, 3],
+                [14, 14, 4, 8, 2, 4],
+                [12, 23, 9, 6, 3, 5],
+                [22, 22, 7, 11, 7, 4],
+                [28, 28, 10, 14, 4, 9],
+                [30, 40, 15, 15, 5, 11],
+                [37, 50, 15, 21, 10, 10],
+                [61, 48, 26, 20, 11, 15],
+                [51, 86, 32, 26, 16, 16],
+                [86, 86, 41, 32, 20, 20],
+                [119, 95, 49, 41, 27, 23],
+                [135, 135, 52, 62, 29, 34],
+                [168, 168, 71, 71, 39, 39],
+                [211, 211, 89, 89, 49, 49],
+                [263, 263, 111, 111, 62, 62],
+                [330, 330, 140, 140, 77, 77],
+                [414, 414, 174, 174, 96, 96],
+                [225, 225, 102, 88, 57, 48],
+                [242, 207, 102, 88, 57, 48],
+                [200, 249, 84, 106, 47, 58]
+            ]
+        },
+        "astraDreir": {
+            "name": "Dreir",
+            "FactionId": "AstraMilitarum",
+            "Subfaction": "DeathKorpsKrieg",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Epic",
+            "powerMultiplier": 93,
+            "Movement": 4,
+            "weapons": [
+                {
+                    "hits": 3,
+                    "DamageProfile": "Power"
+                }
+            ],
+            "stats": {
+                "Health": 100,
+                "Damage": 28,
+                "FixedArmor": 17,
+                "ProgressionIndex": 9
+            },
+            "traits": ["Hero", "Resilient", "Unstoppable"],
+            "activeAbilities": ["LeadingTheCharge"],
+            "passiveAbilities": ["ToughToKill"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Block"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "timestampIfHeroUnlocked": 1758412800000,
+                "timestampIfHeroNotUnlocked": 1761382800000
+            },
+            "releaseStatus": "1758240000000",
+            "unlockQuestIds": ["hero_astraDreir_01"],
+            "upgrades": [
+                ["upgHpC015", "upgHpC004", "upgDmgC010", "upgDmgC011", "upgArmC003", "upgArmC001"],
+                ["upgHpC001", "upgHpC002", "upgDmgU010", "upgDmgU015C", "upgArmC001", "upgArmC013"],
+                ["upgHpU001", "upgHpU004C", "upgDmgC013", "upgDmgC009", "upgArmU002", "upgArmU001"],
+                ["upgHpU018C", "upgHpU017", "upgDmgU010", "upgDmgU012", "upgArmU001", "upgArmU012C"],
+                ["upgHpU001", "upgHpR017C", "upgDmgU018C", "upgDmgU011", "upgArmR006", "upgArmU009"],
+                ["upgHpR003C", "upgHpU006", "upgDmgR025", "upgDmgR011C", "upgArmU012C", "upgArmR005"],
+                ["upgHpR007", "upgHpR005", "upgDmgR13C", "upgDmgR005", "upgArmR008C", "upgArmR001C"],
+                ["upgHpE025C", "upgHpR004C", "upgDmgR003", "upgDmgE008C", "upgArmR025", "upgArmR012C"],
+                ["upgHpR019", "upgHpE001C", "upgDmgE025C", "upgDmgR015C", "upgArmE025C", "upgArmE010"],
+                ["upgHpE025C", "upgHpE015", "upgDmgE025C", "upgDmgE011", "upgArmE025C", "upgArmE012C"],
+                ["upgHpL105", "upgHpE002C", "upgDmgL025C", "upgDmgE008C", "upgArmE025C", "upgArmE001C"],
+                ["upgHpE025C", "upgHpL017C", "upgDmgE025C", "upgDmgL015C", "upgArmL203", "upgArmL008C"],
+                ["upgHpL025C", "upgHpL001C", "upgDmgL003", "upgDmgL006C", "upgArmL025C", "upgArmL010C"],
+                ["upgHpL125C", "upgHpL002C", "upgDmgL025C", "upgDmgL015C", "upgArmL025C", "upgArmL006C"],
+                ["upgHpL025C", "upgHpL009C", "upgDmgL125C", "upgDmgL008C", "upgArmL125C", "upgArmL010C"],
+                ["upgHpL125C", "upgHpL017C", "upgDmgL125C", "upgDmgL005C", "upgArmL125C", "upgArmL008C"],
+                ["upgHpL125C", "upgHpL211C", "upgDmgL125C", "upgDmgL211C", "upgArmL125C", "upgArmL211C"],
+                ["upgHpL125C", "upgHpL211C", "upgDmgM213C", "upgDmgL211C", "upgArmM214C", "upgArmL211C"],
+                ["upgHpM125C", "upgHpL211C", "upgDmgM213C", "upgDmgL211C", "upgArmM214C", "upgArmL211C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [13, 13, 4, 4, 2, 2],
+                [16, 16, 3, 5, 3, 3],
+                [15, 23, 6, 6, 3, 3],
+                [30, 20, 7, 7, 4, 5],
+                [21, 41, 10, 6, 6, 4],
+                [51, 26, 9, 13, 7, 7],
+                [49, 49, 15, 12, 8, 8],
+                [67, 54, 13, 21, 9, 12],
+                [57, 95, 24, 19, 14, 11],
+                [106, 84, 29, 24, 17, 17],
+                [120, 120, 37, 30, 20, 20],
+                [135, 162, 38, 45, 23, 27],
+                [187, 187, 48, 57, 32, 32],
+                [234, 234, 66, 66, 40, 40],
+                [293, 293, 82, 82, 50, 50],
+                [367, 367, 103, 103, 62, 62],
+                [459, 459, 128, 128, 78, 78],
+                [250, 250, 75, 65, 46, 39],
+                [269, 231, 75, 65, 46, 39],
+                [222, 278, 62, 78, 38, 47]
+            ]
+        },
+        "astraOrdnanceBattery": {
+            "name": "Malleus Rocket Launcher",
+            "FactionId": "AstraMilitarum",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Common",
+            "stats": {
+                "Health": 0,
+                "Damage": 0,
+                "FixedArmor": 0,
+                "ProgressionIndex": 0
+            },
+            "traits": ["MachineOfWar"],
+            "activeAbilities": ["MalleusRocketLauncher", "ForwardSpotter"],
+            "mythicAbilities": ["OnMyPosition"],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "timestampIfHeroUnlocked": 1718438400000,
+                "timestampIfHeroNotUnlocked": 1721462400000
+            },
+            "releaseStatus": "1717747200000",
+            "unlockQuestIds": ["hero_astraOrdnanceBattery_01"],
+            "upgrades": null,
+            "upgradesStatIncrease": null
+        },
+        "blackTerminator": {
+            "name": "Angrax",
+            "FactionId": "BlackLegion",
+            "GrandAllianceId": "Chaos",
+            "BaseRarity": "Common",
+            "powerMultiplier": 99,
+            "Movement": 2,
+            "weapons": [
+                {
+                    "hits": 4,
+                    "DamageProfile": "Power"
+                }
+            ],
+            "stats": {
+                "Health": 110,
+                "Damage": 19,
+                "FixedArmor": 30,
+                "ProgressionIndex": 0
+            },
+            "traits": ["Hero", "LetTheGalaxyBurn", "TeleportStrike", "TerminatorArmour"],
+            "activeAbilities": ["BringerOfDespair"],
+            "passiveAbilities": ["HatefulAssault"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Block"],
+            "itemSlotsRelic": [1],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_blackTerminator_01"],
+            "upgrades": [
+                ["upgHpC014", "upgHpC002", "upgDmgC012", "upgDmgC014", "upgArmC004", "upgArmC007"],
+                ["upgHpC014", "upgHpC010", "upgDmgC009", "upgDmgU010", "upgArmC013", "upgArmU009"],
+                ["upgHpC015", "upgHpU012", "upgDmgU013C", "upgDmgU004", "upgArmC012", "upgArmU002"],
+                ["upgHpU014", "upgHpU009", "upgDmgU012", "upgDmgU016C", "upgArmU003C", "upgArmU007"],
+                ["upgHpU014", "upgHpU012", "upgDmgU013C", "upgDmgR13C", "upgArmU006", "upgArmR007C"],
+                ["upgHpR012C", "upgHpR008", "upgDmgR023", "upgDmgU016C", "upgArmU003C", "upgArmR005"],
+                ["upgHpR023", "upgHpR015C", "upgDmgR011C", "upgDmgR006", "upgArmR012C", "upgArmR004C"],
+                ["upgHpE023C", "upgHpR004C", "upgDmgE008C", "upgDmgR010C", "upgArmR023", "upgArmR007C"],
+                ["upgHpR018", "upgHpE007C", "upgDmgE023C", "upgDmgR016C", "upgArmE023C", "upgArmE005C"],
+                ["upgHpE023C", "upgHpE008C", "upgDmgE023C", "upgDmgE004", "upgArmE023C", "upgArmE006C"],
+                ["upgHpE023C", "upgHpE003", "upgDmgL023C", "upgDmgE006C", "upgArmL023C", "upgArmE005C"],
+                ["upgHpL023C", "upgHpL012C", "upgDmgE023C", "upgDmgL016C", "upgArmE023C", "upgArmL006C"],
+                ["upgHpL123C", "upgHpL009C", "upgDmgL023C", "upgDmgL008C", "upgArmL023C", "upgArmL005C"],
+                ["upgHpL023C", "upgHpL009C", "upgDmgL123C", "upgDmgL008C", "upgArmL123C", "upgArmL006C"],
+                ["upgHpL123C", "upgHpL012C", "upgDmgL123C", "upgDmgL016C", "upgArmL123C", "upgArmL005C"],
+                ["upgHpL123C", "upgHpL017C", "upgDmgL123C", "upgDmgL006C", "upgArmL123C", "upgArmL004C"],
+                ["upgHpL123C", "upgHpL213C", "upgDmgL123C", "upgDmgL213C", "upgArmL123C", "upgArmL213C"],
+                ["upgHpL123C", "upgHpL213C", "upgDmgM212C", "upgDmgL213C", "upgArmM212C", "upgArmL213C"],
+                ["upgHpM123C", "upgHpL213C", "upgDmgM212C", "upgDmgL213C", "upgArmM212C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [14, 14, 3, 3, 4, 4],
+                [17, 17, 2, 3, 3, 6],
+                [15, 29, 4, 3, 4, 8],
+                [27, 27, 4, 6, 9, 6],
+                [34, 34, 5, 6, 6, 12],
+                [49, 37, 8, 8, 12, 12],
+                [45, 61, 10, 8, 15, 15],
+                [74, 60, 13, 10, 15, 20],
+                [63, 104, 16, 13, 23, 23],
+                [105, 105, 20, 16, 29, 29],
+                [146, 116, 25, 20, 38, 32],
+                [165, 165, 26, 31, 41, 49],
+                [205, 205, 36, 36, 56, 56],
+                [258, 258, 44, 44, 71, 71],
+                [322, 322, 56, 56, 87, 87],
+                [403, 403, 70, 70, 110, 110],
+                [506, 506, 87, 87, 138, 138],
+                [275, 275, 51, 43, 81, 69],
+                [296, 253, 51, 44, 81, 69],
+                [244, 305, 42, 53, 67, 83]
+            ]
+        },
+        "blackObliterator": {
+            "name": "Volk",
+            "FactionId": "BlackLegion",
+            "GrandAllianceId": "Chaos",
+            "BaseRarity": "Rare",
+            "powerMultiplier": 96,
+            "Movement": 2,
+            "weapons": [
+                {
+                    "hits": 4,
+                    "DamageProfile": "Power"
+                },
+                {
+                    "hits": 6,
+                    "DamageProfile": "HeavyRound",
+                    "Range": 3
+                }
+            ],
+            "stats": {
+                "Health": 125,
+                "Damage": 9,
+                "FixedArmor": 12,
+                "ProgressionIndex": 6
+            },
+            "traits": ["Hero", "LetTheGalaxyBurn", "BigTarget", "Daemon", "HeavyWeapon", "SuppressiveFire"],
+            "activeAbilities": ["FrenziedFiring"],
+            "passiveAbilities": ["FleshmetalGuns"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_blackObliterator_01"],
+            "upgrades": [
+                ["upgHpC014", "upgHpC002", "upgDmgC001", "upgDmgC014", "upgArmC004", "upgArmC007"],
+                ["upgHpC014", "upgHpC010", "upgDmgC012", "upgDmgU009", "upgArmC004", "upgArmU002"],
+                ["upgHpC006", "upgHpU013", "upgDmgU001C", "upgDmgU009", "upgArmC004", "upgArmU007"],
+                ["upgHpU014", "upgHpU009", "upgDmgU003", "upgDmgU016C", "upgArmU003C", "upgArmU007"],
+                ["upgHpU014", "upgHpU013", "upgDmgU001C", "upgDmgR14C", "upgArmU006", "upgArmR007C"],
+                ["upgHpR012C", "upgHpR008", "upgDmgR023", "upgDmgU016C", "upgArmU006", "upgArmR004C"],
+                ["upgHpR023", "upgHpR004C", "upgDmgR001C", "upgDmgR006", "upgArmR012C", "upgArmR004C"],
+                ["upgHpE023C", "upgHpR004C", "upgDmgL002C", "upgDmgR004C", "upgArmR023", "upgArmR007C"],
+                ["upgHpR018", "upgHpE013C", "upgDmgE023C", "upgDmgR016C", "upgArmE023C", "upgArmE005C"],
+                ["upgHpE023C", "upgHpE008C", "upgDmgE023C", "upgDmgE004", "upgArmE023C", "upgArmE002C"],
+                ["upgHpE023C", "upgHpE012", "upgDmgL023C", "upgDmgE007C", "upgArmL023C", "upgArmE005C"],
+                ["upgHpL023C", "upgHpL012C", "upgDmgE023C", "upgDmgL016C", "upgArmE023C", "upgArmL002C"],
+                ["upgHpL123C", "upgHpL001C", "upgDmgL023C", "upgDmgL007C", "upgArmL023C", "upgArmL005C"],
+                ["upgHpL023C", "upgHpL001C", "upgDmgL123C", "upgDmgL007C", "upgArmL123C", "upgArmL002C"],
+                ["upgHpL123C", "upgHpL012C", "upgDmgL123C", "upgDmgL016C", "upgArmL123C", "upgArmL005C"],
+                ["upgHpL123C", "upgHpL017C", "upgDmgL123C", "upgDmgL009C", "upgArmL123C", "upgArmL004C"],
+                ["upgHpL123C", "upgHpL211C", "upgDmgL123C", "upgDmgL211C", "upgArmL123C", "upgArmL211C"],
+                ["upgHpL123C", "upgHpL211C", "upgDmgM212C", "upgDmgL211C", "upgArmM214C", "upgArmL211C"],
+                ["upgHpM123C", "upgHpL211C", "upgDmgM212C", "upgDmgL211C", "upgArmM214C", "upgArmL211C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [16, 16, 1, 1, 2, 2],
+                [20, 20, 1, 2, 1, 2],
+                [16, 32, 2, 2, 2, 3],
+                [31, 31, 2, 2, 3, 2],
+                [39, 39, 3, 3, 3, 5],
+                [55, 41, 4, 4, 3, 6],
+                [52, 70, 4, 3, 6, 6],
+                [84, 68, 7, 4, 6, 8],
+                [71, 119, 8, 6, 10, 10],
+                [119, 119, 9, 8, 11, 11],
+                [166, 132, 12, 10, 15, 13],
+                [187, 187, 12, 15, 16, 20],
+                [233, 233, 17, 17, 23, 23],
+                [293, 293, 21, 21, 28, 28],
+                [366, 366, 26, 26, 35, 35],
+                [459, 459, 33, 33, 44, 44],
+                [574, 574, 42, 42, 55, 55],
+                [312, 312, 24, 20, 32, 28],
+                [337, 288, 24, 21, 32, 28],
+                [277, 347, 20, 25, 27, 33]
+            ]
+        },
+        "blackPossession": {
+            "name": "Archimatos",
+            "FactionId": "BlackLegion",
+            "GrandAllianceId": "Chaos",
+            "BaseRarity": "Uncommon",
+            "powerMultiplier": 85,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 2,
+                    "DamageProfile": "Psychic"
+                },
+                {
+                    "hits": 1,
+                    "DamageProfile": "Psychic",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 80,
+                "Damage": 16,
+                "FixedArmor": 18,
+                "ProgressionIndex": 3
+            },
+            "traits": ["Hero", "LetTheGalaxyBurn", "Psyker"],
+            "activeAbilities": ["Incursion"],
+            "passiveAbilities": ["Possession"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Crit"],
+            "itemSlotsRelic": [2],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_blackPossession_01"],
+            "upgrades": [
+                ["upgHpC007", "upgHpC006", "upgDmgC010", "upgDmgC014", "upgArmC003", "upgArmC007"],
+                ["upgHpC016", "upgHpC010", "upgDmgC002", "upgDmgU003", "upgArmC013", "upgArmU009"],
+                ["upgHpC016", "upgHpU012", "upgDmgU002C", "upgDmgU010", "upgArmC013", "upgArmU013"],
+                ["upgHpU016", "upgHpU009", "upgDmgU003", "upgDmgU016C", "upgArmU003C", "upgArmU007"],
+                ["upgHpU016", "upgHpU015", "upgDmgU013C", "upgDmgR14C", "upgArmU002", "upgArmR007C"],
+                ["upgHpR006C", "upgHpR008", "upgDmgR023", "upgDmgU016C", "upgArmU002", "upgArmR013C"],
+                ["upgHpR023", "upgHpR015C", "upgDmgR002", "upgDmgR010C", "upgArmR012C", "upgArmR004C"],
+                ["upgHpE023C", "upgHpR015C", "upgDmgE002C", "upgDmgR010C", "upgArmR023", "upgArmR013C"],
+                ["upgHpR002", "upgHpE007C", "upgDmgE023C", "upgDmgR016C", "upgArmE023C", "upgArmE005C"],
+                ["upgHpE023C", "upgHpE008C", "upgDmgE023C", "upgDmgE003", "upgArmE023C", "upgArmE011C"],
+                ["upgHpE023C", "upgHpE012", "upgDmgL023C", "upgDmgL002C", "upgArmL023C", "upgArmE005C"],
+                ["upgHpL023C", "upgHpL012C", "upgDmgE023C", "upgDmgL016C", "upgArmE023C", "upgArmL011C"],
+                ["upgHpL123C", "upgHpL011C", "upgDmgL023C", "upgDmgL002C", "upgArmL023C", "upgArmL005C"],
+                ["upgHpL023C", "upgHpL011C", "upgDmgL123C", "upgDmgL002C", "upgArmL123C", "upgArmL011C"],
+                ["upgHpL123C", "upgHpL012C", "upgDmgL123C", "upgDmgL016C", "upgArmL123C", "upgArmL005C"],
+                ["upgHpL123C", "upgHpL011C", "upgDmgL123C", "upgDmgL002C", "upgArmL123C", "upgArmL004C"],
+                ["upgHpL123C", "upgHpL212C", "upgDmgL123C", "upgDmgL212C", "upgArmL123C", "upgArmL212C"],
+                ["upgHpL123C", "upgHpL212C", "upgDmgM211C", "upgDmgL212C", "upgArmM212C", "upgArmL212C"],
+                ["upgHpM123C", "upgHpL212C", "upgDmgM211C", "upgDmgL212C", "upgArmM212C", "upgArmL212C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [10, 10, 2, 2, 3, 3],
+                [13, 13, 2, 3, 1, 3],
+                [10, 21, 4, 2, 2, 5],
+                [20, 20, 3, 5, 5, 4],
+                [25, 25, 4, 6, 4, 7],
+                [35, 26, 7, 7, 5, 9],
+                [33, 45, 6, 8, 9, 9],
+                [54, 43, 11, 9, 9, 13],
+                [46, 76, 13, 11, 14, 14],
+                [76, 76, 17, 13, 17, 17],
+                [106, 85, 20, 20, 23, 19],
+                [120, 120, 21, 25, 25, 29],
+                [149, 149, 30, 30, 34, 34],
+                [187, 187, 38, 38, 42, 42],
+                [235, 235, 47, 47, 53, 53],
+                [293, 293, 58, 58, 66, 66],
+                [368, 368, 74, 74, 82, 82],
+                [200, 200, 43, 36, 48, 42],
+                [215, 184, 43, 37, 48, 42],
+                [177, 222, 36, 44, 40, 50]
+            ]
+        },
+        "blackHaarken": {
+            "name": "Haarken",
+            "FactionId": "BlackLegion",
+            "GrandAllianceId": "Chaos",
+            "BaseRarity": "Epic",
+            "powerMultiplier": 84,
+            "Movement": 4,
+            "weapons": [
+                {
+                    "hits": 4,
+                    "DamageProfile": "Piercing"
+                }
+            ],
+            "stats": {
+                "Health": 95,
+                "Damage": 11,
+                "FixedArmor": 20,
+                "ProgressionIndex": 9
+            },
+            "traits": ["Hero", "LetTheGalaxyBurn", "Flying", "Terrifying"],
+            "activeAbilities": ["HeraldOfTheApocalypse"],
+            "passiveAbilities": ["HeadClaimer"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_blackHaarken_01"],
+            "upgrades": [
+                ["upgHpC017", "upgHpC002", "upgDmgC012", "upgDmgC014", "upgArmC003", "upgArmC007"],
+                ["upgHpC006", "upgHpC010", "upgDmgC002", "upgDmgU010", "upgArmC013", "upgArmU002"],
+                ["upgHpC015", "upgHpU012", "upgDmgU002C", "upgDmgU003", "upgArmC013", "upgArmU009"],
+                ["upgHpU017", "upgHpU009", "upgDmgU012", "upgDmgU016C", "upgArmU003C", "upgArmU007"],
+                ["upgHpU015", "upgHpU012", "upgDmgU013C", "upgDmgR13C", "upgArmU006", "upgArmR007C"],
+                ["upgHpR017C", "upgHpR008", "upgDmgR023", "upgDmgU016C", "upgArmU003C", "upgArmR005"],
+                ["upgHpR023", "upgHpR015C", "upgDmgR002", "upgDmgR010C", "upgArmR012C", "upgArmR004C"],
+                ["upgHpE023C", "upgHpR004C", "upgDmgE002C", "upgDmgR010C", "upgArmR023", "upgArmR007C"],
+                ["upgHpR018", "upgHpE007C", "upgDmgE023C", "upgDmgR016C", "upgArmE023C", "upgArmE005C"],
+                ["upgHpE023C", "upgHpE008C", "upgDmgE023C", "upgDmgE003", "upgArmE023C", "upgArmE006C"],
+                ["upgHpE023C", "upgHpE012", "upgDmgL023C", "upgDmgL002C", "upgArmL023C", "upgArmE005C"],
+                ["upgHpL023C", "upgHpL012C", "upgDmgE023C", "upgDmgL016C", "upgArmE023C", "upgArmL006C"],
+                ["upgHpL123C", "upgHpL009C", "upgDmgL023C", "upgDmgL008C", "upgArmL023C", "upgArmL005C"],
+                ["upgHpL023C", "upgHpL009C", "upgDmgL123C", "upgDmgL008C", "upgArmL123C", "upgArmL006C"],
+                ["upgHpL123C", "upgHpL012C", "upgDmgL123C", "upgDmgL016C", "upgArmL123C", "upgArmL005C"],
+                ["upgHpL123C", "upgHpL017C", "upgDmgL123C", "upgDmgL009C", "upgArmL123C", "upgArmL004C"],
+                ["upgHpL123C", "upgHpL213C", "upgDmgL123C", "upgDmgL213C", "upgArmL123C", "upgArmL213C"],
+                ["upgHpL123C", "upgHpL213C", "upgDmgM212C", "upgDmgL213C", "upgArmM212C", "upgArmL213C"],
+                ["upgHpM123C", "upgHpL213C", "upgDmgM212C", "upgDmgL213C", "upgArmM212C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 2, 2, 3, 3],
+                [15, 15, 1, 1, 2, 3],
+                [12, 25, 3, 2, 3, 5],
+                [24, 24, 2, 3, 6, 4],
+                [29, 29, 3, 4, 4, 9],
+                [42, 32, 4, 4, 8, 8],
+                [39, 53, 5, 6, 9, 9],
+                [64, 52, 7, 6, 11, 14],
+                [54, 90, 9, 8, 15, 15],
+                [91, 91, 12, 9, 19, 19],
+                [126, 100, 13, 13, 26, 22],
+                [142, 142, 15, 18, 27, 33],
+                [177, 177, 21, 21, 37, 37],
+                [223, 223, 26, 26, 47, 47],
+                [278, 278, 32, 32, 59, 59],
+                [349, 349, 40, 40, 73, 73],
+                [436, 436, 51, 51, 92, 92],
+                [237, 237, 29, 25, 54, 46],
+                [256, 219, 30, 25, 54, 46],
+                [211, 263, 24, 31, 44, 56]
+            ]
+        },
+        "blackAbaddon": {
+            "name": "Abaddon",
+            "FactionId": "BlackLegion",
+            "GrandAllianceId": "Chaos",
+            "BaseRarity": "Legendary",
+            "powerMultiplier": 78,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 5,
+                    "DamageProfile": "Power"
+                },
+                {
+                    "hits": 3,
+                    "DamageProfile": "Bolter",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 100,
+                "Damage": 15,
+                "FixedArmor": 25,
+                "ProgressionIndex": 12
+            },
+            "traits": ["Hero", "LetTheGalaxyBurn", "Resilient", "TerminatorArmour"],
+            "activeAbilities": ["Drachnyen"],
+            "passiveAbilities": ["FirstAmongTraitors"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Block"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_blackAbaddon_01"],
+            "upgrades": [
+                ["upgHpC002", "upgHpC015", "upgDmgC013", "upgDmgC014", "upgArmC013", "upgArmC007"],
+                ["upgHpC002", "upgHpC010", "upgDmgC010", "upgDmgU004", "upgArmC012", "upgArmU002"],
+                ["upgHpC014", "upgHpU012", "upgDmgU013C", "upgDmgU010", "upgArmC004", "upgArmU013"],
+                ["upgHpU014", "upgHpU009", "upgDmgU012", "upgDmgU016C", "upgArmU003C", "upgArmU007"],
+                ["upgHpU014", "upgHpU017", "upgDmgU013C", "upgDmgR14C", "upgArmU002", "upgArmR007C"],
+                ["upgHpR004C", "upgHpR008", "upgDmgR023", "upgDmgU016C", "upgArmU003C", "upgArmR005"],
+                ["upgHpR023", "upgHpR015C", "upgDmgR011C", "upgDmgR005", "upgArmR012C", "upgArmR004C"],
+                ["upgHpE023C", "upgHpR017C", "upgDmgE008C", "upgDmgR010C", "upgArmR023", "upgArmR007C"],
+                ["upgHpR018", "upgHpE007C", "upgDmgE023C", "upgDmgR016C", "upgArmE023C", "upgArmE005C"],
+                ["upgHpE023C", "upgHpE008C", "upgDmgE023C", "upgDmgE004", "upgArmE023C", "upgArmE011C"],
+                ["upgHpE023C", "upgHpE003", "upgDmgL023C", "upgDmgE006C", "upgArmL023C", "upgArmE005C"],
+                ["upgHpL023C", "upgHpL012C", "upgDmgE023C", "upgDmgL016C", "upgArmE023C", "upgArmL006C"],
+                ["upgHpL123C", "upgHpL009C", "upgDmgL023C", "upgDmgL008C", "upgArmL023C", "upgArmL005C"],
+                ["upgHpL023C", "upgHpL009C", "upgDmgL123C", "upgDmgL008C", "upgArmL123C", "upgArmL006C"],
+                ["upgHpL123C", "upgHpL012C", "upgDmgL123C", "upgDmgL016C", "upgArmL123C", "upgArmL005C"],
+                ["upgHpL123C", "upgHpL017C", "upgDmgL123C", "upgDmgL006C", "upgArmL123C", "upgArmL004C"],
+                ["upgHpL123C", "upgHpL211C", "upgDmgL123C", "upgDmgL211C", "upgArmL123C", "upgArmL211C"],
+                ["upgHpL123C", "upgHpL211C", "upgDmgM212C", "upgDmgL211C", "upgArmM212C", "upgArmL211C"],
+                ["upgHpM123C", "upgHpL211C", "upgDmgM212C", "upgDmgL211C", "upgArmM212C", "upgArmL211C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [13, 13, 2, 2, 3, 3],
+                [16, 16, 2, 3, 3, 5],
+                [13, 25, 3, 2, 3, 7],
+                [25, 25, 3, 5, 7, 5],
+                [31, 31, 4, 5, 5, 11],
+                [44, 33, 6, 6, 10, 10],
+                [42, 55, 8, 6, 12, 12],
+                [68, 54, 11, 8, 13, 17],
+                [57, 95, 12, 10, 19, 19],
+                [95, 95, 16, 13, 24, 24],
+                [133, 106, 20, 16, 32, 27],
+                [149, 149, 20, 25, 34, 41],
+                [187, 187, 28, 28, 47, 47],
+                [234, 234, 35, 35, 58, 58],
+                [293, 293, 44, 44, 74, 74],
+                [367, 367, 55, 55, 91, 91],
+                [459, 459, 69, 69, 115, 115],
+                [250, 250, 40, 34, 67, 58],
+                [269, 231, 40, 35, 67, 58],
+                [222, 278, 33, 42, 56, 69]
+            ]
+        },
+        "blackForgefiend": {
+            "name": "Forgefiend",
+            "FactionId": "BlackLegion",
+            "GrandAllianceId": "Chaos",
+            "BaseRarity": "Common",
+            "stats": {
+                "Health": 0,
+                "Damage": 0,
+                "FixedArmor": 0,
+                "ProgressionIndex": 0
+            },
+            "traits": ["MachineOfWar"],
+            "activeAbilities": ["HadesAutocannons", "DaemonicOrdnance"],
+            "mythicAbilities": ["ContemptuousDisregard"],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "timestampIfHeroUnlocked": 1718438400000,
+                "timestampIfHeroNotUnlocked": 1721462400000
+            },
+            "releaseStatus": "1717747200000",
+            "unlockQuestIds": ["hero_blackForgefiend_01"],
+            "upgrades": null,
+            "upgradesStatIncrease": null
+        },
+        "deathTyphus": {
+            "name": "Typhus",
+            "FactionId": "DeathGuard",
+            "GrandAllianceId": "Chaos",
+            "BaseRarity": "Legendary",
+            "powerMultiplier": 75,
+            "Movement": 2,
+            "weapons": [
+                {
+                    "hits": 1,
+                    "DamageProfile": "Power"
+                },
+                {
+                    "hits": 1,
+                    "DamageProfile": "Psychic",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 120,
+                "Damage": 18,
+                "FixedArmor": 25,
+                "ProgressionIndex": 12
+            },
+            "traits": ["Hero", "ContagionsOfNurgle", "Resilient", "Psyker", "TerminatorArmour"],
+            "activeAbilities": ["PlagueWind"],
+            "passiveAbilities": ["DestroyerHive"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Block"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_deathTyphus_01"],
+            "upgrades": [
+                ["upgHpC013", "upgHpC002", "upgDmgC013", "upgDmgC014", "upgArmC004", "upgArmC007"],
+                ["upgHpC015", "upgHpC010", "upgDmgC010", "upgDmgU004", "upgArmC003", "upgArmU009"],
+                ["upgHpC014", "upgHpU012", "upgDmgU013C", "upgDmgU010", "upgArmC013", "upgArmU013"],
+                ["upgHpU014", "upgHpU009", "upgDmgU012", "upgDmgU016C", "upgArmU003C", "upgArmU007"],
+                ["upgHpU014", "upgHpU012", "upgDmgU013C", "upgDmgR14C", "upgArmU002", "upgArmR007C"],
+                ["upgHpR012C", "upgHpR008", "upgDmgR024", "upgDmgU016C", "upgArmU003C", "upgArmR005"],
+                ["upgHpR024", "upgHpR015C", "upgDmgR011C", "upgDmgR005", "upgArmR012C", "upgArmR004C"],
+                ["upgHpE024C", "upgHpR004C", "upgDmgE008C", "upgDmgR010C", "upgArmR009", "upgArmR007C"],
+                ["upgHpR019", "upgHpE007C", "upgDmgE024C", "upgDmgR016C", "upgArmE007C", "upgArmE005C"],
+                ["upgHpE024C", "upgHpE008C", "upgDmgE024C", "upgDmgE004", "upgArmE007C", "upgArmE011C"],
+                ["upgHpE024C", "upgHpE003", "upgDmgL024C", "upgDmgE006C", "upgArmL007C", "upgArmE005C"],
+                ["upgHpL024C", "upgHpL012C", "upgDmgE024C", "upgDmgL016C", "upgArmE007C", "upgArmL006C"],
+                ["upgHpL124C", "upgHpL011C", "upgDmgL024C", "upgDmgL008C", "upgArmL007C", "upgArmL005C"],
+                ["upgHpL024C", "upgHpL011C", "upgDmgL124C", "upgDmgL008C", "upgArmL124C", "upgArmL006C"],
+                ["upgHpL124C", "upgHpL012C", "upgDmgL124C", "upgDmgL016C", "upgArmL124C", "upgArmL005C"],
+                ["upgHpL124C", "upgHpL009C", "upgDmgL124C", "upgDmgL006C", "upgArmL124C", "upgArmL002C"],
+                ["upgHpL124C", "upgHpL212C", "upgDmgL124C", "upgDmgL212C", "upgArmL124C", "upgArmL212C"],
+                ["upgHpL124C", "upgHpL212C", "upgDmgM211C", "upgDmgL212C", "upgArmM214C", "upgArmL212C"],
+                ["upgHpM124C", "upgHpL212C", "upgDmgM211C", "upgDmgL212C", "upgArmM214C", "upgArmL212C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [15, 15, 3, 3, 3, 3],
+                [19, 19, 1, 3, 3, 5],
+                [16, 32, 4, 3, 3, 7],
+                [30, 30, 4, 5, 7, 5],
+                [37, 37, 5, 6, 5, 11],
+                [53, 39, 7, 7, 10, 10],
+                [50, 67, 10, 8, 12, 12],
+                [81, 64, 12, 10, 13, 17],
+                [69, 114, 15, 12, 19, 19],
+                [115, 115, 19, 15, 24, 24],
+                [158, 127, 23, 20, 32, 27],
+                [179, 179, 25, 29, 34, 41],
+                [225, 225, 34, 34, 47, 47],
+                [280, 280, 42, 42, 58, 58],
+                [352, 352, 53, 53, 74, 74],
+                [440, 440, 66, 66, 91, 91],
+                [551, 551, 82, 82, 115, 115],
+                [300, 300, 48, 42, 67, 58],
+                [323, 277, 48, 42, 67, 58],
+                [266, 333, 40, 50, 56, 69]
+            ]
+        },
+        "deathBlightlord": {
+            "name": "Maladus",
+            "FactionId": "DeathGuard",
+            "GrandAllianceId": "Chaos",
+            "BaseRarity": "Uncommon",
+            "powerMultiplier": 80,
+            "Movement": 2,
+            "weapons": [
+                {
+                    "hits": 3,
+                    "DamageProfile": "Power"
+                }
+            ],
+            "stats": {
+                "Health": 120,
+                "Damage": 26,
+                "FixedArmor": 33,
+                "ProgressionIndex": 3
+            },
+            "traits": ["Hero", "ContagionsOfNurgle", "Resilient", "TerminatorArmour"],
+            "activeAbilities": ["FlailSwing"],
+            "passiveAbilities": ["HazeOfCorruption"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Block"],
+            "itemSlotsRelic": [1],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_deathBlightlord_01"],
+            "upgrades": [
+                ["upgHpC014", "upgHpC002", "upgDmgC012", "upgDmgC014", "upgArmC004", "upgArmC007"],
+                ["upgHpC013", "upgHpC010", "upgDmgC009", "upgDmgU014", "upgArmC012", "upgArmU009"],
+                ["upgHpC013", "upgHpU012", "upgDmgU013C", "upgDmgU014", "upgArmC013", "upgArmU009"],
+                ["upgHpU014", "upgHpU009", "upgDmgU012", "upgDmgU016C", "upgArmU003C", "upgArmU007"],
+                ["upgHpU014", "upgHpU012", "upgDmgU013C", "upgDmgR13C", "upgArmU002", "upgArmR007C"],
+                ["upgHpR004C", "upgHpR008", "upgDmgR024", "upgDmgU016C", "upgArmU003C", "upgArmR005"],
+                ["upgHpR024", "upgHpR015C", "upgDmgR011C", "upgDmgR006", "upgArmR012C", "upgArmR004C"],
+                ["upgHpE024C", "upgHpR015C", "upgDmgR011C", "upgDmgR012C", "upgArmR009", "upgArmR007C"],
+                ["upgHpR019", "upgHpE007C", "upgDmgE024C", "upgDmgR016C", "upgArmE007C", "upgArmE005C"],
+                ["upgHpE024C", "upgHpE008C", "upgDmgE024C", "upgDmgE004", "upgArmE007C", "upgArmE006C"],
+                ["upgHpE024C", "upgHpE003", "upgDmgL024C", "upgDmgE009C", "upgArmL007C", "upgArmE005C"],
+                ["upgHpL024C", "upgHpL012C", "upgDmgE024C", "upgDmgL016C", "upgArmE007C", "upgArmL006C"],
+                ["upgHpL124C", "upgHpL001C", "upgDmgL024C", "upgDmgL008C", "upgArmL007C", "upgArmL005C"],
+                ["upgHpL024C", "upgHpL001C", "upgDmgL124C", "upgDmgL008C", "upgArmL124C", "upgArmL006C"],
+                ["upgHpL124C", "upgHpL012C", "upgDmgL124C", "upgDmgL016C", "upgArmL124C", "upgArmL005C"],
+                ["upgHpL124C", "upgHpL009C", "upgDmgL124C", "upgDmgL006C", "upgArmL124C", "upgArmL002C"],
+                ["upgHpL124C", "upgHpL211C", "upgDmgL124C", "upgDmgL211C", "upgArmL124C", "upgArmL211C"],
+                ["upgHpL124C", "upgHpL211C", "upgDmgM212C", "upgDmgL211C", "upgArmM212C", "upgArmL211C"],
+                ["upgHpM124C", "upgHpL211C", "upgDmgM212C", "upgDmgL211C", "upgArmM212C", "upgArmL211C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [15, 15, 4, 4, 4, 4],
+                [19, 19, 2, 5, 4, 7],
+                [16, 32, 6, 4, 4, 9],
+                [30, 30, 5, 8, 10, 6],
+                [37, 37, 7, 9, 7, 14],
+                [53, 39, 10, 10, 13, 13],
+                [50, 67, 14, 11, 16, 16],
+                [81, 64, 16, 16, 17, 22],
+                [69, 114, 22, 18, 25, 25],
+                [115, 115, 27, 22, 32, 32],
+                [158, 127, 34, 28, 43, 35],
+                [179, 179, 35, 43, 45, 54],
+                [225, 225, 49, 49, 62, 62],
+                [280, 280, 61, 61, 77, 77],
+                [352, 352, 76, 76, 97, 97],
+                [440, 440, 95, 95, 121, 121],
+                [551, 551, 119, 119, 151, 151],
+                [300, 300, 70, 60, 89, 76],
+                [323, 277, 70, 60, 89, 76],
+                [266, 333, 58, 72, 73, 92]
+            ]
+        },
+        "deathRotbone": {
+            "name": "Nauseous",
+            "FactionId": "DeathGuard",
+            "GrandAllianceId": "Chaos",
+            "BaseRarity": "Epic",
+            "powerMultiplier": 104,
+            "Movement": 2,
+            "weapons": [
+                {
+                    "hits": 4,
+                    "DamageProfile": "Power"
+                }
+            ],
+            "stats": {
+                "Health": 120,
+                "Damage": 14,
+                "FixedArmor": 27,
+                "ProgressionIndex": 9
+            },
+            "traits": ["Hero", "ContagionsOfNurgle", "Resilient", "Healer"],
+            "activeAbilities": ["RevitalizingMalignancy"],
+            "passiveAbilities": ["TaintedNarthecium"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [2],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_deathRotbone_01"],
+            "upgrades": [
+                ["upgHpC006", "upgHpC007", "upgDmgC013", "upgDmgC014", "upgArmC003", "upgArmC007"],
+                ["upgHpC015", "upgHpC010", "upgDmgC002", "upgDmgU003", "upgArmC013", "upgArmU009"],
+                ["upgHpC013", "upgHpU015", "upgDmgU002C", "upgDmgU014", "upgArmC003", "upgArmU013"],
+                ["upgHpU001", "upgHpU009", "upgDmgU010", "upgDmgU016C", "upgArmU003C", "upgArmU007"],
+                ["upgHpU016", "upgHpU015", "upgDmgU013C", "upgDmgR13C", "upgArmU002", "upgArmR007C"],
+                ["upgHpR003C", "upgHpR008", "upgDmgR024", "upgDmgU016C", "upgArmU003C", "upgArmR005"],
+                ["upgHpR024", "upgHpR006C", "upgDmgR002", "upgDmgR012C", "upgArmR012C", "upgArmR004C"],
+                ["upgHpE024C", "upgHpR006C", "upgDmgE002C", "upgDmgR012C", "upgArmR009", "upgArmR007C"],
+                ["upgHpR019", "upgHpE006C", "upgDmgE024C", "upgDmgR016C", "upgArmE007C", "upgArmE005C"],
+                ["upgHpE024C", "upgHpE008C", "upgDmgE024C", "upgDmgE003", "upgArmE007C", "upgArmE011C"],
+                ["upgHpE024C", "upgHpE012", "upgDmgL024C", "upgDmgE009C", "upgArmL007C", "upgArmE005C"],
+                ["upgHpL024C", "upgHpL012C", "upgDmgE024C", "upgDmgL016C", "upgArmE007C", "upgArmL006C"],
+                ["upgHpL124C", "upgHpL011C", "upgDmgL024C", "upgDmgL002C", "upgArmL007C", "upgArmL005C"],
+                ["upgHpL024C", "upgHpL011C", "upgDmgL124C", "upgDmgL002C", "upgArmL124C", "upgArmL011C"],
+                ["upgHpL124C", "upgHpL012C", "upgDmgL124C", "upgDmgL016C", "upgArmL124C", "upgArmL005C"],
+                ["upgHpL124C", "upgHpL009C", "upgDmgL124C", "upgDmgL005C", "upgArmL124C", "upgArmL002C"],
+                ["upgHpL124C", "upgHpL211C", "upgDmgL124C", "upgDmgL211C", "upgArmL124C", "upgArmL211C"],
+                ["upgHpL124C", "upgHpL211C", "upgDmgM211C", "upgDmgL211C", "upgArmM212C", "upgArmL211C"],
+                ["upgHpM124C", "upgHpL211C", "upgDmgM211C", "upgDmgL211C", "upgArmM212C", "upgArmL211C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [15, 15, 2, 2, 4, 4],
+                [19, 19, 1, 3, 2, 5],
+                [16, 32, 3, 2, 4, 7],
+                [30, 30, 3, 4, 8, 5],
+                [37, 37, 4, 5, 6, 11],
+                [53, 39, 6, 6, 11, 11],
+                [50, 67, 6, 7, 13, 13],
+                [81, 64, 9, 8, 14, 18],
+                [69, 114, 12, 9, 21, 21],
+                [115, 115, 14, 12, 26, 26],
+                [158, 127, 19, 15, 34, 29],
+                [179, 179, 19, 23, 37, 44],
+                [225, 225, 26, 26, 50, 50],
+                [280, 280, 33, 33, 64, 64],
+                [352, 352, 41, 41, 79, 79],
+                [440, 440, 51, 51, 99, 99],
+                [551, 551, 65, 65, 124, 124],
+                [300, 300, 37, 32, 72, 62],
+                [323, 277, 38, 32, 73, 62],
+                [266, 333, 31, 39, 60, 75]
+            ]
+        },
+        "deathPutrifier": {
+            "name": "Pestillian",
+            "FactionId": "DeathGuard",
+            "GrandAllianceId": "Chaos",
+            "BaseRarity": "Rare",
+            "powerMultiplier": 95,
+            "Movement": 2,
+            "weapons": [
+                {
+                    "hits": 1,
+                    "DamageProfile": "Toxic"
+                }
+            ],
+            "stats": {
+                "Health": 120,
+                "Damage": 40,
+                "FixedArmor": 27,
+                "ProgressionIndex": 6
+            },
+            "traits": ["Hero", "ContagionsOfNurgle", "Resilient", "PutridExplosion"],
+            "activeAbilities": ["FoulInfusion"],
+            "passiveAbilities": ["ExplosiveMaladies"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [2],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_deathPutrifier_01"],
+            "upgrades": [
+                ["upgHpC013", "upgHpC007", "upgDmgC012", "upgDmgC014", "upgArmC003", "upgArmC007"],
+                ["upgHpC006", "upgHpC010", "upgDmgC002", "upgDmgU003", "upgArmC013", "upgArmU009"],
+                ["upgHpC015", "upgHpU015", "upgDmgU002C", "upgDmgU014", "upgArmC003", "upgArmU013"],
+                ["upgHpU001", "upgHpU009", "upgDmgU010", "upgDmgU016C", "upgArmU003C", "upgArmU007"],
+                ["upgHpU001", "upgHpU015", "upgDmgU013C", "upgDmgR13C", "upgArmU002", "upgArmR007C"],
+                ["upgHpR003C", "upgHpR008", "upgDmgR024", "upgDmgU016C", "upgArmU003C", "upgArmR005"],
+                ["upgHpR024", "upgHpR006C", "upgDmgR002", "upgDmgR012C", "upgArmR012C", "upgArmR004C"],
+                ["upgHpE024C", "upgHpR006C", "upgDmgE002C", "upgDmgR012C", "upgArmR009", "upgArmR007C"],
+                ["upgHpR019", "upgHpE006C", "upgDmgE024C", "upgDmgR016C", "upgArmE007C", "upgArmE005C"],
+                ["upgHpE024C", "upgHpE008C", "upgDmgE024C", "upgDmgE003", "upgArmE007C", "upgArmE011C"],
+                ["upgHpE024C", "upgHpE012", "upgDmgL024C", "upgDmgE009C", "upgArmL007C", "upgArmE005C"],
+                ["upgHpL024C", "upgHpL012C", "upgDmgE024C", "upgDmgL016C", "upgArmE007C", "upgArmL006C"],
+                ["upgHpL124C", "upgHpL011C", "upgDmgL024C", "upgDmgL002C", "upgArmL007C", "upgArmL005C"],
+                ["upgHpL024C", "upgHpL011C", "upgDmgL124C", "upgDmgL002C", "upgArmL124C", "upgArmL006C"],
+                ["upgHpL124C", "upgHpL012C", "upgDmgL124C", "upgDmgL016C", "upgArmL124C", "upgArmL005C"],
+                ["upgHpL124C", "upgHpL009C", "upgDmgL124C", "upgDmgL002C", "upgArmL124C", "upgArmL002C"],
+                ["upgHpL124C", "upgHpL211C", "upgDmgL124C", "upgDmgL211C", "upgArmL124C", "upgArmL211C"],
+                ["upgHpL124C", "upgHpL211C", "upgDmgM211C", "upgDmgL211C", "upgArmM212C", "upgArmL211C"],
+                ["upgHpM124C", "upgHpL211C", "upgDmgM211C", "upgDmgL211C", "upgArmM212C", "upgArmL211C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [15, 15, 5, 5, 4, 4],
+                [19, 19, 4, 9, 2, 5],
+                [16, 32, 10, 6, 4, 7],
+                [30, 30, 8, 11, 8, 5],
+                [37, 37, 11, 14, 6, 11],
+                [53, 39, 16, 16, 11, 11],
+                [50, 67, 16, 22, 13, 13],
+                [81, 64, 27, 21, 14, 18],
+                [69, 114, 34, 27, 21, 21],
+                [115, 115, 43, 34, 26, 26],
+                [158, 127, 52, 43, 34, 29],
+                [179, 179, 54, 65, 37, 44],
+                [225, 225, 75, 75, 50, 50],
+                [280, 280, 94, 94, 64, 64],
+                [352, 352, 117, 117, 79, 79],
+                [440, 440, 147, 147, 99, 99],
+                [551, 551, 183, 183, 124, 124],
+                [300, 300, 108, 92, 72, 62],
+                [323, 277, 108, 92, 73, 62],
+                [266, 333, 89, 111, 60, 75]
+            ]
+        },
+        "deathBlightbringer": {
+            "name": "Corrodius",
+            "FactionId": "DeathGuard",
+            "GrandAllianceId": "Chaos",
+            "BaseRarity": "Rare",
+            "powerMultiplier": 96,
+            "Movement": 2,
+            "weapons": [
+                {
+                    "hits": 1,
+                    "DamageProfile": "Plasma"
+                }
+            ],
+            "stats": {
+                "Health": 125,
+                "Damage": 40,
+                "FixedArmor": 25,
+                "ProgressionIndex": 6
+            },
+            "traits": ["Hero", "ContagionsOfNurgle", "Resilient"],
+            "activeAbilities": ["Poxwalkers"],
+            "passiveAbilities": ["CursedPlagueBell"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [2],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_deathBlightbringer_01"],
+            "upgrades": [
+                ["upgHpC013", "upgHpC001", "upgDmgC013", "upgDmgC014", "upgArmC004", "upgArmC007"],
+                ["upgHpC015", "upgHpC010", "upgDmgC002", "upgDmgU009", "upgArmC013", "upgArmU009"],
+                ["upgHpC006", "upgHpU015", "upgDmgU002C", "upgDmgU009", "upgArmC003", "upgArmU013"],
+                ["upgHpU001", "upgHpU009", "upgDmgU010", "upgDmgU016C", "upgArmU003C", "upgArmU007"],
+                ["upgHpU016", "upgHpU015", "upgDmgU013C", "upgDmgR13C", "upgArmU002", "upgArmR007C"],
+                ["upgHpR003C", "upgHpR008", "upgDmgR024", "upgDmgU016C", "upgArmU003C", "upgArmR005"],
+                ["upgHpR024", "upgHpR015C", "upgDmgR002", "upgDmgR004C", "upgArmR012C", "upgArmR004C"],
+                ["upgHpE024C", "upgHpR015C", "upgDmgE002C", "upgDmgR004C", "upgArmR009", "upgArmR007C"],
+                ["upgHpR019", "upgHpE007C", "upgDmgE024C", "upgDmgR016C", "upgArmE007C", "upgArmE005C"],
+                ["upgHpE024C", "upgHpE008C", "upgDmgE024C", "upgDmgE004", "upgArmE007C", "upgArmE011C"],
+                ["upgHpE024C", "upgHpE012", "upgDmgL024C", "upgDmgE007C", "upgArmL007C", "upgArmE005C"],
+                ["upgHpL024C", "upgHpL012C", "upgDmgE024C", "upgDmgL016C", "upgArmE007C", "upgArmL006C"],
+                ["upgHpL124C", "upgHpL001C", "upgDmgL024C", "upgDmgL006C", "upgArmL007C", "upgArmL005C"],
+                ["upgHpL024C", "upgHpL001C", "upgDmgL124C", "upgDmgL006C", "upgArmL124C", "upgArmL006C"],
+                ["upgHpL124C", "upgHpL012C", "upgDmgL124C", "upgDmgL016C", "upgArmL124C", "upgArmL005C"],
+                ["upgHpL124C", "upgHpL009C", "upgDmgL124C", "upgDmgL002C", "upgArmL124C", "upgArmL002C"],
+                ["upgHpL124C", "upgHpL211C", "upgDmgL124C", "upgDmgL211C", "upgArmL124C", "upgArmL211C"],
+                ["upgHpL124C", "upgHpL211C", "upgDmgM211C", "upgDmgL211C", "upgArmM212C", "upgArmL211C"],
+                ["upgHpM124C", "upgHpL211C", "upgDmgM211C", "upgDmgL211C", "upgArmM212C", "upgArmL211C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [16, 16, 5, 5, 3, 3],
+                [20, 20, 4, 9, 3, 5],
+                [16, 32, 10, 6, 3, 7],
+                [31, 31, 8, 11, 7, 5],
+                [39, 39, 11, 14, 5, 11],
+                [55, 41, 16, 16, 10, 10],
+                [52, 70, 16, 22, 12, 12],
+                [84, 68, 27, 21, 13, 17],
+                [71, 119, 34, 27, 19, 19],
+                [119, 119, 43, 34, 24, 24],
+                [166, 132, 52, 43, 32, 27],
+                [187, 187, 54, 65, 34, 41],
+                [233, 233, 75, 75, 47, 47],
+                [293, 293, 94, 94, 58, 58],
+                [366, 366, 117, 117, 74, 74],
+                [459, 459, 147, 147, 91, 91],
+                [574, 574, 183, 183, 115, 115],
+                [312, 312, 108, 92, 67, 58],
+                [337, 288, 108, 92, 67, 58],
+                [277, 347, 89, 111, 56, 69]
+            ]
+        },
+        "deathCrawler": {
+            "name": "Plagueburst Crawler",
+            "FactionId": "DeathGuard",
+            "GrandAllianceId": "Chaos",
+            "BaseRarity": "Common",
+            "stats": {
+                "Health": 0,
+                "Damage": 0,
+                "FixedArmor": 0,
+                "ProgressionIndex": 0
+            },
+            "traits": ["MachineOfWar"],
+            "activeAbilities": ["EntropyCannons", "PlagueburstMortar"],
+            "mythicAbilities": ["BlightedLand"],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "timestampIfHeroUnlocked": 1742630400000,
+                "timestampIfHeroNotUnlocked": 1745654400000
+            },
+            "releaseStatus": "1741939200000",
+            "unlockQuestIds": ["hero_deathCrawler_01"],
+            "upgrades": null,
+            "upgradesStatIncrease": null
+        },
+        "orksRuntherd": {
+            "name": "Snotflogga",
+            "FactionId": "Orks",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Rare",
+            "powerMultiplier": 115,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 3,
+                    "DamageProfile": "Physical"
+                }
+            ],
+            "stats": {
+                "Health": 120,
+                "Damage": 30,
+                "FixedArmor": 18,
+                "ProgressionIndex": 6
+            },
+            "traits": ["Hero", "GetStuckIn", "BeastSlayer"],
+            "activeAbilities": ["GetEmRuntz"],
+            "passiveAbilities": ["SquigHound"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [1],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_orksRuntherd_01"],
+            "upgrades": [
+                ["upgHpC015", "upgHpC001", "upgDmgC012", "upgDmgC014", "upgArmC011", "upgArmC003"],
+                ["upgHpC015", "upgHpC008", "upgDmgC001", "upgDmgU014", "upgArmC011", "upgArmU002"],
+                ["upgHpC013", "upgHpC008", "upgDmgU001C", "upgDmgU014", "upgArmC011", "upgArmU002"],
+                ["upgHpU015", "upgHpU001", "upgDmgU009", "upgDmgU016C", "upgArmU003C", "upgArmU012"],
+                ["upgHpU015", "upgHpR019", "upgDmgU013C", "upgDmgR001C", "upgArmU013", "upgArmR007C"],
+                ["upgHpR018", "upgHpR003C", "upgDmgR026", "upgDmgU016C", "upgArmU003C", "upgArmR006"],
+                ["upgHpR010", "upgHpR003C", "upgDmgR026", "upgDmgR012C", "upgArmR007C", "upgArmR008C"],
+                ["upgHpE005C", "upgHpR015C", "upgDmgE008C", "upgDmgR012C", "upgArmR026", "upgArmR007C"],
+                ["upgHpR018", "upgHpE007C", "upgDmgE026C", "upgDmgR016C", "upgArmE026C", "upgArmE012C"],
+                ["upgHpE005C", "upgHpE014C", "upgDmgE026C", "upgDmgE004", "upgArmE026C", "upgArmE011C"],
+                ["upgHpE005C", "upgHpE007C", "upgDmgL026C", "upgDmgE004", "upgArmL026C", "upgArmE012C"],
+                ["upgHpL006C", "upgHpL014C", "upgDmgE026C", "upgDmgL017C", "upgArmE026C", "upgArmL002C"],
+                ["upgHpL126C", "upgHpL001C", "upgDmgL026C", "upgDmgL008C", "upgArmL026C", "upgArmL009C"],
+                ["upgHpL006C", "upgHpL001C", "upgDmgL126C", "upgDmgL008C", "upgArmL126C", "upgArmL002C"],
+                ["upgHpL126C", "upgHpL014C", "upgDmgL126C", "upgDmgL017C", "upgArmL126C", "upgArmL009C"],
+                ["upgHpL126C", "upgHpL009C", "upgDmgL126C", "upgDmgL006C", "upgArmL126C", "upgArmL002C"],
+                ["upgHpL126C", "upgHpL211C", "upgDmgL126C", "upgDmgL211C", "upgArmL126C", "upgArmL211C"],
+                ["upgHpL126C", "upgHpL211C", "upgDmgM212C", "upgDmgL211C", "upgArmM214C", "upgArmL211C"],
+                ["upgHpM126C", "upgHpL211C", "upgDmgM212C", "upgDmgL211C", "upgArmM214C", "upgArmL211C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [15, 15, 4, 4, 3, 3],
+                [19, 19, 3, 6, 1, 3],
+                [24, 24, 7, 5, 2, 5],
+                [30, 30, 6, 9, 5, 4],
+                [29, 44, 8, 10, 4, 7],
+                [40, 53, 12, 12, 7, 7],
+                [50, 67, 12, 17, 9, 9],
+                [81, 64, 20, 16, 9, 13],
+                [69, 114, 26, 20, 14, 14],
+                [115, 115, 32, 25, 17, 17],
+                [143, 143, 43, 28, 23, 19],
+                [179, 179, 41, 49, 25, 29],
+                [224, 224, 56, 56, 34, 34],
+                [281, 281, 71, 71, 42, 42],
+                [351, 351, 87, 87, 53, 53],
+                [441, 441, 110, 110, 66, 66],
+                [551, 551, 138, 138, 82, 82],
+                [300, 300, 81, 69, 48, 42],
+                [323, 276, 81, 69, 48, 42],
+                [266, 333, 67, 83, 40, 50]
+            ]
+        },
+        "orksBigMek": {
+            "name": "Gibbascrapz",
+            "FactionId": "Orks",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Common",
+            "powerMultiplier": 139,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 4,
+                    "DamageProfile": "Physical"
+                }
+            ],
+            "stats": {
+                "Health": 80,
+                "Damage": 25,
+                "FixedArmor": 18,
+                "ProgressionIndex": 0
+            },
+            "traits": ["Hero", "GetStuckIn", "Mechanic"],
+            "activeAbilities": ["GrotTank"],
+            "passiveAbilities": ["KustomForceFieldReworked"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [1],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_orksBigMek_01"],
+            "upgrades": [
+                ["upgHpC014", "upgHpC002", "upgDmgC009", "upgDmgC014", "upgArmC003", "upgArmC012"],
+                ["upgHpC015", "upgHpC008", "upgDmgC012", "upgDmgU009", "upgArmC003", "upgArmU002"],
+                ["upgHpC013", "upgHpC008", "upgDmgU001C", "upgDmgU009", "upgArmC003", "upgArmU002"],
+                ["upgHpU015", "upgHpU012", "upgDmgU010", "upgDmgU016C", "upgArmU003C", "upgArmU012"],
+                ["upgHpU014", "upgHpR019", "upgDmgU013C", "upgDmgR001C", "upgArmU002", "upgArmR007C"],
+                ["upgHpR001", "upgHpR012C", "upgDmgR026", "upgDmgU016C", "upgArmU003C", "upgArmR006"],
+                ["upgHpR010", "upgHpR012C", "upgDmgR011C", "upgDmgR006", "upgArmR007C", "upgArmR008C"],
+                ["upgHpE005C", "upgHpR004C", "upgDmgE008C", "upgDmgR004C", "upgArmR026", "upgArmR007C"],
+                ["upgHpR001", "upgHpE001C", "upgDmgE026C", "upgDmgR016C", "upgArmE026C", "upgArmE012C"],
+                ["upgHpE005C", "upgHpE014C", "upgDmgE026C", "upgDmgE004", "upgArmE026C", "upgArmE002C"],
+                ["upgHpE005C", "upgHpE001C", "upgDmgL026C", "upgDmgE004", "upgArmL026C", "upgArmE012C"],
+                ["upgHpL006C", "upgHpL014C", "upgDmgE026C", "upgDmgL017C", "upgArmE026C", "upgArmL002C"],
+                ["upgHpL126C", "upgHpL001C", "upgDmgL026C", "upgDmgL006C", "upgArmL026C", "upgArmL009C"],
+                ["upgHpL006C", "upgHpL001C", "upgDmgL126C", "upgDmgL006C", "upgArmL126C", "upgArmL002C"],
+                ["upgHpL126C", "upgHpL014C", "upgDmgL126C", "upgDmgL017C", "upgArmL126C", "upgArmL009C"],
+                ["upgHpL126C", "upgHpL017C", "upgDmgL126C", "upgDmgL005C", "upgArmL126C", "upgArmL002C"],
+                ["upgHpL126C", "upgHpL214C", "upgDmgL126C", "upgDmgL214C", "upgArmL126C", "upgArmL214C"],
+                ["upgHpL126C", "upgHpL214C", "upgDmgM214C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpM126C", "upgHpL214C", "upgDmgM214C", "upgDmgL214C", "upgArmM213C", "upgArmL214C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [10, 10, 3, 3, 3, 3],
+                [13, 13, 3, 5, 1, 3],
+                [16, 16, 6, 4, 2, 5],
+                [20, 20, 5, 7, 5, 4],
+                [19, 29, 7, 9, 4, 7],
+                [27, 35, 10, 10, 7, 7],
+                [33, 45, 14, 10, 9, 9],
+                [54, 43, 17, 13, 9, 13],
+                [46, 76, 21, 17, 14, 14],
+                [76, 76, 27, 21, 17, 17],
+                [96, 96, 35, 24, 23, 19],
+                [119, 119, 34, 41, 25, 29],
+                [150, 150, 47, 47, 34, 34],
+                [187, 187, 58, 58, 42, 42],
+                [234, 234, 74, 74, 53, 53],
+                [294, 294, 91, 91, 66, 66],
+                [367, 367, 115, 115, 82, 82],
+                [200, 200, 67, 58, 48, 42],
+                [215, 185, 67, 58, 48, 42],
+                [177, 222, 56, 69, 40, 50]
+            ]
+        },
+        "orksKillaKan": {
+            "name": "Snappawrecka",
+            "FactionId": "Orks",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Uncommon",
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 3,
+                    "DamageProfile": "Chain"
+                },
+                {
+                    "hits": 3,
+                    "DamageProfile": "Projectile",
+                    "Range": 3
+                }
+            ],
+            "stats": {
+                "Health": 90,
+                "Damage": 23,
+                "FixedArmor": 20,
+                "ProgressionIndex": 3
+            },
+            "traits": ["Hero", "GetStuckIn", "BigTarget", "Explodes", "Mechanical"],
+            "activeAbilities": ["DakkaDakkaDakka"],
+            "passiveAbilities": ["PowerTrip"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_orksKillaKan_01"],
+            "upgrades": [
+                ["upgHpC013", "upgHpC002", "upgDmgC001", "upgDmgC014", "upgArmC003", "upgArmC012"],
+                ["upgHpC014", "upgHpC008", "upgDmgC012", "upgDmgU003", "upgArmC012", "upgArmU002"],
+                ["upgHpC013", "upgHpC008", "upgDmgU001C", "upgDmgU009", "upgArmC013", "upgArmU002"],
+                ["upgHpU014", "upgHpU013", "upgDmgU014", "upgDmgU016C", "upgArmU003C", "upgArmU012"],
+                ["upgHpU014", "upgHpR019", "upgDmgU001C", "upgDmgR001C", "upgArmU006", "upgArmR007C"],
+                ["upgHpR002", "upgHpR012C", "upgDmgR026", "upgDmgU016C", "upgArmU003C", "upgArmR006"],
+                ["upgHpR010", "upgHpR012C", "upgDmgR012C", "upgDmgR003", "upgArmR007C", "upgArmR008C"],
+                ["upgHpE005C", "upgHpR004C", "upgDmgE009C", "upgDmgR004C", "upgArmR026", "upgArmR007C"],
+                ["upgHpR018", "upgHpE013C", "upgDmgE026C", "upgDmgR016C", "upgArmE026C", "upgArmE012C"],
+                ["upgHpE005C", "upgHpE014C", "upgDmgE026C", "upgDmgE004", "upgArmE026C", "upgArmE002C"],
+                ["upgHpE005C", "upgHpE013C", "upgDmgL026C", "upgDmgE004", "upgArmL026C", "upgArmE012C"],
+                ["upgHpL006C", "upgHpL014C", "upgDmgE026C", "upgDmgL017C", "upgArmE026C", "upgArmL002C"],
+                ["upgHpL126C", "upgHpL013C", "upgDmgL026C", "upgDmgL007C", "upgArmL026C", "upgArmL009C"],
+                ["upgHpL006C", "upgHpL013C", "upgDmgL126C", "upgDmgL007C", "upgArmL126C", "upgArmL002C"],
+                ["upgHpL126C", "upgHpL014C", "upgDmgL126C", "upgDmgL017C", "upgArmL126C", "upgArmL009C"],
+                ["upgHpL126C", "upgHpL017C", "upgDmgL126C", "upgDmgL005C", "upgArmL126C", "upgArmL002C"],
+                ["upgHpL126C", "upgHpL214C", "upgDmgL126C", "upgDmgL214C", "upgArmL126C", "upgArmL214C"],
+                ["upgHpL126C", "upgHpL214C", "upgDmgM213C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpM126C", "upgHpL214C", "upgDmgM213C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 3, 3, 3, 3],
+                [14, 14, 2, 5, 2, 3],
+                [18, 18, 5, 4, 3, 5],
+                [22, 22, 5, 7, 6, 4],
+                [22, 33, 6, 8, 4, 9],
+                [30, 40, 9, 9, 8, 8],
+                [37, 50, 13, 9, 9, 9],
+                [61, 48, 16, 12, 11, 14],
+                [51, 86, 19, 16, 15, 15],
+                [86, 86, 24, 20, 19, 19],
+                [107, 107, 33, 22, 26, 22],
+                [135, 135, 31, 37, 27, 33],
+                [168, 168, 43, 43, 37, 37],
+                [211, 211, 54, 54, 47, 47],
+                [263, 263, 68, 68, 59, 59],
+                [330, 330, 84, 84, 73, 73],
+                [414, 414, 106, 106, 92, 92],
+                [225, 225, 61, 53, 54, 46],
+                [242, 207, 62, 53, 54, 46],
+                [200, 249, 51, 63, 44, 56]
+            ]
+        },
+        "orksNob": {
+            "name": "Tanksmasha",
+            "FactionId": "Orks",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Epic",
+            "powerMultiplier": 98,
+            "Movement": 4,
+            "weapons": [
+                {
+                    "hits": 3,
+                    "DamageProfile": "Eviscerate"
+                }
+            ],
+            "stats": {
+                "Health": 100,
+                "Damage": 24,
+                "FixedArmor": 15,
+                "ProgressionIndex": 9
+            },
+            "traits": ["Hero", "GetStuckIn", "BeastSlayer", "Unstoppable"],
+            "activeAbilities": ["UnstoppableMomentumReworked"],
+            "passiveAbilities": ["SmashaEad"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [1],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_orksNob_01"],
+            "upgrades": [
+                ["upgHpC013", "upgHpC002", "upgDmgC012", "upgDmgC014", "upgArmC003", "upgArmC011"],
+                ["upgHpC013", "upgHpC008", "upgDmgC001", "upgDmgU014", "upgArmC012", "upgArmU002"],
+                ["upgHpC015", "upgHpC008", "upgDmgU001C", "upgDmgU014", "upgArmC011", "upgArmU002"],
+                ["upgHpU015", "upgHpU001", "upgDmgU003", "upgDmgU016C", "upgArmU003C", "upgArmU012"],
+                ["upgHpU015", "upgHpR019", "upgDmgU001C", "upgDmgR001C", "upgArmU002", "upgArmR007C"],
+                ["upgHpR018", "upgHpR003C", "upgDmgR026", "upgDmgU016C", "upgArmU003C", "upgArmR006"],
+                ["upgHpR010", "upgHpR004C", "upgDmgR026", "upgDmgR012C", "upgArmR007C", "upgArmR008C"],
+                ["upgHpE005C", "upgHpR015C", "upgDmgR001C", "upgDmgE009C", "upgArmR026", "upgArmR007C"],
+                ["upgHpR018", "upgHpE007C", "upgDmgE026C", "upgDmgR016C", "upgArmE026C", "upgArmE012C"],
+                ["upgHpE005C", "upgHpE014C", "upgDmgE026C", "upgDmgE004", "upgArmE026C", "upgArmE002C"],
+                ["upgHpE005C", "upgHpE007C", "upgDmgL026C", "upgDmgE004", "upgArmL026C", "upgArmE012C"],
+                ["upgHpL006C", "upgHpL014C", "upgDmgE026C", "upgDmgL017C", "upgArmE026C", "upgArmL002C"],
+                ["upgHpL126C", "upgHpL001C", "upgDmgL026C", "upgDmgL008C", "upgArmL026C", "upgArmL009C"],
+                ["upgHpL006C", "upgHpL001C", "upgDmgL126C", "upgDmgL008C", "upgArmL126C", "upgArmL002C"],
+                ["upgHpL126C", "upgHpL014C", "upgDmgL126C", "upgDmgL017C", "upgArmL126C", "upgArmL009C"],
+                ["upgHpL126C", "upgHpL009C", "upgDmgL126C", "upgDmgL006C", "upgArmL126C", "upgArmL002C"],
+                ["upgHpL126C", "upgHpL211C", "upgDmgL126C", "upgDmgL211C", "upgArmL126C", "upgArmL211C"],
+                ["upgHpL126C", "upgHpL211C", "upgDmgM212C", "upgDmgL211C", "upgArmM214C", "upgArmL211C"],
+                ["upgHpM126C", "upgHpL211C", "upgDmgM212C", "upgDmgL211C", "upgArmM214C", "upgArmL211C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [13, 13, 3, 3, 2, 2],
+                [16, 16, 3, 5, 2, 3],
+                [19, 19, 5, 4, 2, 3],
+                [25, 25, 5, 7, 5, 3],
+                [25, 37, 6, 9, 3, 6],
+                [33, 44, 9, 9, 6, 6],
+                [42, 55, 10, 14, 7, 7],
+                [68, 54, 13, 16, 8, 11],
+                [57, 95, 20, 16, 11, 11],
+                [95, 95, 26, 20, 15, 15],
+                [120, 120, 34, 23, 19, 16],
+                [149, 149, 33, 39, 20, 25],
+                [187, 187, 45, 45, 28, 28],
+                [234, 234, 56, 56, 35, 35],
+                [293, 293, 71, 71, 44, 44],
+                [367, 367, 88, 88, 55, 55],
+                [459, 459, 110, 110, 69, 69],
+                [250, 250, 64, 55, 40, 34],
+                [269, 230, 65, 55, 40, 35],
+                [222, 278, 53, 67, 33, 42]
+            ]
+        },
+        "orksWarboss": {
+            "name": "Gulgortz",
+            "FactionId": "Orks",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Epic",
+            "powerMultiplier": 92,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 2,
+                    "DamageProfile": "Eviscerate"
+                },
+                {
+                    "hits": 1,
+                    "DamageProfile": "Projectile",
+                    "Range": 3
+                }
+            ],
+            "stats": {
+                "Health": 100,
+                "Damage": 26,
+                "FixedArmor": 26,
+                "ProgressionIndex": 9
+            },
+            "traits": ["Hero", "GetStuckIn", "BigTarget", "CrushingStrike", "FinalJustice", "Mechanical"],
+            "activeAbilities": ["Waaagh"],
+            "passiveAbilities": ["LightImUp"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Block"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_orksWarboss_01"],
+            "upgrades": [
+                ["upgHpC014", "upgHpC002", "upgDmgC001", "upgDmgC014", "upgArmC003", "upgArmC004"],
+                ["upgHpC013", "upgHpC008", "upgDmgC012", "upgDmgU009", "upgArmC011", "upgArmU002"],
+                ["upgHpC013", "upgHpC008", "upgDmgU001C", "upgDmgU009", "upgArmC012", "upgArmU002"],
+                ["upgHpU014", "upgHpU012", "upgDmgU014", "upgDmgU016C", "upgArmU003C", "upgArmU012"],
+                ["upgHpU014", "upgHpR019", "upgDmgU001C", "upgDmgR001C", "upgArmU002", "upgArmR007C"],
+                ["upgHpR018", "upgHpR015C", "upgDmgR026", "upgDmgU016C", "upgArmU003C", "upgArmR006"],
+                ["upgHpR010", "upgHpR012C", "upgDmgR012C", "upgDmgR006", "upgArmR007C", "upgArmR008C"],
+                ["upgHpE005C", "upgHpR004C", "upgDmgE009C", "upgDmgR004C", "upgArmR026", "upgArmR007C"],
+                ["upgHpR018", "upgHpE007C", "upgDmgE026C", "upgDmgR016C", "upgArmE026C", "upgArmE012C"],
+                ["upgHpE005C", "upgHpE014C", "upgDmgE026C", "upgDmgE004", "upgArmE026C", "upgArmE002C"],
+                ["upgHpE005C", "upgHpE007C", "upgDmgL026C", "upgDmgE004", "upgArmL026C", "upgArmE012C"],
+                ["upgHpL006C", "upgHpL014C", "upgDmgE026C", "upgDmgL017C", "upgArmE026C", "upgArmL002C"],
+                ["upgHpL126C", "upgHpL001C", "upgDmgL026C", "upgDmgL007C", "upgArmL026C", "upgArmL009C"],
+                ["upgHpL006C", "upgHpL001C", "upgDmgL126C", "upgDmgL007C", "upgArmL126C", "upgArmL002C"],
+                ["upgHpL126C", "upgHpL014C", "upgDmgL126C", "upgDmgL017C", "upgArmL126C", "upgArmL009C"],
+                ["upgHpL126C", "upgHpL009C", "upgDmgL126C", "upgDmgL006C", "upgArmL126C", "upgArmL002C"],
+                ["upgHpL126C", "upgHpL211C", "upgDmgL126C", "upgDmgL211C", "upgArmL126C", "upgArmL211C"],
+                ["upgHpL126C", "upgHpL211C", "upgDmgM213C", "upgDmgL211C", "upgArmM214C", "upgArmL211C"],
+                ["upgHpM126C", "upgHpL211C", "upgDmgM213C", "upgDmgL211C", "upgArmM214C", "upgArmL211C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [13, 13, 4, 4, 4, 4],
+                [16, 16, 2, 5, 2, 5],
+                [19, 19, 6, 4, 3, 7],
+                [25, 25, 5, 8, 8, 5],
+                [25, 37, 7, 9, 5, 11],
+                [33, 44, 10, 10, 10, 10],
+                [42, 55, 14, 11, 13, 13],
+                [68, 54, 18, 14, 13, 18],
+                [57, 95, 22, 18, 20, 20],
+                [95, 95, 27, 22, 25, 25],
+                [120, 120, 37, 25, 33, 28],
+                [149, 149, 35, 43, 35, 43],
+                [187, 187, 49, 49, 49, 49],
+                [234, 234, 61, 61, 61, 61],
+                [293, 293, 76, 76, 76, 76],
+                [367, 367, 95, 95, 95, 95],
+                [459, 459, 119, 119, 119, 119],
+                [250, 250, 70, 60, 70, 60],
+                [269, 230, 70, 60, 70, 60],
+                [222, 278, 58, 72, 58, 72]
+            ]
+        },
+        "orksRukkatrukk": {
+            "name": "Rukkatrukk",
+            "FactionId": "Orks",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Common",
+            "stats": {
+                "Health": 0,
+                "Damage": 0,
+                "FixedArmor": 0,
+                "ProgressionIndex": 0
+            },
+            "traits": ["MachineOfWar"],
+            "activeAbilities": ["SquigLaunchas", "SquigMine"],
+            "mythicAbilities": ["MoreGitzOverEre"],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "timestampIfHeroUnlocked": 1760774400000,
+                "timestampIfHeroNotUnlocked": 1763798400000
+            },
+            "releaseStatus": "1760313600000",
+            "unlockQuestIds": ["hero_orksRukkatrukk_01"],
+            "upgrades": null,
+            "upgradesStatIncrease": null
+        },
+        "templSwordBrother": {
+            "name": "Godswyl",
+            "FactionId": "BlackTemplars",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Common",
+            "powerMultiplier": 122,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 1,
+                    "DamageProfile": "Power"
+                }
+            ],
+            "stats": {
+                "Health": 95,
+                "Damage": 60,
+                "FixedArmor": 24,
+                "ProgressionIndex": 0
+            },
+            "traits": ["Hero", "Parry", "RapidAssault"],
+            "activeAbilities": ["ThunderousAssault"],
+            "passiveAbilities": ["ChampionOfTheFeast"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "campaign": {
+                    "campaignType": "Standard",
+                    "campaignId": "campaign3",
+                    "level": 30
+                }
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_templSwordBrother_01"],
+            "upgrades": [
+                ["upgHpC006", "upgHpC002", "upgDmgC013", "upgDmgC011", "upgArmC006", "upgArmC001"],
+                ["upgHpC013", "upgHpC003", "upgDmgC002", "upgDmgU010", "upgArmC013", "upgArmU009"],
+                ["upgHpC015", "upgHpU002", "upgDmgU002C", "upgDmgR007", "upgArmC003", "upgArmU009"],
+                ["upgHpU015", "upgHpU006", "upgDmgU012", "upgDmgU015C", "upgArmU003C", "upgArmU001"],
+                ["upgHpU008", "upgHpU002", "upgDmgU013C", "upgDmgR13C", "upgArmU008", "upgArmR003C"],
+                ["upgHpR002", "upgHpR017C", "upgDmgR021", "upgDmgU015C", "upgArmR005", "upgArmR007C"],
+                ["upgHpR021", "upgHpR015C", "upgDmgR002", "upgDmgR012C", "upgArmR012C", "upgArmR001C"],
+                ["upgHpE021C", "upgHpR020C", "upgDmgE002C", "upgDmgR012C", "upgArmR021", "upgArmR003C"],
+                ["upgHpR019", "upgHpE001C", "upgDmgE021C", "upgDmgR015C", "upgArmE021C", "upgArmE001C"],
+                ["upgHpE021C", "upgHpE002C", "upgDmgE021C", "upgDmgE004", "upgArmE021C", "upgArmE006C"],
+                ["upgHpE021C", "upgHpE003", "upgDmgL021C", "upgDmgE009C", "upgArmL021C", "upgArmE001C"],
+                ["upgHpL021C", "upgHpL002C", "upgDmgE021C", "upgDmgL015C", "upgArmE021C", "upgArmL006C"],
+                ["upgHpL121C", "upgHpL009C", "upgDmgL021C", "upgDmgL008C", "upgArmL021C", "upgArmL010C"],
+                ["upgHpL021C", "upgHpL009C", "upgDmgL121C", "upgDmgL008C", "upgArmL121C", "upgArmL006C"],
+                ["upgHpL121C", "upgHpL002C", "upgDmgL121C", "upgDmgL015C", "upgArmL121C", "upgArmL010C"],
+                ["upgHpL121C", "upgHpL002C", "upgDmgL121C", "upgDmgL006C", "upgArmL121C", "upgArmL004C"],
+                ["upgHpL121C", "upgHpL213C", "upgDmgL121C", "upgDmgL213C", "upgArmL121C", "upgArmL213C"],
+                ["upgHpL121C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM211C", "upgArmL213C"],
+                ["upgHpM121C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM213C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 8, 8, 3, 3],
+                [15, 15, 6, 12, 3, 5],
+                [12, 25, 12, 12, 3, 6],
+                [24, 24, 12, 17, 7, 5],
+                [29, 29, 16, 22, 5, 10],
+                [32, 42, 23, 23, 8, 10],
+                [39, 53, 25, 33, 12, 12],
+                [64, 52, 41, 32, 12, 17],
+                [54, 90, 51, 41, 18, 18],
+                [91, 91, 63, 51, 23, 23],
+                [126, 100, 78, 65, 31, 26],
+                [142, 142, 81, 98, 33, 39],
+                [177, 177, 112, 112, 45, 45],
+                [223, 223, 141, 141, 56, 56],
+                [278, 278, 176, 176, 71, 71],
+                [349, 349, 220, 220, 88, 88],
+                [436, 436, 275, 275, 110, 110],
+                [237, 237, 162, 138, 64, 55],
+                [256, 219, 162, 138, 65, 55],
+                [211, 263, 133, 167, 53, 67]
+            ]
+        },
+        "templAggressor": {
+            "name": "Burchard",
+            "FactionId": "BlackTemplars",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Uncommon",
+            "powerMultiplier": 86,
+            "Movement": 2,
+            "weapons": [
+                {
+                    "hits": 3,
+                    "DamageProfile": "Power"
+                },
+                {
+                    "hits": 3,
+                    "DamageProfile": "Bolter",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 120,
+                "Damage": 18,
+                "FixedArmor": 22,
+                "ProgressionIndex": 3
+            },
+            "traits": ["Hero", "CrushingStrike", "MkXGravis", "SuppressiveFire"],
+            "activeAbilities": ["FragstormGrenadeLauncher"],
+            "passiveAbilities": ["Boltstorm"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "campaign": {
+                    "campaignType": "Standard",
+                    "campaignId": "campaign3",
+                    "level": 15
+                }
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_templAggressor_01"],
+            "upgrades": [
+                ["upgHpC004", "upgHpC002", "upgDmgC001", "upgDmgC011", "upgArmC006", "upgArmC001"],
+                ["upgHpC015", "upgHpC003", "upgDmgC002", "upgDmgU003", "upgArmC004", "upgArmU009"],
+                ["upgHpC014", "upgHpU002", "upgDmgU002C", "upgDmgU006", "upgArmC013", "upgArmU005"],
+                ["upgHpU003", "upgHpU014", "upgDmgU003", "upgDmgU015C", "upgArmU003C", "upgArmU001"],
+                ["upgHpU014", "upgHpU002", "upgDmgU001C", "upgDmgR13C", "upgArmU008", "upgArmR007C"],
+                ["upgHpR018", "upgHpR012C", "upgDmgR021", "upgDmgU015C", "upgArmU008", "upgArmR003C"],
+                ["upgHpR021", "upgHpR012C", "upgDmgR001C", "upgDmgR003", "upgArmR003C", "upgArmR001C"],
+                ["upgHpE021C", "upgHpR020C", "upgDmgE007C", "upgDmgR004C", "upgArmR021", "upgArmR007C"],
+                ["upgHpR018", "upgHpE001C", "upgDmgE021C", "upgDmgR015C", "upgArmE021C", "upgArmE001C"],
+                ["upgHpE021C", "upgHpE002C", "upgDmgE021C", "upgDmgE004", "upgArmE021C", "upgArmE006C"],
+                ["upgHpE021C", "upgHpE012", "upgDmgL021C", "upgDmgE007C", "upgArmL021C", "upgArmE001C"],
+                ["upgHpL021C", "upgHpL002C", "upgDmgE021C", "upgDmgL015C", "upgArmE021C", "upgArmL006C"],
+                ["upgHpL121C", "upgHpL001C", "upgDmgL021C", "upgDmgL007C", "upgArmL021C", "upgArmL010C"],
+                ["upgHpL021C", "upgHpL001C", "upgDmgL121C", "upgDmgL007C", "upgArmL121C", "upgArmL006C"],
+                ["upgHpL121C", "upgHpL002C", "upgDmgL121C", "upgDmgL015C", "upgArmL121C", "upgArmL010C"],
+                ["upgHpL121C", "upgHpL017C", "upgDmgL121C", "upgDmgL002C", "upgArmL121C", "upgArmL004C"],
+                ["upgHpL121C", "upgHpL213C", "upgDmgL121C", "upgDmgL213C", "upgArmL121C", "upgArmL213C"],
+                ["upgHpL121C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpM121C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [15, 15, 3, 3, 3, 3],
+                [19, 19, 1, 3, 2, 4],
+                [16, 32, 4, 3, 3, 6],
+                [30, 30, 4, 5, 7, 4],
+                [37, 37, 5, 6, 5, 9],
+                [39, 53, 7, 7, 6, 11],
+                [50, 67, 10, 8, 11, 11],
+                [81, 64, 12, 10, 11, 15],
+                [69, 114, 15, 12, 17, 17],
+                [115, 115, 19, 15, 21, 21],
+                [158, 127, 23, 20, 28, 24],
+                [179, 179, 25, 29, 30, 35],
+                [225, 225, 34, 34, 42, 42],
+                [280, 280, 42, 42, 51, 51],
+                [352, 352, 53, 53, 64, 64],
+                [440, 440, 66, 66, 81, 81],
+                [551, 551, 82, 82, 101, 101],
+                [300, 300, 48, 42, 59, 51],
+                [323, 277, 48, 42, 59, 51],
+                [266, 333, 40, 50, 49, 61]
+            ]
+        },
+        "templAncient": {
+            "name": "Thoread",
+            "FactionId": "BlackTemplars",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Rare",
+            "powerMultiplier": 108,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 2,
+                    "DamageProfile": "Power"
+                }
+            ],
+            "stats": {
+                "Health": 100,
+                "Damage": 33,
+                "FixedArmor": 22,
+                "ProgressionIndex": 6
+            },
+            "traits": ["Hero", "FinalJustice", "Parry"],
+            "activeAbilities": ["UnbreakableDuty"],
+            "passiveAbilities": ["AstartesBanner"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "campaign": {
+                    "campaignType": "Standard",
+                    "campaignId": "campaign3",
+                    "level": 45
+                }
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_templAncient_01"],
+            "upgrades": [
+                ["upgHpC006", "upgHpC005", "upgDmgC013", "upgDmgC011", "upgArmC006", "upgArmC001"],
+                ["upgHpC016", "upgHpC003", "upgDmgC002", "upgDmgU003", "upgArmC013", "upgArmU013"],
+                ["upgHpC015", "upgHpU002", "upgDmgU002C", "upgDmgR007", "upgArmC004", "upgArmU009"],
+                ["upgHpU016", "upgHpU012", "upgDmgU012", "upgDmgU015C", "upgArmU003C", "upgArmU001"],
+                ["upgHpU015", "upgHpU002", "upgDmgU013C", "upgDmgR13C", "upgArmU008", "upgArmR003C"],
+                ["upgHpR002", "upgHpR015C", "upgDmgR021", "upgDmgU015C", "upgArmR005", "upgArmR013C"],
+                ["upgHpR021", "upgHpR015C", "upgDmgR002", "upgDmgR010C", "upgArmR012C", "upgArmR001C"],
+                ["upgHpE021C", "upgHpR020C", "upgDmgE002C", "upgDmgR012C", "upgArmR021", "upgArmR013C"],
+                ["upgHpR002", "upgHpE007C", "upgDmgE021C", "upgDmgR015C", "upgArmE021C", "upgArmE001C"],
+                ["upgHpE021C", "upgHpE002C", "upgDmgE021C", "upgDmgE003", "upgArmE021C", "upgArmE006C"],
+                ["upgHpE021C", "upgHpE003", "upgDmgL021C", "upgDmgE006C", "upgArmL021C", "upgArmE001C"],
+                ["upgHpL021C", "upgHpL002C", "upgDmgE021C", "upgDmgL015C", "upgArmE021C", "upgArmL006C"],
+                ["upgHpL121C", "upgHpL009C", "upgDmgL021C", "upgDmgL008C", "upgArmL021C", "upgArmL010C"],
+                ["upgHpL021C", "upgHpL009C", "upgDmgL121C", "upgDmgL008C", "upgArmL121C", "upgArmL006C"],
+                ["upgHpL121C", "upgHpL002C", "upgDmgL121C", "upgDmgL015C", "upgArmL121C", "upgArmL010C"],
+                ["upgHpL121C", "upgHpL002C", "upgDmgL121C", "upgDmgL002C", "upgArmL121C", "upgArmL004C"],
+                ["upgHpL121C", "upgHpL213C", "upgDmgL121C", "upgDmgL213C", "upgArmL121C", "upgArmL213C"],
+                ["upgHpL121C", "upgHpL213C", "upgDmgM214C", "upgDmgL213C", "upgArmM211C", "upgArmL213C"],
+                ["upgHpM121C", "upgHpL213C", "upgDmgM214C", "upgDmgL213C", "upgArmM213C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [13, 13, 4, 4, 3, 3],
+                [16, 16, 4, 7, 2, 4],
+                [13, 25, 7, 7, 3, 6],
+                [25, 25, 6, 9, 7, 4],
+                [31, 31, 9, 12, 5, 9],
+                [33, 44, 13, 13, 7, 10],
+                [42, 55, 13, 18, 11, 11],
+                [68, 54, 22, 18, 11, 15],
+                [57, 95, 28, 22, 17, 17],
+                [95, 95, 35, 28, 21, 21],
+                [133, 106, 43, 36, 28, 24],
+                [149, 149, 45, 54, 30, 35],
+                [187, 187, 62, 62, 42, 42],
+                [234, 234, 77, 77, 51, 51],
+                [293, 293, 97, 97, 64, 64],
+                [367, 367, 121, 121, 81, 81],
+                [459, 459, 151, 151, 101, 101],
+                [250, 250, 89, 76, 59, 51],
+                [269, 231, 89, 76, 59, 51],
+                [222, 278, 73, 92, 49, 61]
+            ]
+        },
+        "templChampion": {
+            "name": "Jaeger",
+            "FactionId": "BlackTemplars",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Epic",
+            "powerMultiplier": 97,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 3,
+                    "DamageProfile": "Power"
+                }
+            ],
+            "stats": {
+                "Health": 110,
+                "Damage": 25,
+                "FixedArmor": 25,
+                "ProgressionIndex": 9
+            },
+            "traits": ["Hero", "FinalJustice", "Parry", "RapidAssault"],
+            "activeAbilities": ["HolyDuel"],
+            "passiveAbilities": ["MartialSuperiority"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Block"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "campaign": {
+                    "campaignType": "Standard",
+                    "campaignId": "campaign3",
+                    "level": 60
+                }
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_templChampion_01"],
+            "upgrades": [
+                ["upgHpC004", "upgHpC017", "upgDmgC010", "upgDmgC011", "upgArmC013", "upgArmC001"],
+                ["upgHpC006", "upgHpC003", "upgDmgC002", "upgDmgU010", "upgArmC006", "upgArmU005"],
+                ["upgHpU015", "upgHpU002", "upgDmgU002C", "upgDmgR007", "upgArmC004", "upgArmU009"],
+                ["upgHpU006", "upgHpU017", "upgDmgU011", "upgDmgU015C", "upgArmU003C", "upgArmU001"],
+                ["upgHpU015", "upgHpU002", "upgDmgU013C", "upgDmgR13C", "upgArmU008", "upgArmR003C"],
+                ["upgHpR018", "upgHpR004C", "upgDmgR021", "upgDmgU015C", "upgArmR005", "upgArmR007C"],
+                ["upgHpR021", "upgHpR017C", "upgDmgR002", "upgDmgR010C", "upgArmR012C", "upgArmR001C"],
+                ["upgHpE021C", "upgHpR020C", "upgDmgE002C", "upgDmgR012C", "upgArmR021", "upgArmR003C"],
+                ["upgHpR018", "upgHpE001C", "upgDmgE021C", "upgDmgR015C", "upgArmE021C", "upgArmE001C"],
+                ["upgHpE021C", "upgHpE002C", "upgDmgE021C", "upgDmgE004", "upgArmE021C", "upgArmE006C"],
+                ["upgHpE021C", "upgHpE003", "upgDmgL021C", "upgDmgE006C", "upgArmL021C", "upgArmE001C"],
+                ["upgHpL021C", "upgHpL002C", "upgDmgE021C", "upgDmgL015C", "upgArmE021C", "upgArmL006C"],
+                ["upgHpL121C", "upgHpL001C", "upgDmgL021C", "upgDmgL008C", "upgArmL021C", "upgArmL010C"],
+                ["upgHpL021C", "upgHpL001C", "upgDmgL121C", "upgDmgL008C", "upgArmL121C", "upgArmL006C"],
+                ["upgHpL121C", "upgHpL002C", "upgDmgL121C", "upgDmgL015C", "upgArmL121C", "upgArmL010C"],
+                ["upgHpL121C", "upgHpL002C", "upgDmgL121C", "upgDmgL006C", "upgArmL121C", "upgArmL004C"],
+                ["upgHpL121C", "upgHpL213C", "upgDmgL121C", "upgDmgL213C", "upgArmL121C", "upgArmL213C"],
+                ["upgHpL121C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpM121C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [14, 14, 3, 3, 3, 3],
+                [17, 17, 3, 5, 3, 5],
+                [22, 22, 5, 5, 3, 7],
+                [27, 27, 5, 7, 7, 5],
+                [34, 34, 7, 9, 5, 11],
+                [37, 49, 10, 10, 8, 11],
+                [45, 61, 10, 14, 13, 13],
+                [74, 60, 17, 13, 12, 17],
+                [63, 104, 21, 17, 19, 19],
+                [105, 105, 27, 21, 24, 24],
+                [146, 116, 32, 27, 32, 27],
+                [165, 165, 34, 41, 34, 41],
+                [205, 205, 47, 47, 47, 47],
+                [258, 258, 58, 58, 58, 58],
+                [322, 322, 74, 74, 74, 74],
+                [403, 403, 91, 91, 91, 91],
+                [506, 506, 115, 115, 115, 115],
+                [275, 275, 67, 58, 67, 58],
+                [296, 253, 67, 58, 67, 58],
+                [244, 305, 56, 69, 56, 69]
+            ]
+        },
+        "templHelbrecht": {
+            "name": "Helbrecht",
+            "FactionId": "BlackTemplars",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Legendary",
+            "powerMultiplier": 95,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 6,
+                    "DamageProfile": "Power"
+                },
+                {
+                    "hits": 3,
+                    "DamageProfile": "Bolter",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 95,
+                "Damage": 15,
+                "FixedArmor": 22,
+                "ProgressionIndex": 12
+            },
+            "traits": ["Hero", "FinalJustice", "Parry"],
+            "activeAbilities": ["CrusadeOfWrath"],
+            "passiveAbilities": ["DestroyTheWitch"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Block"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "campaign": {
+                    "campaignType": "Standard",
+                    "campaignId": "campaign3",
+                    "level": 75
+                }
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_templHelbrecht_01"],
+            "upgrades": [
+                ["upgHpC015", "upgHpC017", "upgDmgC013", "upgDmgC011", "upgArmC006", "upgArmC001"],
+                ["upgHpC015", "upgHpC003", "upgDmgC002", "upgDmgU010", "upgArmC013", "upgArmU009"],
+                ["upgHpC004", "upgHpU002", "upgDmgU002C", "upgDmgU003", "upgArmC006", "upgArmU013"],
+                ["upgHpU015", "upgHpU017", "upgDmgR007", "upgDmgU015C", "upgArmU003C", "upgArmU001"],
+                ["upgHpU006", "upgHpU002", "upgDmgU001C", "upgDmgR13C", "upgArmU008", "upgArmR003C"],
+                ["upgHpR018", "upgHpR015C", "upgDmgR021", "upgDmgU015C", "upgArmR005", "upgArmR013C"],
+                ["upgHpR021", "upgHpR017C", "upgDmgR002", "upgDmgR010C", "upgArmR012C", "upgArmR001C"],
+                ["upgHpE021C", "upgHpR020C", "upgDmgE002C", "upgDmgR012C", "upgArmR021", "upgArmR003C"],
+                ["upgHpR018", "upgHpE007C", "upgDmgE021C", "upgDmgR015C", "upgArmE021C", "upgArmE001C"],
+                ["upgHpE021C", "upgHpE002C", "upgDmgE021C", "upgDmgE003", "upgArmE021C", "upgArmE006C"],
+                ["upgHpE021C", "upgHpE003", "upgDmgL021C", "upgDmgE006C", "upgArmL021C", "upgArmE001C"],
+                ["upgHpL021C", "upgHpL002C", "upgDmgE021C", "upgDmgL015C", "upgArmE021C", "upgArmL006C"],
+                ["upgHpL121C", "upgHpL009C", "upgDmgL021C", "upgDmgL002C", "upgArmL021C", "upgArmL010C"],
+                ["upgHpL021C", "upgHpL009C", "upgDmgL121C", "upgDmgL008C", "upgArmL121C", "upgArmL006C"],
+                ["upgHpL121C", "upgHpL002C", "upgDmgL121C", "upgDmgL015C", "upgArmL121C", "upgArmL010C"],
+                ["upgHpL121C", "upgHpL017C", "upgDmgL121C", "upgDmgL006C", "upgArmL121C", "upgArmL004C"],
+                ["upgHpL121C", "upgHpL213C", "upgDmgL121C", "upgDmgL213C", "upgArmL121C", "upgArmL213C"],
+                ["upgHpL121C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpM121C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 2, 2, 3, 3],
+                [15, 15, 2, 3, 2, 4],
+                [12, 25, 3, 2, 3, 6],
+                [24, 24, 4, 4, 7, 4],
+                [29, 29, 4, 5, 5, 9],
+                [32, 42, 6, 6, 7, 10],
+                [39, 53, 6, 8, 11, 11],
+                [64, 52, 11, 8, 11, 15],
+                [54, 90, 12, 10, 17, 17],
+                [91, 91, 16, 13, 21, 21],
+                [126, 100, 20, 16, 28, 24],
+                [142, 142, 20, 25, 30, 35],
+                [177, 177, 28, 28, 42, 42],
+                [223, 223, 35, 35, 51, 51],
+                [278, 278, 44, 44, 64, 64],
+                [349, 349, 55, 55, 81, 81],
+                [436, 436, 69, 69, 101, 101],
+                [237, 237, 40, 34, 59, 51],
+                [256, 219, 40, 35, 59, 51],
+                [211, 263, 33, 42, 49, 61]
+            ]
+        },
+        "eldarRanger": {
+            "name": "Calandis",
+            "FactionId": "Aeldari",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Common",
+            "powerMultiplier": 127,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 1,
+                    "DamageProfile": "Physical"
+                },
+                {
+                    "hits": 1,
+                    "DamageProfile": "Energy",
+                    "Range": 3
+                }
+            ],
+            "stats": {
+                "Health": 70,
+                "Damage": 45,
+                "FixedArmor": 18,
+                "ProgressionIndex": 0
+            },
+            "traits": ["Hero", "HeavyWeapon", "Overwatch"],
+            "activeAbilities": ["FireAndReposition"],
+            "passiveAbilities": ["WireweaveNet"],
+            "itemSlots": ["I_Crit", "I_Crit", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_eldarRanger_01"],
+            "upgrades": [
+                ["upgHpC006", "upgHpC007", "upgDmgC007", "upgDmgC015", "upgArmC003", "upgArmC003"],
+                ["upgHpC015", "upgHpC008", "upgDmgC005", "upgDmgU009", "upgArmC004", "upgArmU013"],
+                ["upgHpC016", "upgHpU001", "upgDmgU007C", "upgDmgU009", "upgArmC013", "upgArmU013"],
+                ["upgHpU015", "upgHpU007", "upgDmgU012", "upgDmgU017C", "upgArmU003C", "upgArmU014"],
+                ["upgHpU015", "upgHpU001", "upgDmgU007C", "upgDmgR14C", "upgArmU006", "upgArmR013C"],
+                ["upgHpR004C", "upgHpR014", "upgDmgR028", "upgDmgU017C", "upgArmU002", "upgArmR013C"],
+                ["upgHpR028", "upgHpR006C", "upgDmgR008C", "upgDmgR004C", "upgArmR006", "upgArmR014C"],
+                ["upgHpE028C", "upgHpR003C", "upgDmgR008C", "upgDmgE007C", "upgArmR028", "upgArmE011C"],
+                ["upgHpR018", "upgHpE006C", "upgDmgE028C", "upgDmgR017C", "upgArmE028C", "upgArmE014C"],
+                ["upgHpE028C", "upgHpE014C", "upgDmgE028C", "upgDmgE004", "upgArmE028C", "upgArmE011C"],
+                ["upgHpE028C", "upgHpE012", "upgDmgL028C", "upgDmgE007C", "upgArmL028C", "upgArmE014C"],
+                ["upgHpL028C", "upgHpL014C", "upgDmgE028C", "upgDmgL017C", "upgArmE028C", "upgArmL011C"],
+                ["upgHpL128C", "upgHpL001C", "upgDmgL028C", "upgDmgL005C", "upgArmL028C", "upgArmL009C"],
+                ["upgHpL028C", "upgHpL001C", "upgDmgL128C", "upgDmgL005C", "upgArmL128C", "upgArmL011C"],
+                ["upgHpL128C", "upgHpL014C", "upgDmgL128C", "upgDmgL017C", "upgArmL128C", "upgArmL009C"],
+                ["upgHpL128C", "upgHpL017C", "upgDmgL128C", "upgDmgL005C", "upgArmL128C", "upgArmL003C"],
+                ["upgHpL128C", "upgHpL212C", "upgDmgL128C", "upgDmgL212C", "upgArmL128C", "upgArmL212C"],
+                ["upgHpL128C", "upgHpL212C", "upgDmgM213C", "upgDmgL212C", "upgArmM213C", "upgArmL212C"],
+                ["upgHpM128C", "upgHpL212C", "upgDmgM213C", "upgDmgL212C", "upgArmM213C", "upgArmL212C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [9, 9, 6, 6, 3, 3],
+                [11, 11, 5, 9, 1, 3],
+                [9, 18, 10, 7, 2, 5],
+                [18, 18, 9, 14, 5, 4],
+                [21, 21, 12, 15, 4, 7],
+                [31, 24, 18, 18, 5, 9],
+                [29, 39, 22, 22, 8, 10],
+                [47, 38, 24, 30, 8, 14],
+                [40, 66, 38, 30, 14, 14],
+                [67, 67, 48, 38, 17, 17],
+                [92, 74, 58, 49, 23, 19],
+                [105, 105, 61, 74, 25, 29],
+                [131, 131, 84, 84, 34, 34],
+                [164, 164, 105, 105, 42, 42],
+                [205, 205, 132, 132, 53, 53],
+                [256, 256, 165, 165, 66, 66],
+                [322, 322, 207, 207, 82, 82],
+                [175, 175, 121, 103, 48, 42],
+                [188, 161, 121, 104, 48, 42],
+                [156, 194, 100, 125, 40, 50]
+            ]
+        },
+        "eldarAutarch": {
+            "name": "Aethana",
+            "FactionId": "Aeldari",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Uncommon",
+            "Movement": 5,
+            "weapons": [
+                {
+                    "hits": 3,
+                    "DamageProfile": "Piercing"
+                }
+            ],
+            "stats": {
+                "Health": 80,
+                "Damage": 14,
+                "FixedArmor": 17,
+                "ProgressionIndex": 3
+            },
+            "traits": ["Hero", "Flying", "TeleportStrike"],
+            "activeAbilities": ["Loki_SwoopingHawk"],
+            "passiveAbilities": ["PathOfCommand"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Block"],
+            "itemSlotsRelic": [2],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_eldarAutarch_01"],
+            "upgrades": [
+                ["upgHpC015", "upgHpC017", "upgDmgC009", "upgDmgC015", "upgArmC004", "upgArmC004"],
+                ["upgHpC016", "upgHpC008", "upgDmgC013", "upgDmgU009", "upgArmC013", "upgArmU013"],
+                ["upgHpC006", "upgHpU017", "upgDmgU013C", "upgDmgU009", "upgArmC013", "upgArmU014"],
+                ["upgHpU015", "upgHpU007", "upgDmgU012", "upgDmgU017C", "upgArmU003C", "upgArmU014"],
+                ["upgHpU016", "upgHpU012", "upgDmgU013C", "upgDmgR14C", "upgArmU006", "upgArmR013C"],
+                ["upgHpR004C", "upgHpR014", "upgDmgR028", "upgDmgU017C", "upgArmU006", "upgArmR013C"],
+                ["upgHpR028", "upgHpR017C", "upgDmgR006", "upgDmgR004C", "upgArmR012C", "upgArmR014C"],
+                ["upgHpE028C", "upgHpR017C", "upgDmgR011C", "upgDmgE007C", "upgArmR028", "upgArmR013C"],
+                ["upgHpR018", "upgHpE007C", "upgDmgE028C", "upgDmgR017C", "upgArmE028C", "upgArmE014C"],
+                ["upgHpE028C", "upgHpE014C", "upgDmgE028C", "upgDmgE004", "upgArmE028C", "upgArmE011C"],
+                ["upgHpE028C", "upgHpE012", "upgDmgL028C", "upgDmgE007C", "upgArmL028C", "upgArmE014C"],
+                ["upgHpL028C", "upgHpL014C", "upgDmgE028C", "upgDmgL017C", "upgArmE028C", "upgArmL011C"],
+                ["upgHpL128C", "upgHpL001C", "upgDmgL028C", "upgDmgL008C", "upgArmL028C", "upgArmL009C"],
+                ["upgHpL028C", "upgHpL001C", "upgDmgL128C", "upgDmgL008C", "upgArmL128C", "upgArmL011C"],
+                ["upgHpL128C", "upgHpL014C", "upgDmgL128C", "upgDmgL017C", "upgArmL128C", "upgArmL009C"],
+                ["upgHpL128C", "upgHpL017C", "upgDmgL128C", "upgDmgL005C", "upgArmL128C", "upgArmL003C"],
+                ["upgHpL128C", "upgHpL212C", "upgDmgL128C", "upgDmgL212C", "upgArmL128C", "upgArmL212C"],
+                ["upgHpL128C", "upgHpL212C", "upgDmgM214C", "upgDmgL212C", "upgArmM214C", "upgArmL212C"],
+                ["upgHpM128C", "upgHpL212C", "upgDmgM214C", "upgDmgL212C", "upgArmM214C", "upgArmL212C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [10, 10, 2, 2, 2, 2],
+                [13, 13, 1, 3, 2, 4],
+                [10, 21, 3, 2, 2, 4],
+                [20, 20, 3, 4, 5, 4],
+                [25, 25, 4, 5, 3, 7],
+                [35, 26, 6, 6, 4, 9],
+                [33, 45, 6, 7, 9, 9],
+                [54, 43, 8, 9, 9, 11],
+                [46, 76, 12, 9, 13, 13],
+                [76, 76, 14, 12, 16, 16],
+                [106, 85, 19, 15, 22, 18],
+                [120, 120, 19, 23, 23, 28],
+                [149, 149, 26, 26, 32, 32],
+                [187, 187, 33, 33, 40, 40],
+                [235, 235, 41, 41, 50, 50],
+                [293, 293, 51, 51, 62, 62],
+                [368, 368, 65, 65, 78, 78],
+                [200, 200, 37, 32, 46, 39],
+                [215, 184, 38, 32, 46, 39],
+                [177, 222, 31, 39, 38, 47]
+            ]
+        },
+        "eldarFarseer": {
+            "name": "Eldryon",
+            "FactionId": "Aeldari",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Rare",
+            "powerMultiplier": 99,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 2,
+                    "DamageProfile": "Piercing"
+                },
+                {
+                    "hits": 2,
+                    "DamageProfile": "Psychic",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 75,
+                "Damage": 16,
+                "FixedArmor": 16,
+                "ProgressionIndex": 6
+            },
+            "traits": ["Hero", "Psyker"],
+            "activeAbilities": ["Executioner"],
+            "passiveAbilities": ["Doom"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Block"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_eldarFarseer_01"],
+            "upgrades": [
+                ["upgHpC017", "upgHpC007", "upgDmgC009", "upgDmgC015", "upgArmC004", "upgArmC004"],
+                ["upgHpC016", "upgHpC008", "upgDmgC013", "upgDmgU010", "upgArmC013", "upgArmU013"],
+                ["upgHpC016", "upgHpU015", "upgDmgU013C", "upgDmgU010", "upgArmC013", "upgArmU014"],
+                ["upgHpU016", "upgHpU007", "upgDmgU004", "upgDmgU017C", "upgArmU003C", "upgArmU014"],
+                ["upgHpU016", "upgHpU015", "upgDmgU013C", "upgDmgR14C", "upgArmU006", "upgArmR013C"],
+                ["upgHpR017C", "upgHpR014", "upgDmgR028", "upgDmgU017C", "upgArmU006", "upgArmR013C"],
+                ["upgHpR028", "upgHpR006C", "upgDmgR005", "upgDmgR010C", "upgArmR012C", "upgArmR014C"],
+                ["upgHpE028C", "upgHpR006C", "upgDmgR011C", "upgDmgE006C", "upgArmR028", "upgArmR013C"],
+                ["upgHpR018", "upgHpE006C", "upgDmgE028C", "upgDmgR017C", "upgArmE028C", "upgArmE014C"],
+                ["upgHpE028C", "upgHpE014C", "upgDmgE028C", "upgDmgE004", "upgArmE028C", "upgArmE011C"],
+                ["upgHpE028C", "upgHpE012", "upgDmgL028C", "upgDmgE006C", "upgArmL028C", "upgArmE014C"],
+                ["upgHpL028C", "upgHpL014C", "upgDmgE028C", "upgDmgL017C", "upgArmE028C", "upgArmL011C"],
+                ["upgHpL128C", "upgHpL011C", "upgDmgL028C", "upgDmgL005C", "upgArmL028C", "upgArmL009C"],
+                ["upgHpL028C", "upgHpL011C", "upgDmgL128C", "upgDmgL005C", "upgArmL128C", "upgArmL011C"],
+                ["upgHpL128C", "upgHpL014C", "upgDmgL128C", "upgDmgL017C", "upgArmL128C", "upgArmL009C"],
+                ["upgHpL128C", "upgHpL011C", "upgDmgL128C", "upgDmgL006C", "upgArmL128C", "upgArmL003C"],
+                ["upgHpL128C", "upgHpL212C", "upgDmgL128C", "upgDmgL212C", "upgArmL128C", "upgArmL212C"],
+                ["upgHpL128C", "upgHpL212C", "upgDmgM214C", "upgDmgL212C", "upgArmM213C", "upgArmL212C"],
+                ["upgHpM128C", "upgHpL212C", "upgDmgM214C", "upgDmgL212C", "upgArmM213C", "upgArmL212C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [10, 10, 2, 2, 2, 2],
+                [12, 12, 2, 3, 2, 3],
+                [9, 19, 4, 2, 2, 4],
+                [19, 19, 3, 5, 5, 3],
+                [23, 23, 4, 6, 3, 7],
+                [33, 25, 7, 7, 4, 9],
+                [31, 42, 6, 8, 8, 8],
+                [51, 40, 9, 11, 8, 11],
+                [43, 71, 13, 11, 12, 12],
+                [72, 72, 17, 13, 15, 15],
+                [99, 79, 21, 18, 21, 18],
+                [112, 112, 21, 26, 21, 26],
+                [140, 140, 30, 30, 30, 30],
+                [176, 176, 38, 38, 38, 38],
+                [219, 219, 47, 47, 47, 47],
+                [276, 276, 58, 58, 58, 58],
+                [344, 344, 74, 74, 74, 74],
+                [187, 187, 43, 36, 43, 36],
+                [202, 173, 43, 37, 43, 37],
+                [167, 208, 36, 44, 36, 44]
+            ]
+        },
+        "eldarMauganRa": {
+            "name": "Maugan Ra",
+            "FactionId": "Aeldari",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Legendary",
+            "powerMultiplier": 66,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 5,
+                    "DamageProfile": "Power"
+                },
+                {
+                    "hits": 6,
+                    "DamageProfile": "HeavyRound",
+                    "Range": 3
+                }
+            ],
+            "stats": {
+                "Health": 70,
+                "Damage": 9,
+                "FixedArmor": 22,
+                "ProgressionIndex": 12
+            },
+            "traits": ["Hero", "Terrifying", "HeavyWeapon", "Overwatch"],
+            "activeAbilities": ["HarvesterOfSouls"],
+            "passiveAbilities": ["InescapableAccuracy"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Block"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "timestampIfHeroUnlocked": 1688947200000,
+                "timestampIfHeroNotUnlocked": 1691884800000
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_eldarMauganRa_01"],
+            "eventMetadata": {
+                "leg": {
+                    "finalEventEndDate": 1688947200000
+                }
+            },
+            "upgrades": [
+                ["upgHpC015", "upgHpC014", "upgDmgC009", "upgDmgC015", "upgArmC004", "upgArmC004"],
+                ["upgHpC017", "upgHpC008", "upgDmgC005", "upgDmgU009", "upgArmC013", "upgArmU013"],
+                ["upgHpC015", "upgHpU013", "upgDmgU013C", "upgDmgU009", "upgArmC013", "upgArmU014"],
+                ["upgHpU017", "upgHpU007", "upgDmgU012", "upgDmgU017C", "upgArmU003C", "upgArmU014"],
+                ["upgHpU015", "upgHpU013", "upgDmgU013C", "upgDmgR14C", "upgArmU006", "upgArmR013C"],
+                ["upgHpR017C", "upgHpR002", "upgDmgR028", "upgDmgU017C", "upgArmU006", "upgArmR013C"],
+                ["upgHpR028", "upgHpR015C", "upgDmgR006", "upgDmgR004C", "upgArmR012C", "upgArmR014C"],
+                ["upgHpE028C", "upgHpR015C", "upgDmgR011C", "upgDmgE007C", "upgArmR028", "upgArmR013C"],
+                ["upgHpR018", "upgHpE013C", "upgDmgE028C", "upgDmgR017C", "upgArmE028C", "upgArmE014C"],
+                ["upgHpE028C", "upgHpE014C", "upgDmgE028C", "upgDmgE004", "upgArmE028C", "upgArmE011C"],
+                ["upgHpE028C", "upgHpE012", "upgDmgL028C", "upgDmgE007C", "upgArmL028C", "upgArmE014C"],
+                ["upgHpL028C", "upgHpL014C", "upgDmgE028C", "upgDmgL017C", "upgArmE028C", "upgArmL011C"],
+                ["upgHpL128C", "upgHpL013C", "upgDmgL028C", "upgDmgL007C", "upgArmL028C", "upgArmL009C"],
+                ["upgHpL028C", "upgHpL013C", "upgDmgL128C", "upgDmgL007C", "upgArmL128C", "upgArmL003C"],
+                ["upgHpL128C", "upgHpL014C", "upgDmgL128C", "upgDmgL017C", "upgArmL128C", "upgArmL009C"],
+                ["upgHpL128C", "upgHpL017C", "upgDmgL128C", "upgDmgL005C", "upgArmL128C", "upgArmL003C"],
+                ["upgHpL128C", "upgHpL212C", "upgDmgL128C", "upgDmgL212C", "upgArmL128C", "upgArmL212C"],
+                ["upgHpL128C", "upgHpL212C", "upgDmgM213C", "upgDmgL212C", "upgArmM214C", "upgArmL212C"],
+                ["upgHpM128C", "upgHpL212C", "upgDmgM213C", "upgDmgL212C", "upgArmM214C", "upgArmL212C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [9, 9, 1, 1, 3, 3],
+                [11, 11, 1, 2, 2, 4],
+                [9, 18, 2, 2, 3, 6],
+                [18, 18, 2, 2, 7, 4],
+                [21, 21, 3, 3, 5, 9],
+                [31, 24, 4, 4, 6, 11],
+                [29, 39, 3, 4, 11, 11],
+                [47, 38, 5, 6, 11, 15],
+                [40, 66, 8, 6, 17, 17],
+                [67, 67, 9, 8, 21, 21],
+                [92, 74, 12, 10, 28, 24],
+                [105, 105, 12, 15, 30, 35],
+                [131, 131, 17, 17, 42, 42],
+                [164, 164, 21, 21, 51, 51],
+                [205, 205, 26, 26, 64, 64],
+                [256, 256, 33, 33, 81, 81],
+                [322, 322, 42, 42, 101, 101],
+                [175, 175, 24, 20, 59, 51],
+                [188, 161, 24, 21, 59, 51],
+                [156, 194, 20, 25, 49, 61]
+            ]
+        },
+        "eldarJainZar": {
+            "name": "Jain Zar",
+            "FactionId": "Aeldari",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Legendary",
+            "powerMultiplier": 105,
+            "Movement": 4,
+            "weapons": [
+                {
+                    "hits": 3,
+                    "DamageProfile": "Piercing"
+                }
+            ],
+            "stats": {
+                "Health": 75,
+                "Damage": 19,
+                "FixedArmor": 18,
+                "ProgressionIndex": 12
+            },
+            "traits": ["Hero", "Infiltrate"],
+            "activeAbilities": ["SilentDeath"],
+            "passiveAbilities": ["TerrorsLament"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Block"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "timestampIfHeroUnlocked": 1694995200000,
+                "timestampIfHeroNotUnlocked": 1697932800000
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_eldarJainZar_01"],
+            "eventMetadata": {
+                "leg": {
+                    "finalEventEndDate": 1694995200000
+                }
+            },
+            "upgrades": [
+                ["upgHpC015", "upgHpC006", "upgDmgC009", "upgDmgC015", "upgArmC004", "upgArmC004"],
+                ["upgHpC015", "upgHpC008", "upgDmgC013", "upgDmgU010", "upgArmC012", "upgArmU013"],
+                ["upgHpC015", "upgHpU012", "upgDmgU013C", "upgDmgU014", "upgArmC012", "upgArmU014"],
+                ["upgHpU017", "upgHpU007", "upgDmgU012", "upgDmgU017C", "upgArmU003C", "upgArmU014"],
+                ["upgHpU017", "upgHpU012", "upgDmgU013C", "upgDmgR14C", "upgArmU006", "upgArmR013C"],
+                ["upgHpR017C", "upgHpR014", "upgDmgR028", "upgDmgU017C", "upgArmU006", "upgArmR013C"],
+                ["upgHpR028", "upgHpR004C", "upgDmgR006", "upgDmgR010C", "upgArmR012C", "upgArmR014C"],
+                ["upgHpE028C", "upgHpR004C", "upgDmgR011C", "upgDmgE009C", "upgArmR028", "upgArmR013C"],
+                ["upgHpR018", "upgHpE007C", "upgDmgE028C", "upgDmgR017C", "upgArmE028C", "upgArmE014C"],
+                ["upgHpE028C", "upgHpE014C", "upgDmgE028C", "upgDmgE004", "upgArmE028C", "upgArmE011C"],
+                ["upgHpE028C", "upgHpE012", "upgDmgL028C", "upgDmgE006C", "upgArmL028C", "upgArmE014C"],
+                ["upgHpL028C", "upgHpL014C", "upgDmgE028C", "upgDmgL017C", "upgArmE028C", "upgArmL003C"],
+                ["upgHpL128C", "upgHpL009C", "upgDmgL028C", "upgDmgL008C", "upgArmL028C", "upgArmL011C"],
+                ["upgHpL028C", "upgHpL009C", "upgDmgL128C", "upgDmgL008C", "upgArmL128C", "upgArmL003C"],
+                ["upgHpL128C", "upgHpL014C", "upgDmgL128C", "upgDmgL017C", "upgArmL128C", "upgArmL009C"],
+                ["upgHpL128C", "upgHpL017C", "upgDmgL128C", "upgDmgL009C", "upgArmL128C", "upgArmL003C"],
+                ["upgHpL128C", "upgHpL212C", "upgDmgL128C", "upgDmgL212C", "upgArmL128C", "upgArmL212C"],
+                ["upgHpL128C", "upgHpL212C", "upgDmgM213C", "upgDmgL212C", "upgArmM214C", "upgArmL212C"],
+                ["upgHpM128C", "upgHpL212C", "upgDmgM213C", "upgDmgL212C", "upgArmM214C", "upgArmL212C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [10, 10, 3, 3, 3, 3],
+                [12, 12, 2, 3, 1, 3],
+                [9, 19, 4, 3, 2, 5],
+                [19, 19, 4, 6, 5, 4],
+                [23, 23, 5, 6, 4, 7],
+                [33, 25, 8, 8, 5, 9],
+                [31, 42, 8, 10, 9, 9],
+                [51, 40, 10, 13, 9, 13],
+                [43, 71, 16, 13, 14, 14],
+                [72, 72, 20, 16, 17, 17],
+                [99, 79, 25, 20, 23, 19],
+                [112, 112, 26, 31, 25, 29],
+                [140, 140, 36, 36, 34, 34],
+                [176, 176, 44, 44, 42, 42],
+                [219, 219, 56, 56, 53, 53],
+                [276, 276, 70, 70, 66, 66],
+                [344, 344, 87, 87, 82, 82],
+                [187, 187, 51, 43, 48, 42],
+                [202, 173, 51, 44, 48, 42],
+                [167, 208, 42, 53, 40, 50]
+            ]
+        },
+        "eldarLhykhis": {
+            "name": "Lhykhis",
+            "FactionId": "Aeldari",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Legendary",
+            "powerMultiplier": 71,
+            "Movement": 4,
+            "weapons": [
+                {
+                    "hits": 5,
+                    "DamageProfile": "Gauss"
+                },
+                {
+                    "hits": 5,
+                    "DamageProfile": "Eviscerate",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 75,
+                "Damage": 12,
+                "FixedArmor": 22,
+                "ProgressionIndex": 12
+            },
+            "traits": ["Hero", "Infiltrate", "Flying"],
+            "activeAbilities": ["EmpyricAmbush"],
+            "passiveAbilities": ["WhisperingWeb"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "timestampIfHeroUnlocked": 1792454400000,
+                "timestampIfHeroNotUnlocked": 1798502400000
+            },
+            "releaseStatus": "1785974400000",
+            "unlockQuestIds": ["hero_eldarLhykhis_01"],
+            "upgrades": [
+                ["upgHpC002", "upgHpC002", "upgDmgC009", "upgDmgC015", "upgArmC005", "upgArmC013"],
+                ["upgHpC014", "upgHpC015", "upgDmgU012", "upgDmgU017C", "upgArmC013", "upgArmC011"],
+                ["upgHpU014", "upgHpU018C", "upgDmgC008", "upgDmgC010", "upgArmU006", "upgArmU009"],
+                ["upgHpU004C", "upgHpU017", "upgDmgU012", "upgDmgU010", "upgArmU009", "upgArmU004C"],
+                ["upgHpU014", "upgHpR017C", "upgDmgU008C", "upgDmgU004", "upgArmR005", "upgArmU014"],
+                ["upgHpR012C", "upgHpU007", "upgDmgR028", "upgDmgR010C", "upgArmU004C", "upgArmR010"],
+                ["upgHpR028", "upgHpR014", "upgDmgR14C", "upgDmgR005", "upgArmR002C", "upgArmR012C"],
+                ["upgHpE028C", "upgHpR013C", "upgDmgR005", "upgDmgE006C", "upgArmR028", "upgArmR014C"],
+                ["upgHpR014", "upgHpE007C", "upgDmgE028C", "upgDmgR017C", "upgArmE028C", "upgArmE008"],
+                ["upgHpE028C", "upgHpE017", "upgDmgE028C", "upgDmgE011", "upgArmE028C", "upgArmE003C"],
+                ["upgHpL108", "upgHpE014C", "upgDmgL028C", "upgDmgE006C", "upgArmE028C", "upgArmE006C"],
+                ["upgHpE028C", "upgHpL017C", "upgDmgE028C", "upgDmgL017C", "upgArmL202", "upgArmL003C"],
+                ["upgHpL028C", "upgHpL009C", "upgDmgL003", "upgDmgL005C", "upgArmL028C", "upgArmL006C"],
+                ["upgHpL128C", "upgHpL014C", "upgDmgL028C", "upgDmgL017C", "upgArmL028C", "upgArmL009C"],
+                ["upgHpL028C", "upgHpL001C", "upgDmgL128C", "upgDmgL010C", "upgArmL128C", "upgArmL006C"],
+                ["upgHpL128C", "upgHpL013C", "upgDmgL128C", "upgDmgL006C", "upgArmL128C", "upgArmL003C"],
+                ["upgHpL128C", "upgHpL212C", "upgDmgL128C", "upgDmgL212C", "upgArmL128C", "upgArmL212C"],
+                ["upgHpL128C", "upgHpL212C", "upgDmgM213C", "upgDmgL212C", "upgArmM213C", "upgArmL212C"],
+                ["upgHpM128C", "upgHpL212C", "upgDmgM213C", "upgDmgL212C", "upgArmM214C", "upgArmL212C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [10, 10, 2, 2, 3, 3],
+                [12, 12, 1, 2, 3, 3],
+                [11, 17, 3, 3, 5, 5],
+                [22, 15, 2, 2, 4, 6],
+                [16, 31, 5, 3, 8, 6],
+                [39, 19, 4, 5, 9, 9],
+                [37, 37, 7, 5, 10, 10],
+                [50, 40, 5, 9, 12, 15],
+                [43, 71, 11, 8, 18, 15],
+                [79, 64, 13, 10, 21, 21],
+                [90, 90, 15, 13, 27, 27],
+                [101, 122, 16, 20, 29, 35],
+                [140, 140, 20, 25, 42, 42],
+                [176, 176, 28, 28, 51, 51],
+                [219, 219, 35, 35, 64, 64],
+                [276, 276, 44, 44, 81, 81],
+                [344, 344, 56, 56, 101, 101],
+                [187, 187, 32, 27, 59, 51],
+                [202, 173, 32, 28, 59, 51],
+                [167, 208, 27, 33, 49, 61]
+            ]
+        },
+        "tauMarksman": {
+            "name": "Sho'syl",
+            "FactionId": "Tau",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Uncommon",
+            "powerMultiplier": 107,
+            "Movement": 2,
+            "weapons": [
+                {
+                    "hits": 1,
+                    "DamageProfile": "Pulse"
+                },
+                {
+                    "hits": 1,
+                    "DamageProfile": "Piercing",
+                    "Range": 3
+                }
+            ],
+            "stats": {
+                "Health": 65,
+                "Damage": 40,
+                "FixedArmor": 16,
+                "ProgressionIndex": 3
+            },
+            "traits": ["Hero", "Camouflage", "RangedSpecialist"],
+            "activeAbilities": ["SeekerMissileFrequencyLock"],
+            "passiveAbilities": ["MV71SniperDroneSquad"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_tauMarksman_01"],
+            "upgrades": [
+                ["upgHpC017", "upgHpC001", "upgDmgC007", "upgDmgC015", "upgArmC004", "upgArmC005"],
+                ["upgHpC014", "upgHpC008", "upgDmgC005", "upgDmgU012", "upgArmC012", "upgArmU002"],
+                ["upgHpC014", "upgHpU001", "upgDmgU007C", "upgDmgU012", "upgArmC012", "upgArmU014"],
+                ["upgHpU017", "upgHpU007", "upgDmgU004", "upgDmgU017C", "upgArmU003C", "upgArmU014"],
+                ["upgHpU014", "upgHpU013", "upgDmgU007C", "upgDmgR13C", "upgArmU006", "upgArmR002C"],
+                ["upgHpR012C", "upgHpR014", "upgDmgR027", "upgDmgU017C", "upgArmU006", "upgArmR002C"],
+                ["upgHpR027", "upgHpR003C", "upgDmgR006", "upgDmgR011C", "upgArmR007C", "upgArmR014C"],
+                ["upgHpE027C", "upgHpR003C", "upgDmgR008C", "upgDmgE008C", "upgArmR027", "upgArmR002C"],
+                ["upgHpR018", "upgHpE013C", "upgDmgE027C", "upgDmgR017C", "upgArmE027C", "upgArmE014C"],
+                ["upgHpE027C", "upgHpE014C", "upgDmgE027C", "upgDmgE004", "upgArmE027C", "upgArmE003C"],
+                ["upgHpE027C", "upgHpE013C", "upgDmgL027C", "upgDmgE004", "upgArmL027C", "upgArmE014C"],
+                ["upgHpL027C", "upgHpL014C", "upgDmgE027C", "upgDmgL017C", "upgArmE027C", "upgArmL003C"],
+                ["upgHpL127C", "upgHpL013C", "upgDmgL027C", "upgDmgL006C", "upgArmL027C", "upgArmL009C"],
+                ["upgHpL027C", "upgHpL013C", "upgDmgL127C", "upgDmgL006C", "upgArmL127C", "upgArmL003C"],
+                ["upgHpL127C", "upgHpL014C", "upgDmgL127C", "upgDmgL017C", "upgArmL127C", "upgArmL009C"],
+                ["upgHpL127C", "upgHpL017C", "upgDmgL127C", "upgDmgL006C", "upgArmL127C", "upgArmL003C"],
+                ["upgHpL127C", "upgHpL214C", "upgDmgL127C", "upgDmgL214C", "upgArmL127C", "upgArmL214C"],
+                ["upgHpL127C", "upgHpL214C", "upgDmgM214C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpM127C", "upgHpL214C", "upgDmgM214C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [8, 8, 5, 5, 2, 2],
+                [11, 11, 4, 9, 2, 3],
+                [8, 17, 10, 6, 2, 4],
+                [16, 16, 8, 11, 5, 3],
+                [20, 20, 11, 14, 3, 7],
+                [29, 21, 16, 16, 4, 9],
+                [27, 36, 16, 22, 8, 8],
+                [44, 35, 21, 27, 8, 11],
+                [37, 62, 34, 27, 12, 12],
+                [62, 62, 43, 34, 15, 15],
+                [78, 78, 57, 38, 21, 18],
+                [97, 97, 54, 65, 21, 26],
+                [121, 121, 75, 75, 30, 30],
+                [152, 152, 94, 94, 38, 38],
+                [191, 191, 117, 117, 47, 47],
+                [238, 238, 147, 147, 58, 58],
+                [299, 299, 183, 183, 74, 74],
+                [162, 162, 108, 92, 43, 36],
+                [175, 150, 108, 92, 43, 37],
+                [144, 181, 89, 111, 36, 44]
+            ]
+        },
+        "tauCrisis": {
+            "name": "Re'vas",
+            "FactionId": "Tau",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Uncommon",
+            "powerMultiplier": 95,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 6,
+                    "DamageProfile": "Flame"
+                },
+                {
+                    "hits": 6,
+                    "DamageProfile": "Pulse",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 105,
+                "Damage": 7,
+                "FixedArmor": 25,
+                "ProgressionIndex": 3
+            },
+            "traits": ["Hero", "BigTarget", "Flying", "Mechanical", "RangedSpecialist"],
+            "activeAbilities": ["EarlyWarningOverride"],
+            "passiveAbilities": ["CyclicIonBlaster"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Block"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_tauCrisis_01"],
+            "upgrades": [
+                ["upgHpC017", "upgHpC017", "upgDmgC009", "upgDmgC015", "upgArmC004", "upgArmC005"],
+                ["upgHpC014", "upgHpC008", "upgDmgC003", "upgDmgU012", "upgArmC012", "upgArmU002"],
+                ["upgHpC014", "upgHpU017", "upgDmgU013C", "upgDmgU004", "upgArmC012", "upgArmU014"],
+                ["upgHpU014", "upgHpU007", "upgDmgU003", "upgDmgU017C", "upgArmU003C", "upgArmU014"],
+                ["upgHpU014", "upgHpU013", "upgDmgU013C", "upgDmgR13C", "upgArmU006", "upgArmR002C"],
+                ["upgHpR012C", "upgHpR014", "upgDmgR027", "upgDmgU017C", "upgArmU006", "upgArmR002C"],
+                ["upgHpR027", "upgHpR017C", "upgDmgR003", "upgDmgR011C", "upgArmR007C", "upgArmR014C"],
+                ["upgHpE027C", "upgHpR017C", "upgDmgR004C", "upgDmgE007C", "upgArmR027", "upgArmR002C"],
+                ["upgHpR018", "upgHpE013C", "upgDmgE027C", "upgDmgR017C", "upgArmE027C", "upgArmE014C"],
+                ["upgHpE027C", "upgHpE014C", "upgDmgE027C", "upgDmgE004", "upgArmE027C", "upgArmE003C"],
+                ["upgHpE027C", "upgHpE013C", "upgDmgL027C", "upgDmgE004", "upgArmL027C", "upgArmE014C"],
+                ["upgHpL027C", "upgHpL014C", "upgDmgE027C", "upgDmgL017C", "upgArmE027C", "upgArmL003C"],
+                ["upgHpL127C", "upgHpL013C", "upgDmgL027C", "upgDmgL006C", "upgArmL027C", "upgArmL009C"],
+                ["upgHpL027C", "upgHpL013C", "upgDmgL127C", "upgDmgL006C", "upgArmL127C", "upgArmL003C"],
+                ["upgHpL127C", "upgHpL014C", "upgDmgL127C", "upgDmgL017C", "upgArmL127C", "upgArmL009C"],
+                ["upgHpL127C", "upgHpL013C", "upgDmgL127C", "upgDmgL002C", "upgArmL127C", "upgArmL003C"],
+                ["upgHpL127C", "upgHpL214C", "upgDmgL127C", "upgDmgL214C", "upgArmL127C", "upgArmL214C"],
+                ["upgHpL127C", "upgHpL214C", "upgDmgM214C", "upgDmgL214C", "upgArmM213C", "upgArmL214C"],
+                ["upgHpM127C", "upgHpL214C", "upgDmgM214C", "upgDmgL214C", "upgArmM213C", "upgArmL214C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [13, 13, 1, 1, 3, 3],
+                [17, 17, 1, 1, 3, 5],
+                [14, 27, 2, 1, 3, 7],
+                [26, 26, 1, 2, 7, 5],
+                [33, 33, 2, 3, 5, 11],
+                [46, 34, 3, 3, 6, 13],
+                [44, 58, 3, 3, 13, 13],
+                [71, 57, 4, 4, 12, 17],
+                [60, 100, 6, 5, 19, 19],
+                [100, 100, 7, 6, 24, 24],
+                [125, 125, 10, 7, 32, 27],
+                [157, 157, 10, 11, 34, 41],
+                [196, 196, 13, 13, 47, 47],
+                [246, 246, 17, 17, 58, 58],
+                [308, 308, 20, 20, 74, 74],
+                [385, 385, 26, 26, 91, 91],
+                [482, 482, 32, 32, 115, 115],
+                [262, 262, 18, 16, 67, 58],
+                [283, 242, 19, 16, 67, 58],
+                [233, 292, 16, 19, 56, 69]
+            ]
+        },
+        "tauDarkstrider": {
+            "name": "Darkstrider",
+            "FactionId": "Tau",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Rare",
+            "powerMultiplier": 89,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 3,
+                    "DamageProfile": "Physical"
+                },
+                {
+                    "hits": 4,
+                    "DamageProfile": "Pulse",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 75,
+                "Damage": 25,
+                "FixedArmor": 17,
+                "ProgressionIndex": 6
+            },
+            "traits": ["Hero", "Infiltrate", "RangedSpecialist", "SuppressiveFire"],
+            "activeAbilities": ["FightingRetreat"],
+            "passiveAbilities": ["StructuralAnalyser"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_tauDarkstrider_01"],
+            "upgrades": [
+                ["upgHpC001", "upgHpC017", "upgDmgC007", "upgDmgC015", "upgArmC004", "upgArmC005"],
+                ["upgHpC006", "upgHpC008", "upgDmgC005", "upgDmgU012", "upgArmC003", "upgArmU002"],
+                ["upgHpC006", "upgHpU017", "upgDmgU007C", "upgDmgU012", "upgArmC003", "upgArmU014"],
+                ["upgHpU001", "upgHpU007", "upgDmgU004", "upgDmgU017C", "upgArmU003C", "upgArmU014"],
+                ["upgHpU015", "upgHpU017", "upgDmgU007C", "upgDmgR13C", "upgArmU006", "upgArmR002C"],
+                ["upgHpR003C", "upgHpR014", "upgDmgR027", "upgDmgU017C", "upgArmU006", "upgArmR002C"],
+                ["upgHpR027", "upgHpR017C", "upgDmgR006", "upgDmgR011C", "upgArmR007C", "upgArmR014C"],
+                ["upgHpE027C", "upgHpR017C", "upgDmgR008C", "upgDmgR011C", "upgArmR027", "upgArmR002C"],
+                ["upgHpR018", "upgHpE006C", "upgDmgE027C", "upgDmgR017C", "upgArmE027C", "upgArmE014C"],
+                ["upgHpE027C", "upgHpE014C", "upgDmgE027C", "upgDmgE004", "upgArmE027C", "upgArmE003C"],
+                ["upgHpE027C", "upgHpE001C", "upgDmgL027C", "upgDmgE004", "upgArmL027C", "upgArmE014C"],
+                ["upgHpL027C", "upgHpL014C", "upgDmgE027C", "upgDmgL017C", "upgArmE027C", "upgArmL003C"],
+                ["upgHpL127C", "upgHpL001C", "upgDmgL027C", "upgDmgL006C", "upgArmL027C", "upgArmL009C"],
+                ["upgHpL027C", "upgHpL001C", "upgDmgL127C", "upgDmgL006C", "upgArmL127C", "upgArmL003C"],
+                ["upgHpL127C", "upgHpL014C", "upgDmgL127C", "upgDmgL017C", "upgArmL127C", "upgArmL009C"],
+                ["upgHpL127C", "upgHpL017C", "upgDmgL127C", "upgDmgL006C", "upgArmL127C", "upgArmL003C"],
+                ["upgHpL127C", "upgHpL213C", "upgDmgL127C", "upgDmgL213C", "upgArmL127C", "upgArmL213C"],
+                ["upgHpL127C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM213C", "upgArmL213C"],
+                ["upgHpM127C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM213C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [10, 10, 3, 3, 2, 2],
+                [12, 12, 3, 5, 2, 4],
+                [9, 19, 6, 4, 2, 4],
+                [19, 19, 5, 7, 5, 4],
+                [23, 23, 7, 9, 3, 7],
+                [33, 25, 10, 10, 4, 9],
+                [31, 42, 10, 14, 9, 9],
+                [51, 40, 15, 15, 9, 11],
+                [43, 71, 21, 17, 13, 13],
+                [72, 72, 27, 21, 16, 16],
+                [89, 89, 35, 24, 22, 18],
+                [112, 112, 34, 41, 23, 28],
+                [140, 140, 47, 47, 32, 32],
+                [176, 176, 58, 58, 40, 40],
+                [219, 219, 74, 74, 50, 50],
+                [276, 276, 91, 91, 62, 62],
+                [344, 344, 115, 115, 78, 78],
+                [187, 187, 67, 58, 46, 39],
+                [202, 173, 67, 58, 46, 39],
+                [167, 208, 56, 69, 38, 47]
+            ]
+        },
+        "tauAunShi": {
+            "name": "Aun'Shi",
+            "FactionId": "Tau",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Legendary",
+            "powerMultiplier": 117,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 5,
+                    "DamageProfile": "Power"
+                }
+            ],
+            "stats": {
+                "Health": 85,
+                "Damage": 13,
+                "FixedArmor": 16,
+                "ProgressionIndex": 12
+            },
+            "traits": ["Hero"],
+            "activeAbilities": ["InspiredToGreatness"],
+            "passiveAbilities": ["SereneUnifier"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "timestampIfHeroUnlocked": 1707091200000,
+                "timestampIfHeroNotUnlocked": 1710028800000
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_tauAunShi_01"],
+            "eventMetadata": {
+                "leg": {
+                    "finalEventEndDate": 1707091200000
+                }
+            },
+            "upgrades": [
+                ["upgHpC001", "upgHpC007", "upgDmgC009", "upgDmgC015", "upgArmC005", "upgArmC003"],
+                ["upgHpC015", "upgHpC008", "upgDmgC013", "upgDmgU010", "upgArmC011", "upgArmU013"],
+                ["upgHpC015", "upgHpU016", "upgDmgU007C", "upgDmgU010", "upgArmC011", "upgArmU013"],
+                ["upgHpU001", "upgHpU007", "upgDmgU004", "upgDmgU017C", "upgArmU004C", "upgArmU014"],
+                ["upgHpU015", "upgHpU016", "upgDmgU007C", "upgDmgR14C", "upgArmU006", "upgArmR013C"],
+                ["upgHpR003C", "upgHpR014", "upgDmgR027", "upgDmgU017C", "upgArmU006", "upgArmR013C"],
+                ["upgHpR027", "upgHpR006C", "upgDmgR005", "upgDmgR010C", "upgArmR002C", "upgArmR014C"],
+                ["upgHpE027C", "upgHpR006C", "upgDmgR010C", "upgDmgE006C", "upgArmR027", "upgArmR013C"],
+                ["upgHpR019", "upgHpE006C", "upgDmgE027C", "upgDmgR017C", "upgArmE027C", "upgArmE014C"],
+                ["upgHpE027C", "upgHpE014C", "upgDmgE027C", "upgDmgE011", "upgArmE027C", "upgArmE011C"],
+                ["upgHpE027C", "upgHpE006C", "upgDmgL027C", "upgDmgE011", "upgArmL027C", "upgArmE014C"],
+                ["upgHpL027C", "upgHpL014C", "upgDmgE027C", "upgDmgL017C", "upgArmE027C", "upgArmL011C"],
+                ["upgHpL127C", "upgHpL001C", "upgDmgL027C", "upgDmgL008C", "upgArmL027C", "upgArmL009C"],
+                ["upgHpL027C", "upgHpL001C", "upgDmgL127C", "upgDmgL005C", "upgArmL127C", "upgArmL003C"],
+                ["upgHpL127C", "upgHpL014C", "upgDmgL127C", "upgDmgL017C", "upgArmL127C", "upgArmL009C"],
+                ["upgHpL127C", "upgHpL017C", "upgDmgL127C", "upgDmgL009C", "upgArmL127C", "upgArmL003C"],
+                ["upgHpL127C", "upgHpL212C", "upgDmgL127C", "upgDmgL212C", "upgArmL127C", "upgArmL212C"],
+                ["upgHpL127C", "upgHpL212C", "upgDmgM214C", "upgDmgL212C", "upgArmM214C", "upgArmL212C"],
+                ["upgHpM127C", "upgHpL212C", "upgDmgM214C", "upgDmgL212C", "upgArmM214C", "upgArmL212C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [11, 11, 2, 2, 2, 2],
+                [13, 13, 1, 2, 2, 3],
+                [11, 23, 4, 2, 2, 4],
+                [21, 21, 2, 4, 5, 3],
+                [26, 26, 3, 5, 3, 7],
+                [38, 28, 5, 5, 4, 9],
+                [36, 47, 6, 7, 8, 8],
+                [57, 46, 7, 8, 8, 11],
+                [48, 81, 11, 9, 12, 12],
+                [81, 81, 14, 11, 15, 15],
+                [102, 102, 19, 12, 21, 18],
+                [127, 127, 18, 21, 21, 26],
+                [159, 159, 24, 24, 30, 30],
+                [198, 198, 31, 31, 38, 38],
+                [249, 249, 38, 38, 47, 47],
+                [312, 312, 48, 48, 58, 58],
+                [391, 391, 59, 59, 74, 74],
+                [212, 212, 35, 30, 43, 36],
+                [229, 196, 35, 30, 43, 37],
+                [188, 236, 29, 36, 36, 44]
+            ]
+        },
+        "tauShadowsun": {
+            "name": "Shadowsun",
+            "FactionId": "Tau",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Legendary",
+            "powerMultiplier": 75,
+            "Movement": 4,
+            "weapons": [
+                {
+                    "hits": 2,
+                    "DamageProfile": "Blast"
+                },
+                {
+                    "hits": 2,
+                    "DamageProfile": "Melta",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 80,
+                "Damage": 25,
+                "FixedArmor": 18,
+                "ProgressionIndex": 12
+            },
+            "traits": ["Hero", "Camouflage", "Flying", "Infiltrate", "RangedSpecialist"],
+            "activeAbilities": ["ExemplarOfTheKauyon"],
+            "passiveAbilities": ["DefenderOfTheGreaterGood"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "timestampIfHeroUnlocked": 1713139200000,
+                "timestampIfHeroNotUnlocked": 1716076800000
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_tauShadowsun_01"],
+            "eventMetadata": {
+                "leg": {
+                    "finalEventEndDate": 1713139200000
+                }
+            },
+            "upgrades": [
+                ["upgHpC017", "upgHpC017", "upgDmgC009", "upgDmgC015", "upgArmC004", "upgArmC005"],
+                ["upgHpC014", "upgHpC008", "upgDmgC003", "upgDmgU012", "upgArmC012", "upgArmU002"],
+                ["upgHpC014", "upgHpU017", "upgDmgU013C", "upgDmgU004", "upgArmC012", "upgArmU014"],
+                ["upgHpU014", "upgHpU007", "upgDmgU003", "upgDmgU017C", "upgArmU003C", "upgArmU014"],
+                ["upgHpU014", "upgHpU013", "upgDmgU013C", "upgDmgR13C", "upgArmU006", "upgArmR002C"],
+                ["upgHpR012C", "upgHpR014", "upgDmgR027", "upgDmgU017C", "upgArmU006", "upgArmR002C"],
+                ["upgHpR027", "upgHpR017C", "upgDmgR003", "upgDmgR011C", "upgArmR007C", "upgArmR014C"],
+                ["upgHpE027C", "upgHpR017C", "upgDmgR004C", "upgDmgE007C", "upgArmR027", "upgArmR002C"],
+                ["upgHpR018", "upgHpE013C", "upgDmgE027C", "upgDmgR017C", "upgArmE027C", "upgArmE014C"],
+                ["upgHpE027C", "upgHpE014C", "upgDmgE027C", "upgDmgE004", "upgArmE027C", "upgArmE003C"],
+                ["upgHpE027C", "upgHpE013C", "upgDmgL027C", "upgDmgE004", "upgArmL027C", "upgArmE014C"],
+                ["upgHpL027C", "upgHpL014C", "upgDmgE027C", "upgDmgL017C", "upgArmE027C", "upgArmL003C"],
+                ["upgHpL127C", "upgHpL013C", "upgDmgL027C", "upgDmgL006C", "upgArmL027C", "upgArmL009C"],
+                ["upgHpL027C", "upgHpL013C", "upgDmgL127C", "upgDmgL006C", "upgArmL127C", "upgArmL003C"],
+                ["upgHpL127C", "upgHpL014C", "upgDmgL127C", "upgDmgL017C", "upgArmL127C", "upgArmL009C"],
+                ["upgHpL127C", "upgHpL013C", "upgDmgL127C", "upgDmgL006C", "upgArmL127C", "upgArmL003C"],
+                ["upgHpL127C", "upgHpL214C", "upgDmgL127C", "upgDmgL214C", "upgArmL127C", "upgArmL214C"],
+                ["upgHpL127C", "upgHpL214C", "upgDmgM213C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpM127C", "upgHpL214C", "upgDmgM213C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [10, 10, 3, 3, 3, 3],
+                [13, 13, 3, 5, 1, 3],
+                [10, 21, 6, 4, 2, 5],
+                [20, 20, 5, 7, 5, 4],
+                [25, 25, 7, 9, 4, 7],
+                [35, 26, 10, 10, 5, 9],
+                [33, 45, 10, 14, 9, 9],
+                [54, 43, 13, 17, 9, 13],
+                [46, 76, 21, 17, 14, 14],
+                [76, 76, 27, 21, 17, 17],
+                [96, 96, 35, 24, 23, 19],
+                [119, 119, 34, 41, 25, 29],
+                [150, 150, 47, 47, 34, 34],
+                [187, 187, 58, 58, 42, 42],
+                [234, 234, 74, 74, 53, 53],
+                [294, 294, 91, 91, 66, 66],
+                [367, 367, 115, 115, 82, 82],
+                [200, 200, 67, 58, 48, 42],
+                [215, 185, 67, 58, 48, 42],
+                [177, 222, 56, 69, 40, 50]
+            ]
+        },
+        "tauFarsight": {
+            "name": "Farsight",
+            "FactionId": "Tau",
+            "Subfaction": "FarsightEnclaves",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Legendary",
+            "powerMultiplier": 79,
+            "Movement": 4,
+            "weapons": [
+                {
+                    "hits": 4,
+                    "DamageProfile": "Power"
+                },
+                {
+                    "hits": 2,
+                    "DamageProfile": "Plasma",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 100,
+                "Damage": 20,
+                "FixedArmor": 20,
+                "ProgressionIndex": 12
+            },
+            "traits": ["Hero", "BeastSlayer", "BigTarget", "Flying", "Mechanical"],
+            "activeAbilities": ["ExemplarOfTheMontka"],
+            "passiveAbilities": ["WayOfTheShortBlade"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": false,
+                "canDropIfHeroNotUnlocked": false
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_tauFarsight_01"],
+            "upgrades": [
+                ["upgHpC002", "upgHpC008", "upgDmgC009", "upgDmgC015", "upgArmC005", "upgArmC012"],
+                ["upgHpC014", "upgHpC002", "upgDmgU012", "upgDmgU017C", "upgArmC012", "upgArmC011"],
+                ["upgHpU014", "upgHpU004C", "upgDmgC007", "upgDmgC012", "upgArmU006", "upgArmU002"],
+                ["upgHpU004C", "upgHpU016", "upgDmgU012", "upgDmgU009", "upgArmU002", "upgArmU004C"],
+                ["upgHpU014", "upgHpR016C", "upgDmgU007C", "upgDmgU004", "upgArmR006", "upgArmU014"],
+                ["upgHpR012C", "upgHpU007", "upgDmgR027", "upgDmgR004C", "upgArmU004C", "upgArmR010"],
+                ["upgHpR027", "upgHpR014", "upgDmgR008C", "upgDmgR005", "upgArmR002C", "upgArmR008C"],
+                ["upgHpE027C", "upgHpR004C", "upgDmgR006", "upgDmgE007C", "upgArmR027", "upgArmR014C"],
+                ["upgHpR018", "upgHpE001C", "upgDmgE027C", "upgDmgR017C", "upgArmE027C", "upgArmE008"],
+                ["upgHpE027C", "upgHpE017", "upgDmgE027C", "upgDmgE004", "upgArmE027C", "upgArmE003C"],
+                ["upgHpL107", "upgHpE014C", "upgDmgL027C", "upgDmgE007C", "upgArmE027C", "upgArmE012C"],
+                ["upgHpE027C", "upgHpL011C", "upgDmgE027C", "upgDmgL017C", "upgArmL204", "upgArmL003C"],
+                ["upgHpL027C", "upgHpL001C", "upgDmgL204", "upgDmgL012C", "upgArmL027C", "upgArmL008C"],
+                ["upgHpL127C", "upgHpL014C", "upgDmgL027C", "upgDmgL017C", "upgArmL027C", "upgArmL009C"],
+                ["upgHpL027C", "upgHpL001C", "upgDmgL127C", "upgDmgL012C", "upgArmL127C", "upgArmL008C"],
+                ["upgHpL127C", "upgHpL013C", "upgDmgL127C", "upgDmgL006C", "upgArmL127C", "upgArmL003C"],
+                ["upgHpL127C", "upgHpL214C", "upgDmgL127C", "upgDmgL214C", "upgArmL127C", "upgArmL214C"],
+                ["upgHpL127C", "upgHpL214C", "upgDmgM214C", "upgDmgL214C", "upgArmM213C", "upgArmL214C"],
+                ["upgHpM127C", "upgHpL214C", "upgDmgM214C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [13, 13, 3, 3, 3, 3],
+                [16, 16, 2, 3, 3, 3],
+                [15, 23, 4, 4, 4, 4],
+                [30, 20, 5, 5, 4, 5],
+                [21, 41, 8, 5, 8, 5],
+                [51, 26, 6, 9, 8, 8],
+                [49, 49, 11, 8, 9, 9],
+                [67, 54, 9, 16, 11, 14],
+                [57, 95, 17, 13, 17, 13],
+                [106, 84, 21, 17, 19, 19],
+                [120, 120, 26, 22, 24, 24],
+                [135, 162, 27, 33, 27, 33],
+                [187, 187, 34, 40, 37, 37],
+                [234, 234, 47, 47, 47, 47],
+                [293, 293, 59, 59, 59, 59],
+                [367, 367, 73, 73, 73, 73],
+                [459, 459, 92, 92, 92, 92],
+                [250, 250, 54, 46, 54, 46],
+                [269, 231, 54, 46, 54, 46],
+                [222, 278, 44, 56, 44, 56]
+            ]
+        },
+        "tauBroadside": {
+            "name": "Tson'ji",
+            "FactionId": "Tau",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Common",
+            "stats": {
+                "Health": 0,
+                "Damage": 0,
+                "FixedArmor": 0,
+                "ProgressionIndex": 0
+            },
+            "traits": ["MachineOfWar"],
+            "activeAbilities": ["HeavyRailRifle", "TwinSmartMissileSystem"],
+            "mythicAbilities": ["ElectrochaffBackups"],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "timestampIfHeroUnlocked": 1733558400000,
+                "timestampIfHeroNotUnlocked": 1736582400000
+            },
+            "releaseStatus": "1732867200000",
+            "unlockQuestIds": ["hero_tauBroadside_01"],
+            "upgrades": null,
+            "upgradesStatIncrease": null
+        },
+        "spaceWulfen": {
+            "name": "Ulf",
+            "FactionId": "SpaceWolves",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Uncommon",
+            "powerMultiplier": 98,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 3,
+                    "DamageProfile": "Power"
+                }
+            ],
+            "stats": {
+                "Health": 90,
+                "Damage": 33,
+                "FixedArmor": 20,
+                "ProgressionIndex": 3
+            },
+            "traits": ["Hero", "FinalJustice", "Unstoppable"],
+            "activeAbilities": ["GreatFrostAxe"],
+            "passiveAbilities": ["SavageKiller"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_spaceWulfen_01"],
+            "upgrades": [
+                ["upgHpC015", "upgHpC001", "upgDmgC013", "upgDmgC011", "upgArmC006", "upgArmC001"],
+                ["upgHpC013", "upgHpC003", "upgDmgC014", "upgDmgU014", "upgArmC003", "upgArmU005"],
+                ["upgHpC015", "upgHpU012", "upgDmgU018C", "upgDmgU014", "upgArmC003", "upgArmU005"],
+                ["upgHpU015", "upgHpU001", "upgDmgU010", "upgDmgU015C", "upgArmU003C", "upgArmU001"],
+                ["upgHpU015", "upgHpU002", "upgDmgU018C", "upgDmgR13C", "upgArmU009", "upgArmR003C"],
+                ["upgHpR018", "upgHpR003C", "upgDmgR031", "upgDmgU015C", "upgArmR005", "upgArmR003C"],
+                ["upgHpR031", "upgHpR015C", "upgDmgR007", "upgDmgR012C", "upgArmR007C", "upgArmR001C"],
+                ["upgHpE031C", "upgHpR020C", "upgDmgR010C", "upgDmgE009C", "upgArmR031", "upgArmR003C"],
+                ["upgHpR019", "upgHpE007C", "upgDmgE031C", "upgDmgR015C", "upgArmE031C", "upgArmE001C"],
+                ["upgHpE031C", "upgHpE002C", "upgDmgE031C", "upgDmgE011", "upgArmE031C", "upgArmE004C"],
+                ["upgHpE031C", "upgHpE007C", "upgDmgL031C", "upgDmgE011", "upgArmL031C", "upgArmE001C"],
+                ["upgHpL031C", "upgHpL002C", "upgDmgE031C", "upgDmgL015C", "upgArmE031C", "upgArmL004C"],
+                ["upgHpL131C", "upgHpL009C", "upgDmgL031C", "upgDmgL008C", "upgArmL031C", "upgArmL010C"],
+                ["upgHpL031C", "upgHpL009C", "upgDmgL131C", "upgDmgL008C", "upgArmL131C", "upgArmL004C"],
+                ["upgHpL131C", "upgHpL002C", "upgDmgL131C", "upgDmgL015C", "upgArmL131C", "upgArmL010C"],
+                ["upgHpL131C", "upgHpL017C", "upgDmgL131C", "upgDmgL005C", "upgArmL131C", "upgArmL004C"],
+                ["upgHpL131C", "upgHpL211C", "upgDmgL131C", "upgDmgL211C", "upgArmL131C", "upgArmL211C"],
+                ["upgHpL131C", "upgHpL211C", "upgDmgM212C", "upgDmgL211C", "upgArmM214C", "upgArmL211C"],
+                ["upgHpM131C", "upgHpL211C", "upgDmgM212C", "upgDmgL211C", "upgArmM214C", "upgArmL211C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 4, 4, 3, 3],
+                [14, 14, 4, 7, 2, 3],
+                [12, 23, 8, 5, 3, 5],
+                [22, 22, 6, 10, 6, 4],
+                [28, 28, 9, 12, 4, 9],
+                [30, 40, 13, 13, 6, 9],
+                [37, 50, 13, 18, 10, 10],
+                [61, 48, 18, 22, 10, 14],
+                [51, 86, 28, 22, 15, 15],
+                [86, 86, 35, 28, 19, 19],
+                [107, 107, 47, 32, 26, 22],
+                [135, 135, 45, 54, 27, 33],
+                [168, 168, 62, 62, 37, 37],
+                [211, 211, 77, 77, 47, 47],
+                [263, 263, 97, 97, 59, 59],
+                [330, 330, 121, 121, 73, 73],
+                [414, 414, 151, 151, 92, 92],
+                [225, 225, 89, 76, 54, 46],
+                [242, 207, 89, 76, 54, 46],
+                [200, 249, 73, 92, 44, 56]
+            ]
+        },
+        "spaceHound": {
+            "name": "Tjark",
+            "FactionId": "SpaceWolves",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Uncommon",
+            "powerMultiplier": 106,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 4,
+                    "DamageProfile": "Physical"
+                }
+            ],
+            "stats": {
+                "Health": 85,
+                "Damage": 32,
+                "FixedArmor": 23,
+                "ProgressionIndex": 3
+            },
+            "traits": ["Hero", "Infiltrate", "Terrifying"],
+            "activeAbilities": ["GrapnelLauncher"],
+            "passiveAbilities": ["HuntersBeyondDeath"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_spaceHound_01"],
+            "upgrades": [
+                ["upgHpC015", "upgHpC001", "upgDmgC002", "upgDmgC011", "upgArmC006", "upgArmC001"],
+                ["upgHpC013", "upgHpC003", "upgDmgC010", "upgDmgU010", "upgArmC003", "upgArmU005"],
+                ["upgHpC015", "upgHpU012", "upgDmgU002C", "upgDmgU014", "upgArmC003", "upgArmU005"],
+                ["upgHpU015", "upgHpU001", "upgDmgU011", "upgDmgU015C", "upgArmU003C", "upgArmU001"],
+                ["upgHpU015", "upgHpU002", "upgDmgU018C", "upgDmgR13C", "upgArmU009", "upgArmR003C"],
+                ["upgHpR018", "upgHpR003C", "upgDmgR031", "upgDmgU015C", "upgArmR005", "upgArmR003C"],
+                ["upgHpR031", "upgHpR015C", "upgDmgR002", "upgDmgR012C", "upgArmR007C", "upgArmR001C"],
+                ["upgHpE031C", "upgHpR020C", "upgDmgE002C", "upgDmgR010C", "upgArmR031", "upgArmR003C"],
+                ["upgHpR002", "upgHpE007C", "upgDmgE031C", "upgDmgR015C", "upgArmE031C", "upgArmE001C"],
+                ["upgHpE031C", "upgHpE012", "upgDmgE031C", "upgDmgE009C", "upgArmE031C", "upgArmE004C"],
+                ["upgHpE031C", "upgHpE007C", "upgDmgL031C", "upgDmgE001", "upgArmL031C", "upgArmE001C"],
+                ["upgHpL031C", "upgHpL002C", "upgDmgE031C", "upgDmgL015C", "upgArmE031C", "upgArmL004C"],
+                ["upgHpL131C", "upgHpL009C", "upgDmgL031C", "upgDmgL005C", "upgArmL031C", "upgArmL010C"],
+                ["upgHpL031C", "upgHpL009C", "upgDmgL131C", "upgDmgL005C", "upgArmL131C", "upgArmL004C"],
+                ["upgHpL131C", "upgHpL002C", "upgDmgL131C", "upgDmgL015C", "upgArmL131C", "upgArmL010C"],
+                ["upgHpL131C", "upgHpL017C", "upgDmgL131C", "upgDmgL005C", "upgArmL131C", "upgArmL004C"],
+                ["upgHpL131C", "upgHpL213C", "upgDmgL131C", "upgDmgL213C", "upgArmL131C", "upgArmL213C"],
+                ["upgHpL131C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpM131C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [11, 11, 4, 4, 3, 3],
+                [13, 13, 3, 7, 2, 5],
+                [11, 23, 8, 5, 3, 6],
+                [21, 21, 6, 10, 7, 5],
+                [26, 26, 8, 11, 5, 9],
+                [28, 38, 13, 13, 8, 10],
+                [36, 47, 13, 17, 11, 11],
+                [57, 46, 22, 17, 12, 16],
+                [48, 81, 27, 22, 18, 18],
+                [90, 72, 31, 31, 22, 22],
+                [102, 102, 45, 30, 29, 25],
+                [127, 127, 44, 52, 31, 37],
+                [159, 159, 60, 60, 43, 43],
+                [198, 198, 75, 75, 54, 54],
+                [249, 249, 94, 94, 68, 68],
+                [312, 312, 117, 117, 84, 84],
+                [391, 391, 147, 147, 106, 106],
+                [212, 212, 86, 73, 61, 53],
+                [229, 196, 86, 74, 62, 53],
+                [188, 236, 71, 89, 51, 63]
+            ]
+        },
+        "spaceRockfist": {
+            "name": "Arjac",
+            "FactionId": "SpaceWolves",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Rare",
+            "powerMultiplier": 92,
+            "Movement": 2,
+            "weapons": [
+                {
+                    "hits": 3,
+                    "DamageProfile": "Power"
+                }
+            ],
+            "stats": {
+                "Health": 110,
+                "Damage": 23,
+                "FixedArmor": 26,
+                "ProgressionIndex": 6
+            },
+            "traits": ["Hero", "Resilient", "TeleportStrike", "TerminatorArmour", "Unstoppable"],
+            "activeAbilities": ["Foehammer"],
+            "passiveAbilities": ["AnvilShield"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Block"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_spaceRockfist_01"],
+            "upgrades": [
+                ["upgHpC015", "upgHpC001", "upgDmgC009", "upgDmgC011", "upgArmC006", "upgArmC001"],
+                ["upgHpC013", "upgHpC003", "upgDmgC013", "upgDmgU010", "upgArmC003", "upgArmU005"],
+                ["upgHpC014", "upgHpU012", "upgDmgU013C", "upgDmgU014", "upgArmC003", "upgArmU005"],
+                ["upgHpU014", "upgHpU001", "upgDmgU012", "upgDmgU015C", "upgArmU003C", "upgArmU001"],
+                ["upgHpU014", "upgHpU002", "upgDmgU018C", "upgDmgR13C", "upgArmU009", "upgArmR003C"],
+                ["upgHpR018", "upgHpR003C", "upgDmgR031", "upgDmgU015C", "upgArmR005", "upgArmR003C"],
+                ["upgHpR031", "upgHpR015C", "upgDmgR007", "upgDmgR012C", "upgArmR007C", "upgArmR001C"],
+                ["upgHpE031C", "upgHpR020C", "upgDmgE008C", "upgDmgR010C", "upgArmR031", "upgArmR003C"],
+                ["upgHpR019", "upgHpE001C", "upgDmgE031C", "upgDmgR015C", "upgArmE031C", "upgArmE001C"],
+                ["upgHpE031C", "upgHpE012", "upgDmgE031C", "upgDmgE009C", "upgArmE031C", "upgArmE004C"],
+                ["upgHpE031C", "upgHpE007C", "upgDmgL031C", "upgDmgE001", "upgArmL031C", "upgArmE001C"],
+                ["upgHpL031C", "upgHpL002C", "upgDmgE031C", "upgDmgL015C", "upgArmE031C", "upgArmL004C"],
+                ["upgHpL131C", "upgHpL001C", "upgDmgL031C", "upgDmgL005C", "upgArmL031C", "upgArmL010C"],
+                ["upgHpL031C", "upgHpL009C", "upgDmgL131C", "upgDmgL008C", "upgArmL131C", "upgArmL004C"],
+                ["upgHpL131C", "upgHpL002C", "upgDmgL131C", "upgDmgL015C", "upgArmL131C", "upgArmL010C"],
+                ["upgHpL131C", "upgHpL017C", "upgDmgL131C", "upgDmgL005C", "upgArmL131C", "upgArmL004C"],
+                ["upgHpL131C", "upgHpL213C", "upgDmgL131C", "upgDmgL213C", "upgArmL131C", "upgArmL213C"],
+                ["upgHpL131C", "upgHpL213C", "upgDmgM214C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpM131C", "upgHpL213C", "upgDmgM214C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [14, 14, 3, 3, 4, 4],
+                [17, 17, 2, 5, 2, 5],
+                [15, 29, 5, 4, 3, 7],
+                [27, 27, 5, 7, 8, 5],
+                [34, 34, 6, 8, 5, 11],
+                [37, 49, 9, 9, 9, 11],
+                [45, 61, 9, 13, 13, 13],
+                [74, 60, 16, 12, 13, 18],
+                [63, 104, 19, 16, 20, 20],
+                [117, 93, 22, 22, 25, 25],
+                [131, 131, 33, 22, 33, 28],
+                [165, 165, 31, 37, 35, 43],
+                [205, 205, 43, 43, 49, 49],
+                [258, 258, 54, 54, 61, 61],
+                [322, 322, 68, 68, 76, 76],
+                [403, 403, 84, 84, 95, 95],
+                [506, 506, 106, 106, 119, 119],
+                [275, 275, 61, 53, 70, 60],
+                [296, 253, 62, 53, 70, 60],
+                [244, 305, 51, 63, 58, 72]
+            ]
+        },
+        "spaceStormcaller": {
+            "name": "Njal",
+            "FactionId": "SpaceWolves",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Epic",
+            "powerMultiplier": 92,
+            "Movement": 2,
+            "weapons": [
+                {
+                    "hits": 3,
+                    "DamageProfile": "Psychic"
+                },
+                {
+                    "hits": 2,
+                    "DamageProfile": "Psychic",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 80,
+                "Damage": 8,
+                "FixedArmor": 26,
+                "ProgressionIndex": 9
+            },
+            "traits": ["Hero", "Psyker", "TerminatorArmour", "Unstoppable"],
+            "activeAbilities": ["Stormcaller"],
+            "passiveAbilities": ["LordOfTempests"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Block"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_spaceStormcaller_01"],
+            "upgrades": [
+                ["upgHpC007", "upgHpC004", "upgDmgC010", "upgDmgC011", "upgArmC013", "upgArmC002"],
+                ["upgHpC001", "upgHpC015", "upgDmgU010", "upgDmgU015C", "upgArmC006", "upgArmC001"],
+                ["upgHpU001", "upgHpU018C", "upgDmgC008", "upgDmgC009", "upgArmU009", "upgArmU001"],
+                ["upgHpU005C", "upgHpU016", "upgDmgU010", "upgDmgU012", "upgArmU013", "upgArmU003C"],
+                ["upgHpU001", "upgHpR016C", "upgDmgU008C", "upgDmgU011", "upgArmR005", "upgArmU001"],
+                ["upgHpR003C", "upgHpU006", "upgDmgR031", "upgDmgR011C", "upgArmU003C", "upgArmR015"],
+                ["upgHpR031", "upgHpR005", "upgDmgR14C", "upgDmgR005", "upgArmR013C", "upgArmR003C"],
+                ["upgHpE031C", "upgHpR013C", "upgDmgR006", "upgDmgE008C", "upgArmR031", "upgArmR001C"],
+                ["upgHpR014", "upgHpE007C", "upgDmgE031C", "upgDmgR015C", "upgArmE031C", "upgArmE009"],
+                ["upgHpE031C", "upgHpE003", "upgDmgE031C", "upgDmgE010", "upgArmE031C", "upgArmE004C"],
+                ["upgHpL111", "upgHpE002C", "upgDmgL031C", "upgDmgE008C", "upgArmE031C", "upgArmE001C"],
+                ["upgHpE031C", "upgHpL011C", "upgDmgE031C", "upgDmgL015C", "upgArmL202", "upgArmL004C"],
+                ["upgHpL031C", "upgHpL009C", "upgDmgL202", "upgDmgL006C", "upgArmL031C", "upgArmL010C"],
+                ["upgHpL131C", "upgHpL002C", "upgDmgL031C", "upgDmgL015C", "upgArmL031C", "upgArmL011C"],
+                ["upgHpL031C", "upgHpL011C", "upgDmgL131C", "upgDmgL010C", "upgArmL131C", "upgArmL010C"],
+                ["upgHpL131C", "upgHpL017C", "upgDmgL131C", "upgDmgL005C", "upgArmL131C", "upgArmL004C"],
+                ["upgHpL131C", "upgHpL212C", "upgDmgL131C", "upgDmgL212C", "upgArmL131C", "upgArmL212C"],
+                ["upgHpL131C", "upgHpL212C", "upgDmgM211C", "upgDmgL212C", "upgArmM211C", "upgArmL212C"],
+                ["upgHpM131C", "upgHpL212C", "upgDmgM211C", "upgDmgL212C", "upgArmM213C", "upgArmL212C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [10, 10, 1, 1, 4, 4],
+                [13, 13, 1, 2, 4, 4],
+                [12, 19, 2, 2, 5, 5],
+                [24, 16, 2, 2, 5, 7],
+                [16, 33, 2, 2, 10, 6],
+                [41, 21, 3, 3, 10, 10],
+                [39, 39, 5, 3, 13, 13],
+                [54, 43, 3, 6, 13, 18],
+                [46, 76, 7, 5, 22, 18],
+                [84, 68, 9, 7, 25, 25],
+                [96, 96, 10, 9, 31, 31],
+                [108, 130, 11, 13, 35, 42],
+                [150, 150, 14, 16, 49, 49],
+                [187, 187, 19, 19, 61, 61],
+                [234, 234, 23, 23, 76, 76],
+                [294, 294, 30, 30, 95, 95],
+                [367, 367, 36, 36, 119, 119],
+                [200, 200, 22, 18, 70, 60],
+                [215, 185, 22, 18, 70, 60],
+                [177, 222, 18, 22, 58, 72]
+            ]
+        },
+        "spaceBlackmane": {
+            "name": "Ragnar",
+            "FactionId": "SpaceWolves",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Legendary",
+            "powerMultiplier": 99,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 7,
+                    "DamageProfile": "Chain"
+                }
+            ],
+            "stats": {
+                "Health": 100,
+                "Damage": 14,
+                "FixedArmor": 24,
+                "ProgressionIndex": 12
+            },
+            "traits": ["Hero", "BeastSlayer", "FinalJustice", "RapidAssault"],
+            "activeAbilities": ["WarHowl"],
+            "passiveAbilities": ["SagaOfTheWarriorBorn"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "timestampIfHeroUnlocked": 1722211200000,
+                "timestampIfHeroNotUnlocked": 1725148800000
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_spaceBlackmane_01"],
+            "eventMetadata": {
+                "leg": {
+                    "finalEventEndDate": 1722211200000
+                }
+            },
+            "upgrades": [
+                ["upgHpC015", "upgHpC004", "upgDmgC003", "upgDmgC011", "upgArmC013", "upgArmC002"],
+                ["upgHpC001", "upgHpC002", "upgDmgU014", "upgDmgU015C", "upgArmC006", "upgArmC001"],
+                ["upgHpU001", "upgHpU004C", "upgDmgC013", "upgDmgC010", "upgArmU009", "upgArmU001"],
+                ["upgHpU018C", "upgHpU012", "upgDmgU014", "upgDmgU010", "upgArmU013", "upgArmU003C"],
+                ["upgHpU001", "upgHpR015C", "upgDmgU018C", "upgDmgU011", "upgArmR005", "upgArmU001"],
+                ["upgHpR003C", "upgHpU006", "upgDmgR031", "upgDmgR010C", "upgArmU004C", "upgArmR015"],
+                ["upgHpR031", "upgHpR005", "upgDmgR13C", "upgDmgR005", "upgArmR013C", "upgArmR003C"],
+                ["upgHpE031C", "upgHpR004C", "upgDmgR002", "upgDmgE006C", "upgArmR031", "upgArmR001C"],
+                ["upgHpR018", "upgHpE001C", "upgDmgE031C", "upgDmgR015C", "upgArmE031C", "upgArmE013"],
+                ["upgHpE031C", "upgHpE003", "upgDmgE031C", "upgDmgE011", "upgArmE031C", "upgArmE004C"],
+                ["upgHpL111", "upgHpE002C", "upgDmgL031C", "upgDmgE006C", "upgArmE031C", "upgArmE001C"],
+                ["upgHpE031C", "upgHpL009C", "upgDmgE031C", "upgDmgL015C", "upgArmL203", "upgArmL004C"],
+                ["upgHpL031C", "upgHpL001C", "upgDmgL003", "upgDmgL005C", "upgArmL031C", "upgArmL010C"],
+                ["upgHpL131C", "upgHpL002C", "upgDmgL031C", "upgDmgL015C", "upgArmL031C", "upgArmL011C"],
+                ["upgHpL031C", "upgHpL009C", "upgDmgL131C", "upgDmgL008C", "upgArmL131C", "upgArmL010C"],
+                ["upgHpL131C", "upgHpL017C", "upgDmgL131C", "upgDmgL009C", "upgArmL131C", "upgArmL004C"],
+                ["upgHpL131C", "upgHpL213C", "upgDmgL131C", "upgDmgL213C", "upgArmL131C", "upgArmL213C"],
+                ["upgHpL131C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpM131C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [13, 13, 2, 2, 3, 3],
+                [16, 16, 2, 2, 4, 4],
+                [15, 23, 3, 3, 5, 5],
+                [30, 20, 3, 3, 4, 7],
+                [21, 41, 5, 4, 9, 6],
+                [51, 26, 5, 6, 9, 9],
+                [49, 49, 8, 6, 12, 12],
+                [67, 54, 6, 11, 12, 17],
+                [57, 95, 12, 9, 20, 16],
+                [106, 84, 14, 12, 23, 23],
+                [120, 120, 19, 15, 29, 29],
+                [135, 162, 19, 23, 32, 39],
+                [187, 187, 24, 28, 45, 45],
+                [234, 234, 33, 33, 56, 56],
+                [293, 293, 41, 41, 71, 71],
+                [367, 367, 51, 51, 88, 88],
+                [459, 459, 65, 65, 110, 110],
+                [250, 250, 37, 32, 64, 55],
+                [269, 231, 38, 32, 65, 55],
+                [222, 278, 31, 39, 53, 67]
+            ]
+        },
+        "spaceWolfPriest": {
+            "name": "Baldr",
+            "FactionId": "SpaceWolves",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Rare",
+            "powerMultiplier": 97,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 3,
+                    "DamageProfile": "Power"
+                }
+            ],
+            "stats": {
+                "Health": 90,
+                "Damage": 25,
+                "FixedArmor": 21,
+                "ProgressionIndex": 6
+            },
+            "traits": ["Hero", "Healer", "FinalJustice", "Terrifying"],
+            "activeAbilities": ["RitesOfMorkai"],
+            "passiveAbilities": ["HealingBalms"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Crit"],
+            "itemSlotsRelic": [2],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_spaceWolfPriest_01"],
+            "upgrades": [
+                ["upgHpC015", "upgHpC004", "upgDmgC010", "upgDmgC011", "upgArmC002", "upgArmC013"],
+                ["upgHpC001", "upgHpC007", "upgDmgU010", "upgDmgU015C", "upgArmC013", "upgArmC001"],
+                ["upgHpU001", "upgHpU005C", "upgDmgC013", "upgDmgC003", "upgArmU005", "upgArmU009"],
+                ["upgHpU018C", "upgHpU012", "upgDmgU010", "upgDmgU014", "upgArmU009", "upgArmU010C"],
+                ["upgHpU001", "upgHpR015C", "upgDmgU018C", "upgDmgU011", "upgArmR005", "upgArmU001"],
+                ["upgHpR003C", "upgHpU006", "upgDmgR031", "upgDmgR012C", "upgArmU010C", "upgArmR015"],
+                ["upgHpR031", "upgHpR005", "upgDmgR13C", "upgDmgR005", "upgArmR003C", "upgArmR012C"],
+                ["upgHpE031C", "upgHpR006C", "upgDmgR002", "upgDmgE009C", "upgArmR031", "upgArmR001C"],
+                ["upgHpR014", "upgHpE006C", "upgDmgE031C", "upgDmgR015C", "upgArmE031C", "upgArmE013"],
+                ["upgHpE031C", "upgHpE012", "upgDmgE031C", "upgDmgE011", "upgArmE031C", "upgArmE004C"],
+                ["upgHpL111", "upgHpE002C", "upgDmgL031C", "upgDmgE009C", "upgArmE031C", "upgArmE006C"],
+                ["upgHpE031C", "upgHpL009C", "upgDmgE031C", "upgDmgL015C", "upgArmL203", "upgArmL004C"],
+                ["upgHpL031C", "upgHpL011C", "upgDmgL204", "upgDmgL009C", "upgArmL031C", "upgArmL006C"],
+                ["upgHpL131C", "upgHpL002C", "upgDmgL031C", "upgDmgL015C", "upgArmL031C", "upgArmL010C"],
+                ["upgHpL031C", "upgHpL009C", "upgDmgL131C", "upgDmgL008C", "upgArmL131C", "upgArmL006C"],
+                ["upgHpL131C", "upgHpL017C", "upgDmgL131C", "upgDmgL005C", "upgArmL131C", "upgArmL004C"],
+                ["upgHpL131C", "upgHpL213C", "upgDmgL131C", "upgDmgL213C", "upgArmL131C", "upgArmL213C"],
+                ["upgHpL131C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM211C", "upgArmL213C"],
+                ["upgHpM131C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 3, 3, 3, 3],
+                [14, 14, 3, 5, 3, 3],
+                [14, 21, 5, 5, 4, 4],
+                [26, 18, 6, 6, 4, 7],
+                [19, 37, 10, 6, 8, 5],
+                [47, 23, 8, 11, 8, 8],
+                [44, 44, 14, 11, 10, 10],
+                [60, 48, 11, 19, 11, 15],
+                [51, 86, 21, 17, 18, 14],
+                [96, 76, 27, 21, 20, 20],
+                [107, 107, 32, 27, 25, 25],
+                [122, 147, 34, 41, 29, 34],
+                [168, 168, 42, 51, 39, 39],
+                [211, 211, 59, 59, 49, 49],
+                [264, 264, 73, 73, 62, 62],
+                [330, 330, 92, 92, 77, 77],
+                [413, 413, 115, 115, 96, 96],
+                [225, 225, 67, 57, 57, 48],
+                [242, 208, 67, 58, 57, 48],
+                [200, 249, 56, 69, 47, 58]
+            ]
+        },
+        "thousTzaangor": {
+            "name": "Yazaghor",
+            "FactionId": "ThousandSons",
+            "GrandAllianceId": "Chaos",
+            "BaseRarity": "Common",
+            "powerMultiplier": 111,
+            "Movement": 4,
+            "weapons": [
+                {
+                    "hits": 1,
+                    "DamageProfile": "Physical"
+                },
+                {
+                    "hits": 1,
+                    "DamageProfile": "HeavyRound",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 65,
+                "Damage": 49,
+                "FixedArmor": 14,
+                "ProgressionIndex": 0
+            },
+            "traits": ["Hero", "WeaverOfFate", "Flying"],
+            "activeAbilities": ["SorcerousFacade"],
+            "passiveAbilities": ["RealityUnbound"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "campaign": {
+                    "campaignType": "Standard",
+                    "campaignId": "campaign4",
+                    "level": 45
+                }
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_thousTzaangor_01"],
+            "upgrades": [
+                ["upgHpC001", "upgHpC010", "upgDmgC005", "upgDmgC014", "upgArmC011", "upgArmC005"],
+                ["upgHpC006", "upgHpC016", "upgDmgU004", "upgDmgU016C", "upgArmC013", "upgArmC007"],
+                ["upgHpU001", "upgHpU004C", "upgDmgC005", "upgDmgC003", "upgArmU002", "upgArmU009"],
+                ["upgHpU005C", "upgHpU009", "upgDmgU012", "upgDmgU014", "upgArmU013", "upgArmU004C"],
+                ["upgHpU015", "upgHpR003C", "upgDmgU018C", "upgDmgU003", "upgArmR006", "upgArmU007"],
+                ["upgHpR003C", "upgHpU016", "upgDmgR029", "upgDmgR012C", "upgArmU003C", "upgArmR005"],
+                ["upgHpR029", "upgHpR008", "upgDmgR14C", "upgDmgR003", "upgArmR012C", "upgArmR002C"],
+                ["upgHpE029C", "upgHpR015C", "upgDmgR006", "upgDmgE009C", "upgArmR029", "upgArmR004C"],
+                ["upgHpR002", "upgHpE007C", "upgDmgE029C", "upgDmgR016C", "upgArmE029C", "upgArmE008"],
+                ["upgHpE029C", "upgHpE012", "upgDmgE029C", "upgDmgE010", "upgArmE029C", "upgArmE003C"],
+                ["upgHpE029C", "upgHpE008C", "upgDmgL029C", "upgDmgE009C", "upgArmE008", "upgArmE005C"],
+                ["upgHpL109", "upgHpL011C", "upgDmgE029C", "upgDmgL016C", "upgArmE029C", "upgArmL006C"],
+                ["upgHpL029C", "upgHpL009C", "upgDmgL001", "upgDmgL002C", "upgArmL029C", "upgArmL003C"],
+                ["upgHpL129C", "upgHpL012C", "upgDmgL029C", "upgDmgL016C", "upgArmL029C", "upgArmL005C"],
+                ["upgHpL029C", "upgHpL011C", "upgDmgL129C", "upgDmgL002C", "upgArmL129C", "upgArmL006C"],
+                ["upgHpL129C", "upgHpL017C", "upgDmgL129C", "upgDmgL002C", "upgArmL129C", "upgArmL002C"],
+                ["upgHpL129C", "upgHpL212C", "upgDmgL129C", "upgDmgL212C", "upgArmL129C", "upgArmL212C"],
+                ["upgHpL129C", "upgHpL212C", "upgDmgM212C", "upgDmgL212C", "upgArmM214C", "upgArmL212C"],
+                ["upgHpM129C", "upgHpL212C", "upgDmgM212C", "upgDmgL212C", "upgArmM214C", "upgArmL212C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [8, 8, 6, 6, 2, 2],
+                [11, 11, 6, 10, 2, 2],
+                [10, 15, 10, 10, 3, 3],
+                [19, 13, 12, 12, 2, 4],
+                [13, 27, 18, 12, 5, 4],
+                [33, 17, 16, 22, 6, 6],
+                [32, 32, 27, 20, 7, 7],
+                [43, 35, 23, 38, 7, 9],
+                [37, 62, 41, 32, 12, 9],
+                [69, 55, 52, 42, 13, 13],
+                [78, 78, 64, 53, 15, 19],
+                [88, 105, 66, 80, 19, 23],
+                [122, 122, 83, 100, 26, 26],
+                [152, 152, 115, 115, 33, 33],
+                [190, 190, 143, 143, 41, 41],
+                [239, 239, 180, 180, 51, 51],
+                [298, 298, 225, 225, 65, 65],
+                [163, 163, 132, 113, 37, 32],
+                [174, 150, 132, 113, 38, 32],
+                [144, 181, 109, 136, 31, 39]
+            ]
+        },
+        "thousTerminator": {
+            "name": "Toth",
+            "FactionId": "ThousandSons",
+            "GrandAllianceId": "Chaos",
+            "BaseRarity": "Uncommon",
+            "powerMultiplier": 97,
+            "Movement": 2,
+            "weapons": [
+                {
+                    "hits": 4,
+                    "DamageProfile": "Power"
+                },
+                {
+                    "hits": 5,
+                    "DamageProfile": "Flame",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 90,
+                "Damage": 10,
+                "FixedArmor": 27,
+                "ProgressionIndex": 3
+            },
+            "traits": ["Hero", "WeaverOfFate", "SuppressiveFire", "TerminatorArmour"],
+            "activeAbilities": ["HellfyreMissileRack"],
+            "passiveAbilities": ["TimeFlux"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Block"],
+            "itemSlotsRelic": [1],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "campaign": {
+                    "campaignType": "Standard",
+                    "campaignId": "campaign4",
+                    "level": 15
+                }
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_thousTerminator_01"],
+            "upgrades": [
+                ["upgHpC014", "upgHpC010", "upgDmgC001", "upgDmgC014", "upgArmC012", "upgArmC004"],
+                ["upgHpC015", "upgHpC017", "upgDmgU004", "upgDmgU001C", "upgArmC013", "upgArmC007"],
+                ["upgHpU014", "upgHpU004C", "upgDmgC012", "upgDmgC003", "upgArmU008", "upgArmU009"],
+                ["upgHpU005C", "upgHpU009", "upgDmgU011", "upgDmgU011", "upgArmU013", "upgArmU003C"],
+                ["upgHpU015", "upgHpR017C", "upgDmgU012", "upgDmgU016C", "upgArmR006", "upgArmU007"],
+                ["upgHpR012C", "upgHpU017", "upgDmgR029", "upgDmgR001C", "upgArmU004C", "upgArmR005"],
+                ["upgHpR029", "upgHpR008", "upgDmgR14C", "upgDmgR006", "upgArmR012C", "upgArmR007C"],
+                ["upgHpE029C", "upgHpR015C", "upgDmgR005", "upgDmgE008C", "upgArmR029", "upgArmR004C"],
+                ["upgHpR002", "upgHpE007C", "upgDmgE029C", "upgDmgR016C", "upgArmE029C", "upgArmE008"],
+                ["upgHpE029C", "upgHpE003", "upgDmgE029C", "upgDmgE010", "upgArmE029C", "upgArmE002C"],
+                ["upgHpE029C", "upgHpE008C", "upgDmgL029C", "upgDmgE008C", "upgArmE008", "upgArmE005C"],
+                ["upgHpL109", "upgHpL001C", "upgDmgE029C", "upgDmgL007C", "upgArmE029C", "upgArmL006C"],
+                ["upgHpL029C", "upgHpL009C", "upgDmgL001", "upgDmgL008C", "upgArmL029C", "upgArmL002C"],
+                ["upgHpL129C", "upgHpL012C", "upgDmgL029C", "upgDmgL016C", "upgArmL029C", "upgArmL005C"],
+                ["upgHpL029C", "upgHpL001C", "upgDmgL129C", "upgDmgL006C", "upgArmL129C", "upgArmL006C"],
+                ["upgHpL129C", "upgHpL017C", "upgDmgL129C", "upgDmgL002C", "upgArmL129C", "upgArmL004C"],
+                ["upgHpL129C", "upgHpL212C", "upgDmgL129C", "upgDmgL212C", "upgArmL129C", "upgArmL212C"],
+                ["upgHpL129C", "upgHpL212C", "upgDmgM213C", "upgDmgL212C", "upgArmM214C", "upgArmL212C"],
+                ["upgHpM129C", "upgHpL212C", "upgDmgM213C", "upgDmgL212C", "upgArmM214C", "upgArmL212C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 2, 2, 4, 4],
+                [14, 14, 1, 1, 4, 4],
+                [14, 21, 2, 2, 5, 5],
+                [26, 18, 3, 3, 5, 8],
+                [19, 37, 2, 3, 10, 7],
+                [47, 23, 3, 5, 11, 11],
+                [44, 44, 5, 4, 13, 13],
+                [60, 48, 5, 8, 14, 18],
+                [51, 86, 8, 7, 23, 18],
+                [96, 76, 11, 8, 26, 26],
+                [107, 107, 13, 10, 28, 36],
+                [122, 147, 14, 16, 37, 44],
+                [168, 168, 17, 21, 50, 50],
+                [211, 211, 24, 24, 64, 64],
+                [264, 264, 29, 29, 79, 79],
+                [330, 330, 36, 36, 99, 99],
+                [413, 413, 46, 46, 124, 124],
+                [225, 225, 27, 23, 72, 62],
+                [242, 208, 27, 23, 73, 62],
+                [200, 249, 22, 28, 60, 75]
+            ]
+        },
+        "thousInfernalMaster": {
+            "name": "Abraxas",
+            "FactionId": "ThousandSons",
+            "GrandAllianceId": "Chaos",
+            "BaseRarity": "Rare",
+            "powerMultiplier": 96,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 2,
+                    "DamageProfile": "Flame"
+                },
+                {
+                    "hits": 1,
+                    "DamageProfile": "Psychic",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 70,
+                "Damage": 18,
+                "FixedArmor": 20,
+                "ProgressionIndex": 6
+            },
+            "traits": ["Hero", "WeaverOfFate", "Psyker"],
+            "activeAbilities": ["MasterOfTheTutelaries"],
+            "passiveAbilities": ["InfernalPacts"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Crit"],
+            "itemSlotsRelic": [2],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "campaign": {
+                    "campaignType": "Standard",
+                    "campaignId": "campaign4",
+                    "level": 30
+                }
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_thousInfernalMaster_01"],
+            "upgrades": [
+                ["upgHpC007", "upgHpC010", "upgDmgC010", "upgDmgC014", "upgArmC006", "upgArmC005"],
+                ["upgHpC016", "upgHpC017", "upgDmgU004", "upgDmgU016C", "upgArmC013", "upgArmC007"],
+                ["upgHpU016", "upgHpU004C", "upgDmgC013", "upgDmgC003", "upgArmU008", "upgArmU013"],
+                ["upgHpU005C", "upgHpU009", "upgDmgU011", "upgDmgU010", "upgArmU009", "upgArmU004C"],
+                ["upgHpU015", "upgHpR017C", "upgDmgU018C", "upgDmgU003", "upgArmR005", "upgArmU007"],
+                ["upgHpR006C", "upgHpU017", "upgDmgR029", "upgDmgR010C", "upgArmU003C", "upgArmR006"],
+                ["upgHpR029", "upgHpR008", "upgDmgR14C", "upgDmgR003", "upgArmR012C", "upgArmR013C"],
+                ["upgHpE029C", "upgHpR015C", "upgDmgR005", "upgDmgE006C", "upgArmR029", "upgArmR004C"],
+                ["upgHpR002", "upgHpE007C", "upgDmgE029C", "upgDmgR016C", "upgArmE029C", "upgArmE008"],
+                ["upgHpE029C", "upgHpE012", "upgDmgE029C", "upgDmgE003", "upgArmE029C", "upgArmE003C"],
+                ["upgHpE029C", "upgHpE008C", "upgDmgL029C", "upgDmgE006C", "upgArmE008", "upgArmE005C"],
+                ["upgHpL109", "upgHpL011C", "upgDmgE029C", "upgDmgL002C", "upgArmE029C", "upgArmL011C"],
+                ["upgHpL029C", "upgHpL009C", "upgDmgE010", "upgDmgL005C", "upgArmL029C", "upgArmL003C"],
+                ["upgHpL129C", "upgHpL012C", "upgDmgL029C", "upgDmgL016C", "upgArmL029C", "upgArmL005C"],
+                ["upgHpL029C", "upgHpL011C", "upgDmgL129C", "upgDmgL002C", "upgArmL129C", "upgArmL011C"],
+                ["upgHpL129C", "upgHpL011C", "upgDmgL129C", "upgDmgL002C", "upgArmL129C", "upgArmL004C"],
+                ["upgHpL129C", "upgHpL212C", "upgDmgL129C", "upgDmgL212C", "upgArmL129C", "upgArmL212C"],
+                ["upgHpL129C", "upgHpL212C", "upgDmgM211C", "upgDmgL212C", "upgArmM214C", "upgArmL212C"],
+                ["upgHpM129C", "upgHpL212C", "upgDmgM211C", "upgDmgL212C", "upgArmM214C", "upgArmL212C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [9, 9, 3, 3, 3, 3],
+                [11, 11, 2, 2, 3, 3],
+                [11, 16, 4, 4, 4, 4],
+                [21, 14, 4, 4, 4, 5],
+                [14, 29, 7, 4, 8, 5],
+                [37, 18, 6, 8, 8, 8],
+                [34, 34, 10, 8, 9, 9],
+                [47, 38, 8, 14, 11, 14],
+                [40, 66, 15, 12, 17, 13],
+                [74, 59, 19, 15, 19, 19],
+                [84, 84, 23, 20, 21, 27],
+                [95, 113, 25, 29, 27, 33],
+                [131, 131, 27, 40, 37, 37],
+                [164, 164, 43, 43, 47, 47],
+                [205, 205, 52, 52, 59, 59],
+                [257, 257, 66, 66, 73, 73],
+                [321, 321, 83, 83, 92, 92],
+                [175, 175, 48, 41, 54, 46],
+                [188, 162, 48, 42, 54, 46],
+                [156, 194, 40, 50, 44, 56]
+            ]
+        },
+        "thousSorcerer": {
+            "name": "Thaumachus",
+            "FactionId": "ThousandSons",
+            "GrandAllianceId": "Chaos",
+            "BaseRarity": "Epic",
+            "powerMultiplier": 94,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 1,
+                    "DamageProfile": "Flame"
+                },
+                {
+                    "hits": 1,
+                    "DamageProfile": "Psychic",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 75,
+                "Damage": 27,
+                "FixedArmor": 18,
+                "ProgressionIndex": 9
+            },
+            "traits": ["Hero", "WeaverOfFate", "Flying", "Psyker"],
+            "activeAbilities": ["AttemptedPossession"],
+            "passiveAbilities": ["ArcaneShield"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Crit"],
+            "itemSlotsRelic": [2],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "campaign": {
+                    "campaignType": "Standard",
+                    "campaignId": "campaign4",
+                    "level": 60
+                }
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_thousSorcerer_01"],
+            "upgrades": [
+                ["upgHpC007", "upgHpC010", "upgDmgC010", "upgDmgC014", "upgArmC006", "upgArmC005"],
+                ["upgHpC016", "upgHpC017", "upgDmgU004", "upgDmgU016C", "upgArmC013", "upgArmC007"],
+                ["upgHpU016", "upgHpU004C", "upgDmgC013", "upgDmgC003", "upgArmU008", "upgArmU013"],
+                ["upgHpU005C", "upgHpU009", "upgDmgU011", "upgDmgU010", "upgArmU009", "upgArmU004C"],
+                ["upgHpU015", "upgHpR017C", "upgDmgU018C", "upgDmgU003", "upgArmR005", "upgArmU007"],
+                ["upgHpR006C", "upgHpU017", "upgDmgR029", "upgDmgR010C", "upgArmU003C", "upgArmR006"],
+                ["upgHpR029", "upgHpR008", "upgDmgR14C", "upgDmgR003", "upgArmR012C", "upgArmR013C"],
+                ["upgHpE029C", "upgHpR015C", "upgDmgR005", "upgDmgE006C", "upgArmR029", "upgArmR004C"],
+                ["upgHpR002", "upgHpE007C", "upgDmgE029C", "upgDmgR016C", "upgArmE029C", "upgArmE008"],
+                ["upgHpE029C", "upgHpE012", "upgDmgE029C", "upgDmgE003", "upgArmE029C", "upgArmE003C"],
+                ["upgHpE029C", "upgHpE008C", "upgDmgL029C", "upgDmgE006C", "upgArmE008", "upgArmE005C"],
+                ["upgHpL109", "upgHpL011C", "upgDmgE029C", "upgDmgL002C", "upgArmE029C", "upgArmL011C"],
+                ["upgHpL029C", "upgHpL009C", "upgDmgE010", "upgDmgL005C", "upgArmL029C", "upgArmL003C"],
+                ["upgHpL129C", "upgHpL012C", "upgDmgL029C", "upgDmgL016C", "upgArmL029C", "upgArmL005C"],
+                ["upgHpL029C", "upgHpL011C", "upgDmgL129C", "upgDmgL002C", "upgArmL129C", "upgArmL011C"],
+                ["upgHpL129C", "upgHpL011C", "upgDmgL129C", "upgDmgL002C", "upgArmL129C", "upgArmL004C"],
+                ["upgHpL129C", "upgHpL212C", "upgDmgL129C", "upgDmgL212C", "upgArmL129C", "upgArmL212C"],
+                ["upgHpL129C", "upgHpL212C", "upgDmgM211C", "upgDmgL212C", "upgArmM212C", "upgArmL212C"],
+                ["upgHpM129C", "upgHpL212C", "upgDmgM211C", "upgDmgL212C", "upgArmM213C", "upgArmL212C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [10, 10, 4, 4, 3, 3],
+                [12, 12, 3, 4, 2, 2],
+                [11, 17, 6, 6, 4, 4],
+                [22, 15, 6, 6, 3, 5],
+                [16, 31, 10, 7, 7, 4],
+                [39, 19, 9, 12, 7, 7],
+                [37, 37, 15, 11, 9, 9],
+                [50, 40, 12, 21, 9, 13],
+                [43, 71, 23, 18, 15, 12],
+                [79, 64, 29, 23, 17, 17],
+                [90, 90, 35, 29, 19, 24],
+                [101, 122, 37, 44, 25, 29],
+                [140, 140, 40, 60, 34, 34],
+                [176, 176, 64, 64, 42, 42],
+                [219, 219, 79, 79, 53, 53],
+                [276, 276, 99, 99, 66, 66],
+                [344, 344, 124, 124, 82, 82],
+                [187, 187, 72, 62, 48, 42],
+                [202, 173, 73, 62, 48, 42],
+                [167, 208, 60, 75, 40, 50]
+            ]
+        },
+        "thousAhriman": {
+            "name": "Ahriman",
+            "FactionId": "ThousandSons",
+            "GrandAllianceId": "Chaos",
+            "BaseRarity": "Legendary",
+            "powerMultiplier": 88,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 1,
+                    "DamageProfile": "Flame"
+                },
+                {
+                    "hits": 1,
+                    "DamageProfile": "Psychic",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 80,
+                "Damage": 30,
+                "FixedArmor": 18,
+                "ProgressionIndex": 12
+            },
+            "traits": ["Hero", "WeaverOfFate", "Flying", "Psyker"],
+            "activeAbilities": ["Doombolt"],
+            "passiveAbilities": ["PsychicStalk"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "campaign": {
+                    "campaignType": "Standard",
+                    "campaignId": "campaign4",
+                    "level": 75
+                }
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_thousAhriman_01"],
+            "upgrades": [
+                ["upgHpC007", "upgHpC010", "upgDmgC004", "upgDmgC014", "upgArmC013", "upgArmC006"],
+                ["upgHpC016", "upgHpC015", "upgDmgU003", "upgDmgU012", "upgArmC007", "upgArmC006"],
+                ["upgHpU016", "upgHpU015", "upgDmgC008", "upgDmgC010", "upgArmU009", "upgArmU013"],
+                ["upgHpU005C", "upgHpU017", "upgDmgU003", "upgDmgU010", "upgArmU007", "upgArmU005"],
+                ["upgHpU016", "upgHpR017C", "upgDmgU008C", "upgDmgU012", "upgArmR005", "upgArmU013"],
+                ["upgHpR017C", "upgHpU009", "upgDmgR029", "upgDmgR010C", "upgArmU009", "upgArmR015"],
+                ["upgHpR029", "upgHpR008", "upgDmgR14C", "upgDmgR005", "upgArmR004C", "upgArmR003C"],
+                ["upgHpE029C", "upgHpR015C", "upgDmgR003", "upgDmgE006C", "upgArmR029", "upgArmR013C"],
+                ["upgHpR014", "upgHpE007C", "upgDmgE029C", "upgDmgR016C", "upgArmE029C", "upgArmE013"],
+                ["upgHpE029C", "upgHpE017", "upgDmgE029C", "upgDmgE010", "upgArmE029C", "upgArmE004C"],
+                ["upgHpL109", "upgHpE008C", "upgDmgL029C", "upgDmgE006C", "upgArmE029C", "upgArmE011C"],
+                ["upgHpE029C", "upgHpL017C", "upgDmgE029C", "upgDmgL016C", "upgArmL202", "upgArmL004C"],
+                ["upgHpL029C", "upgHpL009C", "upgDmgL202", "upgDmgL005C", "upgArmL029C", "upgArmL011C"],
+                ["upgHpL129C", "upgHpL012C", "upgDmgL029C", "upgDmgL016C", "upgArmL029C", "upgArmL005C"],
+                ["upgHpL029C", "upgHpL011C", "upgDmgL129C", "upgDmgL010C", "upgArmL129C", "upgArmL011C"],
+                ["upgHpL129C", "upgHpL011C", "upgDmgL129C", "upgDmgL002C", "upgArmL129C", "upgArmL004C"],
+                ["upgHpL129C", "upgHpL212C", "upgDmgL129C", "upgDmgL212C", "upgArmL129C", "upgArmL212C"],
+                ["upgHpL129C", "upgHpL212C", "upgDmgM211C", "upgDmgL212C", "upgArmM214C", "upgArmL212C"],
+                ["upgHpM129C", "upgHpL212C", "upgDmgM211C", "upgDmgL212C", "upgArmM214C", "upgArmL212C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [10, 10, 4, 4, 3, 3],
+                [13, 13, 5, 5, 2, 2],
+                [16, 16, 6, 6, 4, 4],
+                [23, 16, 7, 7, 4, 4],
+                [16, 33, 11, 7, 7, 4],
+                [41, 21, 10, 14, 6, 8],
+                [39, 39, 17, 12, 9, 9],
+                [54, 43, 14, 23, 9, 13],
+                [46, 76, 25, 20, 15, 12],
+                [84, 68, 32, 25, 17, 17],
+                [96, 96, 39, 32, 22, 22],
+                [108, 130, 41, 49, 24, 29],
+                [150, 150, 51, 61, 34, 34],
+                [187, 187, 71, 71, 42, 42],
+                [234, 234, 87, 87, 53, 53],
+                [294, 294, 110, 110, 66, 66],
+                [367, 367, 138, 138, 82, 82],
+                [200, 200, 81, 69, 48, 42],
+                [215, 185, 81, 69, 48, 42],
+                [177, 222, 67, 83, 40, 50]
+            ]
+        },
+        "thousSekhetar": {
+            "name": "Sekhetar Robot",
+            "FactionId": "ThousandSons",
+            "GrandAllianceId": "Chaos",
+            "BaseRarity": "Uncommon",
+            "powerMultiplier": 67,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 2,
+                    "DamageProfile": "Power"
+                },
+                {
+                    "hits": 2,
+                    "DamageProfile": "HeavyRound",
+                    "Range": 3
+                }
+            ],
+            "stats": {
+                "Health": 95,
+                "Damage": 28,
+                "FixedArmor": 22,
+                "ProgressionIndex": 3
+            },
+            "traits": ["Hero", "WeaverOfFate", "Mechanical", "Camouflage", "Infiltrate", "Overwatch"],
+            "activeAbilities": ["HeavyWarpFlamer"],
+            "passiveAbilities": ["PropheticSentinel"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [1],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "timestampIfHeroUnlocked": 1787529600000,
+                "timestampIfHeroNotUnlocked": 1789516800000
+            },
+            "releaseStatus": "1785974400000",
+            "unlockQuestIds": ["hero_thousSekhetar_01"],
+            "upgrades": [
+                ["upgHpC002", "upgHpC002", "upgDmgC004", "upgDmgC014", "upgArmC003", "upgArmC013"],
+                ["upgHpC014", "upgHpC002", "upgDmgU003", "upgDmgU016C", "upgArmC013", "upgArmC012"],
+                ["upgHpU014", "upgHpU004C", "upgDmgC008", "upgDmgC009", "upgArmU005", "upgArmU009"],
+                ["upgHpU004C", "upgHpU017", "upgDmgU003", "upgDmgU012", "upgArmU009", "upgArmU010C"],
+                ["upgHpU014", "upgHpR017C", "upgDmgU008C", "upgDmgU019", "upgArmR005", "upgArmU002"],
+                ["upgHpR012C", "upgHpU007", "upgDmgR029", "upgDmgR011C", "upgArmU010C", "upgArmR006"],
+                ["upgHpR029", "upgHpR014", "upgDmgR14C", "upgDmgR005", "upgArmR003C", "upgArmR012C"],
+                ["upgHpE029C", "upgHpR004C", "upgDmgR003", "upgDmgE008C", "upgArmR029", "upgArmR008C"],
+                ["upgHpR014", "upgHpE001C", "upgDmgE029C", "upgDmgR016C", "upgArmE029C", "upgArmE010"],
+                ["upgHpE029C", "upgHpE017", "upgDmgE029C", "upgDmgE010", "upgArmE029C", "upgArmE004C"],
+                ["upgHpL109", "upgHpE014C", "upgDmgL029C", "upgDmgE008C", "upgArmE029C", "upgArmE006C"],
+                ["upgHpE029C", "upgHpL017C", "upgDmgE029C", "upgDmgL016C", "upgArmL202", "upgArmL004C"],
+                ["upgHpL029C", "upgHpL001C", "upgDmgL202", "upgDmgL006C", "upgArmL029C", "upgArmL006C"],
+                ["upgHpL129C", "upgHpL014C", "upgDmgL029C", "upgDmgL016C", "upgArmL029C", "upgArmL008C"],
+                ["upgHpL029C", "upgHpL001C", "upgDmgL129C", "upgDmgL010C", "upgArmL129C", "upgArmL006C"],
+                ["upgHpL129C", "upgHpL017C", "upgDmgL129C", "upgDmgL002C", "upgArmL129C", "upgArmL004C"],
+                ["upgHpL129C", "upgHpL214C", "upgDmgL129C", "upgDmgL214C", "upgArmL129C", "upgArmL214C"],
+                ["upgHpL129C", "upgHpL214C", "upgDmgM214C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpM129C", "upgHpL214C", "upgDmgM214C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 4, 4, 3, 3],
+                [15, 15, 3, 5, 3, 3],
+                [15, 22, 6, 6, 5, 5],
+                [28, 19, 7, 7, 4, 6],
+                [20, 39, 10, 6, 8, 6],
+                [49, 25, 9, 13, 9, 9],
+                [46, 46, 15, 12, 10, 10],
+                [64, 52, 13, 21, 12, 15],
+                [54, 90, 24, 19, 18, 15],
+                [101, 80, 29, 24, 21, 21],
+                [114, 114, 37, 30, 27, 27],
+                [128, 154, 38, 45, 29, 35],
+                [178, 178, 48, 57, 42, 42],
+                [222, 222, 66, 66, 51, 51],
+                [279, 279, 82, 82, 64, 64],
+                [348, 348, 103, 103, 81, 81],
+                [436, 436, 128, 128, 101, 101],
+                [238, 238, 75, 65, 59, 51],
+                [255, 219, 75, 65, 59, 51],
+                [211, 263, 62, 78, 49, 61]
+            ]
+        },
+        "thousDaemonPrince": {
+            "name": "Z'Kar",
+            "FactionId": "ThousandSons",
+            "GrandAllianceId": "Chaos",
+            "BaseRarity": "Common",
+            "stats": {
+                "Health": 0,
+                "Damage": 0,
+                "FixedArmor": 0,
+                "ProgressionIndex": 0
+            },
+            "traits": ["MachineOfWar"],
+            "activeAbilities": ["AetherStride", "InfernalCannon"],
+            "mythicAbilities": ["CabalOfSorcerers"],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "timestampIfHeroUnlocked": 1766822400000,
+                "timestampIfHeroNotUnlocked": 1769846400000
+            },
+            "releaseStatus": "1766102400000",
+            "unlockQuestIds": ["hero_thousDaemonPrince_01"],
+            "upgrades": null,
+            "upgradesStatIncrease": null
+        },
+        "darkaHellblaster": {
+            "name": "Sarquael",
+            "FactionId": "DarkAngels",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Uncommon",
+            "powerMultiplier": 90,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 1,
+                    "DamageProfile": "Physical"
+                },
+                {
+                    "hits": 1,
+                    "DamageProfile": "Plasma",
+                    "Range": 3
+                }
+            ],
+            "stats": {
+                "Health": 70,
+                "Damage": 50,
+                "FixedArmor": 20,
+                "ProgressionIndex": 3
+            },
+            "traits": ["Hero", "FinalJustice", "Overwatch", "HeavyWeapon"],
+            "activeAbilities": ["Supercharge"],
+            "passiveAbilities": ["GrimRetribution"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_darkaHellblaster_01"],
+            "upgrades": [
+                ["upgHpC014", "upgHpC002", "upgDmgC013", "upgDmgC011", "upgArmC006", "upgArmC001"],
+                ["upgHpC014", "upgHpC003", "upgDmgC002", "upgDmgU009", "upgArmC013", "upgArmU005"],
+                ["upgHpC015", "upgHpU003", "upgDmgU013C", "upgDmgU009", "upgArmC013", "upgArmU009"],
+                ["upgHpU001", "upgHpU004C", "upgDmgU004", "upgDmgU015C", "upgArmU013", "upgArmU001"],
+                ["upgHpU001", "upgHpU002", "upgDmgU002C", "upgDmgR13C", "upgArmU013", "upgArmR003C"],
+                ["upgHpR018", "upgHpR004C", "upgDmgR032", "upgDmgU015C", "upgArmR013C", "upgArmR005"],
+                ["upgHpR032", "upgHpR004C", "upgDmgR002", "upgDmgR004C", "upgArmR012C", "upgArmR001C"],
+                ["upgHpE032C", "upgHpR020C", "upgDmgE002C", "upgDmgR004C", "upgArmR032", "upgArmR003C"],
+                ["upgHpR019", "upgHpE001C", "upgDmgE032C", "upgDmgR015C", "upgArmE032C", "upgArmE001C"],
+                ["upgHpE032C", "upgHpE002C", "upgDmgE032C", "upgDmgE004", "upgArmE032C", "upgArmE004C"],
+                ["upgHpE032C", "upgHpE012", "upgDmgL032C", "upgDmgE007C", "upgArmL032C", "upgArmE001C"],
+                ["upgHpL032C", "upgHpL002C", "upgDmgE032C", "upgDmgL015C", "upgArmE032C", "upgArmL006C"],
+                ["upgHpL132C", "upgHpL001C", "upgDmgL032C", "upgDmgL006C", "upgArmL032C", "upgArmL010C"],
+                ["upgHpL032C", "upgHpL009C", "upgDmgL132C", "upgDmgL006C", "upgArmL132C", "upgArmL004C"],
+                ["upgHpL132C", "upgHpL002C", "upgDmgL132C", "upgDmgL015C", "upgArmL132C", "upgArmL010C"],
+                ["upgHpL132C", "upgHpL017C", "upgDmgL132C", "upgDmgL002C", "upgArmL132C", "upgArmL004C"],
+                ["upgHpL132C", "upgHpL213C", "upgDmgL132C", "upgDmgL213C", "upgArmL132C", "upgArmL213C"],
+                ["upgHpL132C", "upgHpL213C", "upgDmgM214C", "upgDmgL213C", "upgArmM211C", "upgArmL213C"],
+                ["upgHpM132C", "upgHpL213C", "upgDmgM214C", "upgDmgL213C", "upgArmM213C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [9, 9, 7, 7, 3, 3],
+                [11, 11, 5, 9, 2, 3],
+                [9, 18, 12, 8, 3, 5],
+                [14, 21, 10, 15, 5, 5],
+                [22, 22, 13, 18, 4, 9],
+                [23, 31, 20, 20, 9, 6],
+                [29, 39, 20, 27, 10, 10],
+                [47, 38, 34, 27, 10, 14],
+                [40, 66, 42, 34, 15, 15],
+                [67, 67, 53, 42, 19, 19],
+                [92, 74, 65, 54, 26, 22],
+                [105, 105, 68, 82, 27, 33],
+                [131, 131, 94, 94, 37, 37],
+                [164, 164, 117, 117, 47, 47],
+                [205, 205, 146, 146, 59, 59],
+                [256, 256, 183, 183, 73, 73],
+                [322, 322, 230, 230, 92, 92],
+                [175, 175, 135, 115, 54, 46],
+                [188, 161, 135, 115, 54, 46],
+                [156, 194, 111, 138, 44, 56]
+            ]
+        },
+        "darkaTerminator": {
+            "name": "Baraqiel",
+            "FactionId": "DarkAngels",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Uncommon",
+            "Movement": 2,
+            "weapons": [
+                {
+                    "hits": 3,
+                    "DamageProfile": "Power"
+                }
+            ],
+            "stats": {
+                "Health": 110,
+                "Damage": 22,
+                "FixedArmor": 29,
+                "ProgressionIndex": 3
+            },
+            "traits": ["Hero", "TeleportStrike", "CrushingStrike", "HeavyWeapon", "TerminatorArmour"],
+            "activeAbilities": ["PlasmaCannon"],
+            "passiveAbilities": ["Deathwing"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Block"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_darkaTerminator_01"],
+            "upgrades": [
+                ["upgHpC002", "upgHpC004", "upgDmgC009", "upgDmgC011", "upgArmC004", "upgArmC002"],
+                ["upgHpC014", "upgHpC002", "upgDmgU012", "upgDmgU015C", "upgArmC001", "upgArmC001"],
+                ["upgHpU014", "upgHpU004C", "upgDmgC013", "upgDmgC012", "upgArmU008", "upgArmU001"],
+                ["upgHpU004C", "upgHpU017", "upgDmgU012", "upgDmgU009", "upgArmU001", "upgArmU010C"],
+                ["upgHpU014", "upgHpR017C", "upgDmgU018C", "upgDmgU011", "upgArmR005", "upgArmU001"],
+                ["upgHpR012C", "upgHpU006", "upgDmgR032", "upgDmgR004C", "upgArmU003C", "upgArmR015"],
+                ["upgHpR032", "upgHpR005", "upgDmgR13C", "upgDmgR005", "upgArmR001C", "upgArmR003C"],
+                ["upgHpE032C", "upgHpR004C", "upgDmgR006", "upgDmgE007C", "upgArmR032", "upgArmR001C"],
+                ["upgHpR019", "upgHpE001C", "upgDmgE032C", "upgDmgR015C", "upgArmE032C", "upgArmE013"],
+                ["upgHpE032C", "upgHpE003", "upgDmgE032C", "upgDmgE004", "upgArmE032C", "upgArmE004C"],
+                ["upgHpL112", "upgHpE002C", "upgDmgL032C", "upgDmgE007C", "upgArmE032C", "upgArmE001C"],
+                ["upgHpE032C", "upgHpL017C", "upgDmgE032C", "upgDmgL015C", "upgArmL001", "upgArmL004C"],
+                ["upgHpL032C", "upgHpL001C", "upgDmgL003", "upgDmgL012C", "upgArmL032C", "upgArmL010C"],
+                ["upgHpL132C", "upgHpL002C", "upgDmgL032C", "upgDmgL015C", "upgArmL032C", "upgArmL010C"],
+                ["upgHpL032C", "upgHpL001C", "upgDmgL132C", "upgDmgL008C", "upgArmL132C", "upgArmL010C"],
+                ["upgHpL132C", "upgHpL017C", "upgDmgL132C", "upgDmgL006C", "upgArmL132C", "upgArmL004C"],
+                ["upgHpL132C", "upgHpL213C", "upgDmgL132C", "upgDmgL213C", "upgArmL132C", "upgArmL213C"],
+                ["upgHpL132C", "upgHpL213C", "upgDmgM214C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpM132C", "upgHpL213C", "upgDmgM214C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [14, 14, 3, 3, 4, 4],
+                [17, 17, 2, 4, 4, 4],
+                [18, 26, 5, 5, 6, 6],
+                [32, 22, 5, 5, 6, 8],
+                [23, 45, 8, 6, 11, 7],
+                [57, 29, 7, 10, 12, 12],
+                [53, 53, 12, 9, 14, 14],
+                [74, 60, 10, 17, 15, 19],
+                [63, 104, 18, 15, 24, 20],
+                [117, 93, 23, 19, 28, 28],
+                [131, 131, 29, 24, 35, 35],
+                [150, 179, 30, 35, 39, 46],
+                [206, 206, 38, 45, 55, 55],
+                [257, 257, 52, 52, 67, 67],
+                [322, 322, 64, 64, 85, 85],
+                [404, 404, 81, 81, 107, 107],
+                [505, 505, 101, 101, 133, 133],
+                [275, 275, 59, 50, 78, 66],
+                [296, 254, 59, 51, 78, 67],
+                [244, 305, 49, 61, 64, 81]
+            ]
+        },
+        "darkaCompanion": {
+            "name": "Forcas",
+            "FactionId": "DarkAngels",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Rare",
+            "powerMultiplier": 108,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 6,
+                    "DamageProfile": "Power"
+                }
+            ],
+            "stats": {
+                "Health": 90,
+                "Damage": 12,
+                "FixedArmor": 21,
+                "ProgressionIndex": 6
+            },
+            "traits": ["Hero", "Camouflage", "Parry"],
+            "activeAbilities": ["CalibaniteGreatsword"],
+            "passiveAbilities": ["EnmityForTheUnworthy"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_darkaCompanion_01"],
+            "upgrades": [
+                ["upgHpC015", "upgHpC004", "upgDmgC010", "upgDmgC011", "upgArmC013", "upgArmC002"],
+                ["upgHpC003", "upgHpC002", "upgDmgU010", "upgDmgU015C", "upgArmC006", "upgArmC001"],
+                ["upgHpU002", "upgHpU004C", "upgDmgC013", "upgDmgC004", "upgArmU009", "upgArmU001"],
+                ["upgHpU018C", "upgHpU017", "upgDmgU010", "upgDmgU003", "upgArmU013", "upgArmU010C"],
+                ["upgHpU002", "upgHpR017C", "upgDmgU018C", "upgDmgU011", "upgArmR005", "upgArmU001"],
+                ["upgHpR020C", "upgHpU006", "upgDmgR032", "upgDmgR012C", "upgArmU003C", "upgArmR015"],
+                ["upgHpR032", "upgHpR005", "upgDmgR13C", "upgDmgR005", "upgArmR013C", "upgArmR003C"],
+                ["upgHpE032C", "upgHpR004C", "upgDmgR002", "upgDmgE002C", "upgArmR032", "upgArmR001C"],
+                ["upgHpR019", "upgHpE001C", "upgDmgE032C", "upgDmgR015C", "upgArmE032C", "upgArmE013"],
+                ["upgHpE032C", "upgHpE017", "upgDmgE032C", "upgDmgE011", "upgArmE032C", "upgArmE004C"],
+                ["upgHpL112", "upgHpE002C", "upgDmgL032C", "upgDmgE002C", "upgArmE032C", "upgArmE001C"],
+                ["upgHpE032C", "upgHpL017C", "upgDmgE032C", "upgDmgL015C", "upgArmL203", "upgArmL004C"],
+                ["upgHpL032C", "upgHpL001C", "upgDmgL001", "upgDmgL002C", "upgArmL032C", "upgArmL010C"],
+                ["upgHpL132C", "upgHpL002C", "upgDmgL032C", "upgDmgL015C", "upgArmL032C", "upgArmL011C"],
+                ["upgHpL032C", "upgHpL009C", "upgDmgL132C", "upgDmgL008C", "upgArmL132C", "upgArmL010C"],
+                ["upgHpL132C", "upgHpL002C", "upgDmgL132C", "upgDmgL005C", "upgArmL132C", "upgArmL004C"],
+                ["upgHpL132C", "upgHpL213C", "upgDmgL132C", "upgDmgL213C", "upgArmL132C", "upgArmL213C"],
+                ["upgHpL132C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM211C", "upgArmL213C"],
+                ["upgHpM132C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM213C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 2, 2, 3, 3],
+                [14, 14, 1, 2, 3, 3],
+                [14, 21, 3, 3, 4, 4],
+                [26, 18, 2, 2, 4, 7],
+                [19, 37, 5, 3, 8, 5],
+                [47, 23, 4, 5, 8, 8],
+                [44, 44, 7, 5, 10, 10],
+                [60, 48, 5, 9, 11, 15],
+                [51, 86, 11, 8, 18, 14],
+                [96, 76, 13, 10, 20, 20],
+                [107, 107, 15, 13, 25, 25],
+                [122, 147, 16, 20, 29, 34],
+                [168, 168, 20, 25, 39, 39],
+                [211, 211, 28, 28, 49, 49],
+                [264, 264, 35, 35, 62, 62],
+                [330, 330, 44, 44, 77, 77],
+                [413, 413, 56, 56, 96, 96],
+                [225, 225, 32, 27, 57, 48],
+                [242, 208, 32, 28, 57, 48],
+                [200, 249, 27, 33, 47, 58]
+            ]
+        },
+        "darkaAsmodai": {
+            "name": "Asmodai",
+            "FactionId": "DarkAngels",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Epic",
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 4,
+                    "DamageProfile": "Power"
+                }
+            ],
+            "stats": {
+                "Health": 90,
+                "Damage": 20,
+                "FixedArmor": 23,
+                "ProgressionIndex": 9
+            },
+            "traits": ["Hero", "Terrifying"],
+            "activeAbilities": ["ExemplarOfHate"],
+            "passiveAbilities": ["FearedInterrogator"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_darkaAsmodai_01"],
+            "upgrades": [
+                ["upgHpC015", "upgHpC004", "upgDmgC003", "upgDmgC011", "upgArmC013", "upgArmC002"],
+                ["upgHpC013", "upgHpC007", "upgDmgU014", "upgDmgU015C", "upgArmC006", "upgArmC001"],
+                ["upgHpU012", "upgHpU005C", "upgDmgC013", "upgDmgC004", "upgArmU009", "upgArmU001"],
+                ["upgHpU018C", "upgHpU017", "upgDmgU014", "upgDmgU003", "upgArmU013", "upgArmU010C"],
+                ["upgHpU012", "upgHpR017C", "upgDmgU018C", "upgDmgU011", "upgArmR005", "upgArmU001"],
+                ["upgHpR015C", "upgHpU006", "upgDmgR032", "upgDmgR012C", "upgArmU003C", "upgArmR015"],
+                ["upgHpR032", "upgHpR005", "upgDmgR13C", "upgDmgR005", "upgArmR013C", "upgArmR003C"],
+                ["upgHpE032C", "upgHpR006C", "upgDmgR002", "upgDmgE002C", "upgArmR032", "upgArmR001C"],
+                ["upgHpR018", "upgHpE006C", "upgDmgE032C", "upgDmgR015C", "upgArmE032C", "upgArmE013"],
+                ["upgHpE032C", "upgHpE017", "upgDmgE032C", "upgDmgE003", "upgArmE032C", "upgArmE004C"],
+                ["upgHpL112", "upgHpE002C", "upgDmgL032C", "upgDmgE002C", "upgArmE032C", "upgArmE001C"],
+                ["upgHpE032C", "upgHpL017C", "upgDmgE032C", "upgDmgL015C", "upgArmL001", "upgArmL004C"],
+                ["upgHpL032C", "upgHpL011C", "upgDmgL003", "upgDmgL002C", "upgArmL032C", "upgArmL010C"],
+                ["upgHpL132C", "upgHpL002C", "upgDmgL032C", "upgDmgL015C", "upgArmL032C", "upgArmL011C"],
+                ["upgHpL032C", "upgHpL009C", "upgDmgL132C", "upgDmgL008C", "upgArmL132C", "upgArmL010C"],
+                ["upgHpL132C", "upgHpL009C", "upgDmgL132C", "upgDmgL009C", "upgArmL132C", "upgArmL004C"],
+                ["upgHpL132C", "upgHpL211C", "upgDmgL132C", "upgDmgL211C", "upgArmL132C", "upgArmL211C"],
+                ["upgHpL132C", "upgHpL211C", "upgDmgM211C", "upgDmgL211C", "upgArmM211C", "upgArmL211C"],
+                ["upgHpM132C", "upgHpL211C", "upgDmgM211C", "upgDmgL211C", "upgArmM213C", "upgArmL211C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 3, 3, 3, 3],
+                [14, 14, 2, 3, 4, 4],
+                [14, 21, 4, 4, 4, 4],
+                [26, 18, 5, 5, 5, 7],
+                [19, 37, 8, 5, 8, 6],
+                [47, 23, 6, 9, 9, 9],
+                [44, 44, 11, 8, 11, 11],
+                [60, 48, 9, 16, 12, 16],
+                [51, 86, 17, 13, 19, 16],
+                [96, 76, 21, 17, 22, 22],
+                [107, 107, 26, 22, 28, 28],
+                [122, 147, 27, 33, 30, 37],
+                [168, 168, 34, 40, 43, 43],
+                [211, 211, 47, 47, 54, 54],
+                [264, 264, 59, 59, 68, 68],
+                [330, 330, 73, 73, 84, 84],
+                [413, 413, 92, 92, 106, 106],
+                [225, 225, 54, 46, 61, 53],
+                [242, 208, 54, 46, 62, 53],
+                [200, 249, 44, 56, 51, 63]
+            ]
+        },
+        "darkaAzrael": {
+            "name": "Azrael",
+            "FactionId": "DarkAngels",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Epic",
+            "powerMultiplier": 84,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 3,
+                    "DamageProfile": "Power"
+                },
+                {
+                    "hits": 1,
+                    "DamageProfile": "Plasma",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 95,
+                "Damage": 28,
+                "FixedArmor": 24,
+                "ProgressionIndex": 9
+            },
+            "traits": ["Hero", "FinalJustice", "Overwatch"],
+            "activeAbilities": ["DarkTalonStrike"],
+            "passiveAbilities": ["LionHelm"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Block"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_darkaAzrael_01"],
+            "upgrades": [
+                ["upgHpC015", "upgHpC002", "upgDmgC013", "upgDmgC011", "upgArmC006", "upgArmC001"],
+                ["upgHpC016", "upgHpC003", "upgDmgC002", "upgDmgU009", "upgArmC013", "upgArmU005"],
+                ["upgHpC015", "upgHpU017", "upgDmgU018C", "upgDmgU009", "upgArmC013", "upgArmU013"],
+                ["upgHpU015", "upgHpU004C", "upgDmgU004", "upgDmgU015C", "upgArmU009", "upgArmU001"],
+                ["upgHpU015", "upgHpU002", "upgDmgU002C", "upgDmgR13C", "upgArmU009", "upgArmR003C"],
+                ["upgHpR018", "upgHpR017C", "upgDmgR032", "upgDmgU015C", "upgArmR005", "upgArmR013C"],
+                ["upgHpR032", "upgHpR017C", "upgDmgR007", "upgDmgR004C", "upgArmR012C", "upgArmR001C"],
+                ["upgHpE032C", "upgHpR020C", "upgDmgE002C", "upgDmgR004C", "upgArmR032", "upgArmR003C"],
+                ["upgHpR019", "upgHpE001C", "upgDmgE032C", "upgDmgR015C", "upgArmE032C", "upgArmE001C"],
+                ["upgHpE032C", "upgHpE002C", "upgDmgE032C", "upgDmgE011", "upgArmE032C", "upgArmE004C"],
+                ["upgHpE032C", "upgHpE012", "upgDmgL032C", "upgDmgE007C", "upgArmL032C", "upgArmE001C"],
+                ["upgHpL032C", "upgHpL002C", "upgDmgE032C", "upgDmgL015C", "upgArmE032C", "upgArmL011C"],
+                ["upgHpL132C", "upgHpL001C", "upgDmgL032C", "upgDmgL008C", "upgArmL032C", "upgArmL010C"],
+                ["upgHpL032C", "upgHpL009C", "upgDmgL132C", "upgDmgL008C", "upgArmL132C", "upgArmL004C"],
+                ["upgHpL132C", "upgHpL002C", "upgDmgL132C", "upgDmgL015C", "upgArmL132C", "upgArmL010C"],
+                ["upgHpL132C", "upgHpL002C", "upgDmgL132C", "upgDmgL005C", "upgArmL132C", "upgArmL004C"],
+                ["upgHpL132C", "upgHpL213C", "upgDmgL132C", "upgDmgL213C", "upgArmL132C", "upgArmL213C"],
+                ["upgHpL132C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM211C", "upgArmL213C"],
+                ["upgHpM132C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM213C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 4, 4, 3, 3],
+                [15, 15, 3, 5, 3, 5],
+                [12, 25, 7, 4, 3, 6],
+                [19, 28, 6, 8, 6, 6],
+                [30, 30, 7, 10, 5, 10],
+                [31, 42, 11, 11, 8, 10],
+                [39, 53, 12, 15, 12, 12],
+                [64, 52, 19, 15, 12, 17],
+                [54, 90, 24, 19, 18, 18],
+                [91, 91, 29, 24, 23, 23],
+                [126, 100, 37, 30, 31, 26],
+                [142, 142, 38, 45, 33, 39],
+                [177, 177, 53, 53, 45, 45],
+                [223, 223, 65, 65, 56, 56],
+                [278, 278, 82, 82, 71, 71],
+                [349, 349, 103, 103, 88, 88],
+                [436, 436, 129, 129, 110, 110],
+                [237, 237, 75, 64, 64, 55],
+                [256, 219, 75, 65, 65, 55],
+                [211, 263, 62, 78, 53, 67]
+            ]
+        },
+        "darkaSternguard": {
+            "name": "Ramus",
+            "FactionId": "DarkAngels",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Rare",
+            "powerMultiplier": 108,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 1,
+                    "DamageProfile": "Melta"
+                },
+                {
+                    "hits": 1,
+                    "DamageProfile": "Bolter",
+                    "Range": 3
+                }
+            ],
+            "stats": {
+                "Health": 85,
+                "Damage": 40,
+                "FixedArmor": 21,
+                "ProgressionIndex": 6
+            },
+            "traits": ["Hero", "Overwatch"],
+            "activeAbilities": ["SternguardFocus"],
+            "passiveAbilities": ["SpecialIssueCombiMelta"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "timestampIfHeroUnlocked": 1784419200000,
+                "timestampIfHeroNotUnlocked": 1788652800000
+            },
+            "releaseStatus": "1784419200000",
+            "unlockQuestIds": ["hero_darkaSternguard_01"],
+            "upgrades": [
+                ["upgHpC015", "upgHpC004", "upgDmgC004", "upgDmgC011", "upgArmC002", "upgArmC001"],
+                ["upgHpC003", "upgHpC002", "upgDmgU003", "upgDmgU015C", "upgArmC001", "upgArmC001"],
+                ["upgHpU002", "upgHpU004C", "upgDmgC001", "upgDmgC009", "upgArmU005", "upgArmU001"],
+                ["upgHpU018C", "upgHpU017", "upgDmgU003", "upgDmgU012", "upgArmU001", "upgArmU010C"],
+                ["upgHpU002", "upgHpR017C", "upgDmgU001C", "upgDmgU011", "upgArmR006", "upgArmU001"],
+                ["upgHpR020C", "upgHpU006", "upgDmgR032", "upgDmgR011C", "upgArmU010C", "upgArmR015"],
+                ["upgHpR032", "upgHpR005", "upgDmgR001C", "upgDmgR005", "upgArmR003C", "upgArmR001C"],
+                ["upgHpE032C", "upgHpR004C", "upgDmgR002", "upgDmgE008C", "upgArmR032", "upgArmR001C"],
+                ["upgHpR018", "upgHpE001C", "upgDmgE032C", "upgDmgR015C", "upgArmE032C", "upgArmE013"],
+                ["upgHpE032C", "upgHpE017", "upgDmgE032C", "upgDmgE004", "upgArmE032C", "upgArmE004C"],
+                ["upgHpL112", "upgHpE002C", "upgDmgL032C", "upgDmgE008C", "upgArmE032C", "upgArmE001C"],
+                ["upgHpE032C", "upgHpL017C", "upgDmgE032C", "upgDmgL015C", "upgArmL203", "upgArmL004C"],
+                ["upgHpL032C", "upgHpL001C", "upgDmgL001", "upgDmgL006C", "upgArmL032C", "upgArmL010C"],
+                ["upgHpL132C", "upgHpL002C", "upgDmgL032C", "upgDmgL015C", "upgArmL032C", "upgArmL010C"],
+                ["upgHpL032C", "upgHpL009C", "upgDmgL132C", "upgDmgL007C", "upgArmL132C", "upgArmL010C"],
+                ["upgHpL132C", "upgHpL002C", "upgDmgL132C", "upgDmgL002C", "upgArmL132C", "upgArmL004C"],
+                ["upgHpL132C", "upgHpL213C", "upgDmgL132C", "upgDmgL213C", "upgArmL132C", "upgArmL213C"],
+                ["upgHpL132C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM211C", "upgArmL213C"],
+                ["upgHpM132C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [11, 11, 5, 5, 3, 3],
+                [13, 13, 5, 8, 3, 3],
+                [14, 20, 8, 8, 4, 4],
+                [25, 17, 10, 10, 4, 7],
+                [17, 35, 14, 10, 8, 5],
+                [44, 22, 13, 18, 8, 8],
+                [42, 42, 22, 17, 10, 10],
+                [57, 45, 18, 30, 11, 15],
+                [48, 81, 34, 27, 18, 14],
+                [90, 72, 43, 34, 20, 20],
+                [102, 102, 52, 43, 25, 25],
+                [115, 138, 54, 65, 29, 34],
+                [159, 159, 68, 82, 39, 39],
+                [199, 199, 94, 94, 49, 49],
+                [249, 249, 117, 117, 62, 62],
+                [312, 312, 147, 147, 77, 77],
+                [390, 390, 183, 183, 96, 96],
+                [213, 213, 108, 92, 57, 48],
+                [228, 196, 108, 92, 57, 48],
+                [188, 236, 89, 111, 47, 58]
+            ]
+        },
+        "darkaStormSpeeder": {
+            "name": "Storm Speeder",
+            "FactionId": "DarkAngels",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Common",
+            "stats": {
+                "Health": 0,
+                "Damage": 0,
+                "FixedArmor": 0,
+                "ProgressionIndex": 0
+            },
+            "traits": ["MachineOfWar"],
+            "activeAbilities": ["DeathOnTheWind", "Hailstrike"],
+            "mythicAbilities": ["MastersOfManoeuvre"],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "timestampIfHeroUnlocked": 1772870400000,
+                "timestampIfHeroNotUnlocked": 1775894400000
+            },
+            "releaseStatus": "1772179200000",
+            "unlockQuestIds": ["hero_darkaStormSpeeder_01"],
+            "upgrades": null,
+            "upgradesStatIncrease": null
+        },
+        "tyranNeurothrope": {
+            "name": "Neurothrope",
+            "FactionId": "Tyranids",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Rare",
+            "powerMultiplier": 93,
+            "Movement": 2,
+            "weapons": [
+                {
+                    "hits": 1,
+                    "DamageProfile": "Physical"
+                },
+                {
+                    "hits": 1,
+                    "DamageProfile": "Psychic",
+                    "Range": 3
+                }
+            ],
+            "stats": {
+                "Health": 85,
+                "Damage": 20,
+                "FixedArmor": 17,
+                "ProgressionIndex": 6
+            },
+            "traits": ["Hero", "RangedSpecialist", "Flying", "Psyker", "ShadowInTheWarp", "Synapse"],
+            "activeAbilities": ["SpiritLeech"],
+            "passiveAbilities": ["Neuroparasite"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Block"],
+            "itemSlotsRelic": [2],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_tyranNeurothrope_01"],
+            "upgrades": [
+                ["upgHpC013", "upgHpC010", "upgDmgC003", "upgDmgC003", "upgArmC005", "upgArmC005"],
+                ["upgHpC017", "upgHpC009", "upgDmgU014", "upgDmgU016C", "upgArmC005", "upgArmC007"],
+                ["upgHpU017", "upgHpU010C", "upgDmgC008", "upgDmgC014", "upgArmU007", "upgArmC007"],
+                ["upgHpU010C", "upgHpU009", "upgDmgU014", "upgDmgU014", "upgArmU007", "upgArmU004C"],
+                ["upgHpU017", "upgHpR009C", "upgDmgU008C", "upgDmgU014", "upgArmR015", "upgArmU007"],
+                ["upgHpR017C", "upgHpU009", "upgDmgR033", "upgDmgR14C", "upgArmU004C", "upgArmR015"],
+                ["upgHpR033", "upgHpR008", "upgDmgR14C", "upgDmgR005", "upgArmR002C", "upgArmR002C"],
+                ["upgHpE033C", "upgHpR009C", "upgDmgR005", "upgDmgE009C", "upgArmR033", "upgArmR004C"],
+                ["upgHpR019", "upgHpE013C", "upgDmgE033C", "upgDmgR016C", "upgArmE033C", "upgArmE008"],
+                ["upgHpE033C", "upgHpE015", "upgDmgE033C", "upgDmgE010", "upgArmE033C", "upgArmE003C"],
+                ["upgHpL113", "upgHpE008C", "upgDmgL033C", "upgDmgE009C", "upgArmE033C", "upgArmE005C"],
+                ["upgHpE033C", "upgHpL012C", "upgDmgE033C", "upgDmgL016C", "upgArmL202", "upgArmE003C"],
+                ["upgHpL033C", "upgHpL013C", "upgDmgL202", "upgDmgL010C", "upgArmL033C", "upgArmL003C"],
+                ["upgHpL133C", "upgHpL012C", "upgDmgL033C", "upgDmgL016C", "upgArmL033C", "upgArmL005C"],
+                ["upgHpL033C", "upgHpL013C", "upgDmgL133C", "upgDmgL009C", "upgArmL133C", "upgArmL005C"],
+                ["upgHpL133C", "upgHpL017C", "upgDmgL133C", "upgDmgL010C", "upgArmL133C", "upgArmL003C"],
+                ["upgHpL133C", "upgHpL212C", "upgDmgL133C", "upgDmgL212C", "upgArmL133C", "upgArmL212C"],
+                ["upgHpL133C", "upgHpL212C", "upgDmgM212C", "upgDmgL212C", "upgArmM212C", "upgArmL212C"],
+                ["upgHpM133C", "upgHpL212C", "upgDmgM212C", "upgDmgL212C", "upgArmM212C", "upgArmL212C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [11, 11, 3, 3, 2, 2],
+                [13, 13, 2, 3, 3, 3],
+                [14, 20, 4, 4, 4, 2],
+                [25, 17, 5, 5, 4, 5],
+                [17, 35, 8, 5, 6, 4],
+                [44, 22, 6, 9, 7, 7],
+                [42, 42, 11, 8, 8, 8],
+                [57, 45, 9, 16, 9, 12],
+                [48, 81, 17, 13, 14, 11],
+                [90, 72, 21, 17, 17, 17],
+                [102, 102, 26, 22, 20, 20],
+                [115, 138, 27, 33, 25, 25],
+                [159, 159, 34, 40, 32, 32],
+                [199, 199, 47, 47, 40, 40],
+                [249, 249, 59, 59, 50, 50],
+                [312, 312, 73, 73, 62, 62],
+                [390, 390, 92, 92, 78, 78],
+                [213, 213, 54, 46, 46, 39],
+                [228, 196, 54, 46, 46, 39],
+                [188, 236, 44, 56, 38, 47]
+            ]
+        },
+        "tyranTyrantGuard": {
+            "name": "Tyrant Guard",
+            "FactionId": "Tyranids",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Uncommon",
+            "powerMultiplier": 113,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 2,
+                    "DamageProfile": "Piercing"
+                }
+            ],
+            "stats": {
+                "Health": 125,
+                "Damage": 16,
+                "FixedArmor": 22,
+                "ProgressionIndex": 3
+            },
+            "traits": ["Hero", "BigTarget", "CrushingStrike"],
+            "activeAbilities": ["CrushingClaws"],
+            "passiveAbilities": ["GuardianOrganism"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Defensive"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_tyranTyrantGuard_01"],
+            "upgrades": [
+                ["upgHpC009", "upgHpC010", "upgDmgC003", "upgDmgC014", "upgArmC005", "upgArmC005"],
+                ["upgHpC001", "upgHpC009", "upgDmgU014", "upgDmgU016C", "upgArmC007", "upgArmC007"],
+                ["upgHpU001", "upgHpU010C", "upgDmgC008", "upgDmgC003", "upgArmU006", "upgArmU007"],
+                ["upgHpU010C", "upgHpU017", "upgDmgU014", "upgDmgU014", "upgArmU007", "upgArmU006"],
+                ["upgHpU001", "upgHpR017C", "upgDmgU008C", "upgDmgU019", "upgArmR015", "upgArmU007"],
+                ["upgHpR003C", "upgHpU009", "upgDmgR033", "upgDmgR012C", "upgArmU006", "upgArmR015"],
+                ["upgHpR033", "upgHpR008", "upgDmgR14C", "upgDmgR005", "upgArmR004C", "upgArmR002C"],
+                ["upgHpE033C", "upgHpR009C", "upgDmgR005", "upgDmgE009C", "upgArmR033", "upgArmR004C"],
+                ["upgHpR019", "upgHpE013C", "upgDmgE033C", "upgDmgR016C", "upgArmE033C", "upgArmE013"],
+                ["upgHpE033C", "upgHpE015", "upgDmgE033C", "upgDmgE010", "upgArmE033C", "upgArmE003C"],
+                ["upgHpL113", "upgHpE008C", "upgDmgL033C", "upgDmgE009C", "upgArmE033C", "upgArmE005C"],
+                ["upgHpE033C", "upgHpL017C", "upgDmgE033C", "upgDmgL016C", "upgArmL202", "upgArmL003C"],
+                ["upgHpL033C", "upgHpL013C", "upgDmgL202", "upgDmgL009C", "upgArmL033C", "upgArmL005C"],
+                ["upgHpL133C", "upgHpL012C", "upgDmgL033C", "upgDmgL016C", "upgArmL033C", "upgArmL005C"],
+                ["upgHpL033C", "upgHpL013C", "upgDmgL133C", "upgDmgL009C", "upgArmL133C", "upgArmL005C"],
+                ["upgHpL133C", "upgHpL017C", "upgDmgL133C", "upgDmgL009C", "upgArmL133C", "upgArmL003C"],
+                ["upgHpL133C", "upgHpL211C", "upgDmgL133C", "upgDmgL211C", "upgArmL133C", "upgArmL211C"],
+                ["upgHpL133C", "upgHpL211C", "upgDmgM212C", "upgDmgL211C", "upgArmM212C", "upgArmL211C"],
+                ["upgHpM133C", "upgHpL211C", "upgDmgM212C", "upgDmgL211C", "upgArmM212C", "upgArmL211C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [16, 16, 2, 2, 3, 3],
+                [20, 20, 2, 3, 3, 3],
+                [19, 29, 3, 3, 5, 5],
+                [37, 25, 4, 4, 5, 5],
+                [26, 52, 6, 4, 8, 6],
+                [64, 32, 6, 7, 7, 10],
+                [61, 61, 9, 6, 11, 11],
+                [84, 68, 8, 13, 11, 15],
+                [71, 119, 13, 10, 18, 15],
+                [132, 106, 17, 13, 21, 21],
+                [149, 149, 21, 18, 27, 27],
+                [170, 203, 21, 26, 29, 35],
+                [234, 234, 27, 33, 42, 42],
+                [293, 293, 38, 38, 51, 51],
+                [366, 366, 47, 47, 64, 64],
+                [458, 458, 58, 58, 81, 81],
+                [574, 574, 74, 74, 101, 101],
+                [313, 313, 43, 36, 59, 51],
+                [336, 288, 43, 37, 59, 51],
+                [277, 347, 36, 44, 49, 61]
+            ]
+        },
+        "tyranWingedPrime": {
+            "name": "Winged Prime",
+            "FactionId": "Tyranids",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Rare",
+            "Movement": 4,
+            "weapons": [
+                {
+                    "hits": 6,
+                    "DamageProfile": "Bio"
+                }
+            ],
+            "stats": {
+                "Health": 100,
+                "Damage": 11,
+                "FixedArmor": 19,
+                "ProgressionIndex": 6
+            },
+            "traits": ["Hero", "Synapse", "Flying", "FinalJustice"],
+            "activeAbilities": ["AlphaWarrior"],
+            "passiveAbilities": ["SynapticLinchpin"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_tyranWingedPrime_01"],
+            "upgrades": [
+                ["upgHpC009", "upgHpC010", "upgDmgC003", "upgDmgC014", "upgArmC005", "upgArmC005"],
+                ["upgHpC001", "upgHpC009", "upgDmgU014", "upgDmgU016C", "upgArmC007", "upgArmC007"],
+                ["upgHpU001", "upgHpU010C", "upgDmgC008", "upgDmgC003", "upgArmU006", "upgArmU007"],
+                ["upgHpU010C", "upgHpU017", "upgDmgU014", "upgDmgU014", "upgArmU007", "upgArmU004C"],
+                ["upgHpU001", "upgHpR017C", "upgDmgU008C", "upgDmgU019", "upgArmR015", "upgArmU007"],
+                ["upgHpR003C", "upgHpU009", "upgDmgR033", "upgDmgR012C", "upgArmU004C", "upgArmR015"],
+                ["upgHpR033", "upgHpR008", "upgDmgR14C", "upgDmgR005", "upgArmR004C", "upgArmR002C"],
+                ["upgHpE033C", "upgHpR009C", "upgDmgR005", "upgDmgE009C", "upgArmR033", "upgArmR004C"],
+                ["upgHpR019", "upgHpE013C", "upgDmgE033C", "upgDmgR016C", "upgArmE033C", "upgArmE013"],
+                ["upgHpE033C", "upgHpE015", "upgDmgE033C", "upgDmgE010", "upgArmE033C", "upgArmE003C"],
+                ["upgHpL113", "upgHpE008C", "upgDmgL033C", "upgDmgE009C", "upgArmE033C", "upgArmE005C"],
+                ["upgHpE033C", "upgHpL017C", "upgDmgE033C", "upgDmgL016C", "upgArmL202", "upgArmL003C"],
+                ["upgHpL033C", "upgHpL013C", "upgDmgL202", "upgDmgL009C", "upgArmL033C", "upgArmL005C"],
+                ["upgHpL133C", "upgHpL012C", "upgDmgL033C", "upgDmgL016C", "upgArmL033C", "upgArmL005C"],
+                ["upgHpL033C", "upgHpL013C", "upgDmgL133C", "upgDmgL010C", "upgArmL133C", "upgArmL005C"],
+                ["upgHpL133C", "upgHpL017C", "upgDmgL133C", "upgDmgL009C", "upgArmL133C", "upgArmL003C"],
+                ["upgHpL133C", "upgHpL211C", "upgDmgL133C", "upgDmgL211C", "upgArmL133C", "upgArmL211C"],
+                ["upgHpL133C", "upgHpL211C", "upgDmgM212C", "upgDmgL211C", "upgArmM212C", "upgArmL211C"],
+                ["upgHpM133C", "upgHpL211C", "upgDmgM212C", "upgDmgL211C", "upgArmM212C", "upgArmL211C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [13, 13, 2, 2, 3, 3],
+                [16, 16, 1, 1, 3, 3],
+                [15, 23, 3, 3, 3, 3],
+                [30, 20, 2, 2, 4, 6],
+                [21, 41, 4, 3, 7, 4],
+                [51, 26, 3, 5, 8, 8],
+                [49, 49, 6, 5, 9, 9],
+                [67, 54, 5, 8, 10, 13],
+                [57, 95, 9, 8, 16, 13],
+                [106, 84, 12, 9, 18, 18],
+                [120, 120, 14, 12, 23, 23],
+                [135, 162, 15, 18, 25, 31],
+                [187, 187, 19, 22, 36, 36],
+                [234, 234, 26, 26, 44, 44],
+                [293, 293, 32, 32, 56, 56],
+                [367, 367, 41, 41, 70, 70],
+                [459, 459, 50, 50, 87, 87],
+                [250, 250, 30, 25, 51, 43],
+                [269, 231, 30, 25, 51, 44],
+                [222, 278, 24, 31, 42, 53]
+            ]
+        },
+        "tyranDeathleaper": {
+            "name": "Deathleaper",
+            "FactionId": "Tyranids",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Epic",
+            "powerMultiplier": 102,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 3,
+                    "DamageProfile": "Bio"
+                }
+            ],
+            "stats": {
+                "Health": 80,
+                "Damage": 24,
+                "FixedArmor": 17,
+                "ProgressionIndex": 9
+            },
+            "traits": ["Hero", "Camouflage", "TeleportStrike", "Infiltrate", "Terrifying"],
+            "activeAbilities": ["FearOfTheUnseen"],
+            "passiveAbilities": ["FeederTendrils"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_tyranDeathleaper_01"],
+            "upgrades": [
+                ["upgHpC009", "upgHpC010", "upgDmgC003", "upgDmgC014", "upgArmC005", "upgArmC005"],
+                ["upgHpC013", "upgHpC009", "upgDmgU014", "upgDmgU016C", "upgArmC007", "upgArmC007"],
+                ["upgHpU012", "upgHpU010C", "upgDmgC008", "upgDmgC003", "upgArmU006", "upgArmU007"],
+                ["upgHpU010C", "upgHpU017", "upgDmgU014", "upgDmgU014", "upgArmU007", "upgArmU004C"],
+                ["upgHpU012", "upgHpR017C", "upgDmgU008C", "upgDmgU012", "upgArmR015", "upgArmU007"],
+                ["upgHpR015C", "upgHpU009", "upgDmgR033", "upgDmgR012C", "upgArmU004C", "upgArmR015"],
+                ["upgHpR033", "upgHpR008", "upgDmgR14C", "upgDmgR005", "upgArmR004C", "upgArmR002C"],
+                ["upgHpE033C", "upgHpR009C", "upgDmgR005", "upgDmgE009C", "upgArmR033", "upgArmR004C"],
+                ["upgHpR019", "upgHpE013C", "upgDmgE033C", "upgDmgR016C", "upgArmE033C", "upgArmE013"],
+                ["upgHpE033C", "upgHpE017", "upgDmgE033C", "upgDmgE010", "upgArmE033C", "upgArmE003C"],
+                ["upgHpL113", "upgHpE008C", "upgDmgL033C", "upgDmgE009C", "upgArmE033C", "upgArmE005C"],
+                ["upgHpE033C", "upgHpL017C", "upgDmgE033C", "upgDmgL016C", "upgArmL202", "upgArmL003C"],
+                ["upgHpL033C", "upgHpL013C", "upgDmgL202", "upgDmgL009C", "upgArmL033C", "upgArmL005C"],
+                ["upgHpL133C", "upgHpL012C", "upgDmgL033C", "upgDmgL016C", "upgArmL033C", "upgArmL005C"],
+                ["upgHpL033C", "upgHpL013C", "upgDmgL133C", "upgDmgL010C", "upgArmL133C", "upgArmL005C"],
+                ["upgHpL133C", "upgHpL017C", "upgDmgL133C", "upgDmgL009C", "upgArmL133C", "upgArmL003C"],
+                ["upgHpL133C", "upgHpL212C", "upgDmgL133C", "upgDmgL212C", "upgArmL133C", "upgArmL212C"],
+                ["upgHpL133C", "upgHpL212C", "upgDmgM212C", "upgDmgL212C", "upgArmM212C", "upgArmL212C"],
+                ["upgHpM133C", "upgHpL212C", "upgDmgM212C", "upgDmgL212C", "upgArmM212C", "upgArmL212C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [10, 10, 3, 3, 2, 2],
+                [13, 13, 3, 5, 3, 3],
+                [12, 19, 5, 5, 3, 3],
+                [24, 16, 6, 6, 4, 5],
+                [16, 33, 8, 6, 6, 4],
+                [41, 21, 8, 10, 7, 7],
+                [39, 39, 14, 10, 8, 8],
+                [54, 43, 11, 18, 9, 12],
+                [46, 76, 20, 16, 14, 11],
+                [84, 68, 26, 20, 17, 17],
+                [96, 96, 31, 26, 20, 20],
+                [108, 130, 33, 39, 23, 27],
+                [150, 150, 41, 49, 32, 32],
+                [187, 187, 56, 56, 40, 40],
+                [234, 234, 71, 71, 50, 50],
+                [294, 294, 88, 88, 62, 62],
+                [367, 367, 110, 110, 78, 78],
+                [200, 200, 64, 55, 46, 39],
+                [215, 185, 65, 55, 46, 39],
+                [177, 222, 53, 67, 38, 47]
+            ]
+        },
+        "tyranParasite": {
+            "name": "Parasite of Mortrex",
+            "FactionId": "Tyranids",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Epic",
+            "powerMultiplier": 98,
+            "Movement": 4,
+            "weapons": [
+                {
+                    "hits": 1,
+                    "DamageProfile": "Toxic"
+                }
+            ],
+            "stats": {
+                "Health": 90,
+                "Damage": 45,
+                "FixedArmor": 17,
+                "ProgressionIndex": 9
+            },
+            "traits": ["Hero", "Flying", "Synapse"],
+            "activeAbilities": ["ItItches"],
+            "passiveAbilities": ["BarbedOvipositor"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "timestampIfHeroUnlocked": 1737244800000,
+                "timestampIfHeroNotUnlocked": 1737244800000
+            },
+            "releaseStatus": "1734220800000",
+            "unlockQuestIds": ["hero_tyranParasite_01"],
+            "upgrades": [
+                ["upgHpC009", "upgHpC010", "upgDmgC003", "upgDmgC014", "upgArmC005", "upgArmC005"],
+                ["upgHpC001", "upgHpC009", "upgDmgU014", "upgDmgU016C", "upgArmC007", "upgArmC007"],
+                ["upgHpU001", "upgHpU010C", "upgDmgC008", "upgDmgC003", "upgArmU006", "upgArmU007"],
+                ["upgHpU010C", "upgHpU017", "upgDmgU014", "upgDmgU014", "upgArmU007", "upgArmU004C"],
+                ["upgHpU001", "upgHpR017C", "upgDmgU008C", "upgDmgU019", "upgArmR015", "upgArmU007"],
+                ["upgHpR003C", "upgHpU009", "upgDmgR033", "upgDmgR012C", "upgArmU004C", "upgArmR015"],
+                ["upgHpR033", "upgHpR008", "upgDmgR14C", "upgDmgR005", "upgArmR004C", "upgArmR002C"],
+                ["upgHpE033C", "upgHpR009C", "upgDmgR005", "upgDmgE009C", "upgArmR033", "upgArmR004C"],
+                ["upgHpR019", "upgHpE013C", "upgDmgE033C", "upgDmgR016C", "upgArmE033C", "upgArmE013"],
+                ["upgHpE033C", "upgHpE015", "upgDmgE033C", "upgDmgE010", "upgArmE033C", "upgArmE003C"],
+                ["upgHpL113", "upgHpE008C", "upgDmgL033C", "upgDmgE009C", "upgArmE033C", "upgArmE005C"],
+                ["upgHpE033C", "upgHpL017C", "upgDmgE033C", "upgDmgL016C", "upgArmL202", "upgArmL003C"],
+                ["upgHpL033C", "upgHpL013C", "upgDmgL202", "upgDmgL009C", "upgArmL033C", "upgArmL005C"],
+                ["upgHpL133C", "upgHpL012C", "upgDmgL033C", "upgDmgL016C", "upgArmL033C", "upgArmL005C"],
+                ["upgHpL033C", "upgHpL013C", "upgDmgL133C", "upgDmgL010C", "upgArmL133C", "upgArmL005C"],
+                ["upgHpL133C", "upgHpL017C", "upgDmgL133C", "upgDmgL009C", "upgArmL133C", "upgArmL003C"],
+                ["upgHpL133C", "upgHpL211C", "upgDmgL133C", "upgDmgL211C", "upgArmL133C", "upgArmL211C"],
+                ["upgHpL133C", "upgHpL211C", "upgDmgM212C", "upgDmgL211C", "upgArmM212C", "upgArmL211C"],
+                ["upgHpM133C", "upgHpL211C", "upgDmgM212C", "upgDmgL211C", "upgArmM212C", "upgArmL211C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 6, 6, 2, 2],
+                [14, 14, 6, 8, 3, 3],
+                [14, 21, 9, 9, 3, 3],
+                [26, 18, 11, 11, 4, 5],
+                [19, 37, 16, 11, 6, 4],
+                [47, 23, 15, 20, 7, 7],
+                [44, 44, 25, 19, 8, 8],
+                [60, 48, 21, 34, 9, 12],
+                [51, 86, 38, 30, 14, 11],
+                [96, 76, 48, 38, 17, 17],
+                [107, 107, 58, 49, 20, 20],
+                [122, 147, 61, 74, 23, 27],
+                [168, 168, 76, 92, 32, 32],
+                [211, 211, 105, 105, 40, 40],
+                [264, 264, 132, 132, 50, 50],
+                [330, 330, 165, 165, 62, 62],
+                [413, 413, 207, 207, 78, 78],
+                [225, 225, 121, 103, 46, 39],
+                [242, 208, 121, 104, 46, 39],
+                [200, 249, 100, 125, 38, 47]
+            ]
+        },
+        "tyranBiovore": {
+            "name": "Biovore",
+            "FactionId": "Tyranids",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Common",
+            "stats": {
+                "Health": 0,
+                "Damage": 0,
+                "FixedArmor": 0,
+                "ProgressionIndex": 0
+            },
+            "traits": ["MachineOfWar"],
+            "activeAbilities": ["BioMinefield", "SporeMineLauncher"],
+            "mythicAbilities": ["HyperCorrosiveAcid"],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "timestampIfHeroUnlocked": 1718438400000,
+                "timestampIfHeroNotUnlocked": 1721462400000
+            },
+            "releaseStatus": "1717747200000",
+            "unlockQuestIds": ["hero_tyranBiovore_01"],
+            "upgrades": null,
+            "upgradesStatIncrease": null
+        },
+        "admecDominus": {
+            "name": "Vitruvius",
+            "FactionId": "AdeptusMechanicus",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Legendary",
+            "powerMultiplier": 108,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 1,
+                    "DamageProfile": "Power"
+                },
+                {
+                    "hits": 1,
+                    "DamageProfile": "Gauss",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 90,
+                "Damage": 50,
+                "FixedArmor": 18,
+                "ProgressionIndex": 12
+            },
+            "traits": ["Hero", "Mechanical", "Mechanic"],
+            "activeAbilities": ["RadBombardment"],
+            "passiveAbilities": ["MasterAnnihilator"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "timestampIfHeroUnlocked": 1728259200000,
+                "timestampIfHeroNotUnlocked": 1731196800000
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_admecDominus_01"],
+            "eventMetadata": {
+                "leg": {
+                    "finalEventEndDate": 1728259200000
+                }
+            },
+            "upgrades": [
+                ["upgHpC015", "upgHpC004", "upgDmgC012", "upgDmgC011", "upgArmC005", "upgArmC004"],
+                ["upgHpC016", "upgHpC002", "upgDmgU009", "upgDmgU015C", "upgArmC001", "upgArmC006"],
+                ["upgHpU016", "upgHpU004C", "upgDmgC007", "upgDmgC009", "upgArmU006", "upgArmU013"],
+                ["upgHpU018C", "upgHpU014", "upgDmgU009", "upgDmgU012", "upgArmU001", "upgArmU003C"],
+                ["upgHpU016", "upgHpR012C", "upgDmgU007C", "upgDmgU011", "upgArmR015", "upgArmU013"],
+                ["upgHpR016C", "upgHpU006", "upgDmgR034", "upgDmgR011C", "upgArmU004C", "upgArmR010"],
+                ["upgHpR001", "upgHpR005", "upgDmgR008C", "upgDmgR005", "upgArmR001C", "upgArmR007C"],
+                ["upgHpE034C", "upgHpR004C", "upgDmgR006", "upgDmgE008C", "upgArmR034", "upgArmR013C"],
+                ["upgHpR002", "upgHpE001C", "upgDmgE034C", "upgDmgR015C", "upgArmE034C", "upgArmE010"],
+                ["upgHpE034C", "upgHpE012", "upgDmgE034C", "upgDmgE004", "upgArmE034C", "upgArmE002C"],
+                ["upgHpL114", "upgHpE002C", "upgDmgL034C", "upgDmgE008C", "upgArmE034C", "upgArmE011C"],
+                ["upgHpE034C", "upgHpL013C", "upgDmgE034C", "upgDmgL015C", "upgArmL203", "upgArmL002C"],
+                ["upgHpL034C", "upgHpL001C", "upgDmgL003", "upgDmgL006C", "upgArmL034C", "upgArmL011C"],
+                ["upgHpL134C", "upgHpL002C", "upgDmgL034C", "upgDmgL015C", "upgArmL034C", "upgArmL010C"],
+                ["upgHpL034C", "upgHpL009C", "upgDmgL134C", "upgDmgL012C", "upgArmL134C", "upgArmL011C"],
+                ["upgHpL134C", "upgHpL011C", "upgDmgL134C", "upgDmgL012C", "upgArmL134C", "upgArmL002C"],
+                ["upgHpL134C", "upgHpL214C", "upgDmgL134C", "upgDmgL214C", "upgArmL134C", "upgArmL214C"],
+                ["upgHpL134C", "upgHpL214C", "upgDmgM213C", "upgDmgL214C", "upgArmM213C", "upgArmL214C"],
+                ["upgHpM134C", "upgHpL214C", "upgDmgM213C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 7, 7, 3, 3],
+                [14, 14, 6, 8, 2, 2],
+                [14, 21, 10, 10, 4, 4],
+                [26, 18, 13, 13, 3, 5],
+                [19, 37, 18, 12, 7, 4],
+                [47, 23, 17, 22, 7, 7],
+                [44, 44, 27, 21, 9, 9],
+                [60, 48, 23, 38, 9, 13],
+                [51, 86, 42, 34, 15, 12],
+                [96, 76, 53, 42, 17, 17],
+                [107, 107, 65, 54, 22, 22],
+                [122, 147, 68, 82, 24, 29],
+                [168, 168, 85, 102, 34, 34],
+                [211, 211, 117, 117, 42, 42],
+                [264, 264, 147, 147, 53, 53],
+                [330, 330, 183, 183, 66, 66],
+                [413, 413, 230, 230, 82, 82],
+                [225, 225, 134, 115, 48, 42],
+                [242, 208, 135, 115, 48, 42],
+                [200, 249, 111, 138, 40, 50]
+            ]
+        },
+        "admecManipulus": {
+            "name": "Actus",
+            "FactionId": "AdeptusMechanicus",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Rare",
+            "powerMultiplier": 107,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 2,
+                    "DamageProfile": "Energy"
+                },
+                {
+                    "hits": 2,
+                    "DamageProfile": "Energy",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 95,
+                "Damage": 25,
+                "FixedArmor": 19,
+                "ProgressionIndex": 6
+            },
+            "traits": ["Hero", "Mechanical", "Mechanic", "Flying"],
+            "activeAbilities": ["DefendTheDivineWork"],
+            "passiveAbilities": ["GalvanicField"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Block"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_admecManipulus_01"],
+            "upgrades": [
+                ["upgHpC015", "upgHpC004", "upgDmgC012", "upgDmgC011", "upgArmC005", "upgArmC004"],
+                ["upgHpC016", "upgHpC002", "upgDmgU009", "upgDmgU015C", "upgArmC001", "upgArmC006"],
+                ["upgHpU016", "upgHpU004C", "upgDmgC007", "upgDmgC009", "upgArmU006", "upgArmU013"],
+                ["upgHpU018C", "upgHpU014", "upgDmgU009", "upgDmgU012", "upgArmU001", "upgArmU003C"],
+                ["upgHpU016", "upgHpR012C", "upgDmgU007C", "upgDmgU011", "upgArmR015", "upgArmU013"],
+                ["upgHpR016C", "upgHpU006", "upgDmgR034", "upgDmgR011C", "upgArmU004C", "upgArmR010"],
+                ["upgHpR001", "upgHpR005", "upgDmgR008C", "upgDmgR005", "upgArmR001C", "upgArmR007C"],
+                ["upgHpE034C", "upgHpR004C", "upgDmgR006", "upgDmgE008C", "upgArmR034", "upgArmR013C"],
+                ["upgHpR002", "upgHpE001C", "upgDmgE034C", "upgDmgR015C", "upgArmE034C", "upgArmE010"],
+                ["upgHpE034C", "upgHpE012", "upgDmgE034C", "upgDmgE004", "upgArmE034C", "upgArmE002C"],
+                ["upgHpL114", "upgHpE002C", "upgDmgL034C", "upgDmgE008C", "upgArmE034C", "upgArmE011C"],
+                ["upgHpE034C", "upgHpL013C", "upgDmgE034C", "upgDmgL015C", "upgArmL203", "upgArmL002C"],
+                ["upgHpL034C", "upgHpL001C", "upgDmgL003", "upgDmgL006C", "upgArmL034C", "upgArmL011C"],
+                ["upgHpL134C", "upgHpL002C", "upgDmgL034C", "upgDmgL015C", "upgArmL034C", "upgArmL010C"],
+                ["upgHpL034C", "upgHpL009C", "upgDmgL134C", "upgDmgL012C", "upgArmL134C", "upgArmL011C"],
+                ["upgHpL134C", "upgHpL011C", "upgDmgL134C", "upgDmgL012C", "upgArmL134C", "upgArmL002C"],
+                ["upgHpL134C", "upgHpL214C", "upgDmgL134C", "upgDmgL214C", "upgArmL134C", "upgArmL214C"],
+                ["upgHpL134C", "upgHpL214C", "upgDmgM214C", "upgDmgL214C", "upgArmM213C", "upgArmL214C"],
+                ["upgHpM134C", "upgHpL214C", "upgDmgM214C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 3, 3, 3, 3],
+                [15, 15, 3, 5, 3, 3],
+                [15, 22, 5, 5, 3, 3],
+                [28, 19, 6, 6, 4, 6],
+                [20, 39, 10, 6, 7, 4],
+                [49, 25, 8, 11, 8, 8],
+                [46, 46, 14, 11, 9, 9],
+                [64, 52, 11, 19, 10, 13],
+                [54, 90, 21, 17, 16, 13],
+                [101, 80, 27, 21, 18, 18],
+                [114, 114, 32, 27, 23, 23],
+                [128, 154, 34, 41, 25, 31],
+                [178, 178, 42, 51, 36, 36],
+                [222, 222, 59, 59, 44, 44],
+                [279, 279, 73, 73, 56, 56],
+                [348, 348, 92, 92, 70, 70],
+                [436, 436, 115, 115, 87, 87],
+                [238, 238, 67, 57, 51, 43],
+                [255, 219, 67, 58, 51, 44],
+                [211, 263, 56, 69, 42, 53]
+            ]
+        },
+        "admecMarshall": {
+            "name": "Tan Gi'da",
+            "FactionId": "AdeptusMechanicus",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Rare",
+            "powerMultiplier": 117,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 2,
+                    "DamageProfile": "Physical"
+                },
+                {
+                    "hits": 1,
+                    "DamageProfile": "Toxic",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 85,
+                "Damage": 35,
+                "FixedArmor": 16,
+                "ProgressionIndex": 6
+            },
+            "traits": ["Hero", "Mechanical"],
+            "activeAbilities": ["DoctrinaImperatives"],
+            "passiveAbilities": ["ControlEdict"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [2],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_admecMarshall_01"],
+            "upgrades": [
+                ["upgHpC015", "upgHpC004", "upgDmgC010", "upgDmgC011", "upgArmC005", "upgArmC004"],
+                ["upgHpC017", "upgHpC002", "upgDmgU010", "upgDmgU015C", "upgArmC001", "upgArmC006"],
+                ["upgHpU017", "upgHpU004C", "upgDmgC013", "upgDmgC009", "upgArmU006", "upgArmU013"],
+                ["upgHpU018C", "upgHpU014", "upgDmgU010", "upgDmgU012", "upgArmU001", "upgArmU003C"],
+                ["upgHpU017", "upgHpR012C", "upgDmgU018C", "upgDmgU011", "upgArmR006", "upgArmU013"],
+                ["upgHpR017C", "upgHpU006", "upgDmgR034", "upgDmgR011C", "upgArmU004C", "upgArmR010"],
+                ["upgHpR001", "upgHpR005", "upgDmgR13C", "upgDmgR005", "upgArmR001C", "upgArmR007C"],
+                ["upgHpE034C", "upgHpR004C", "upgDmgR006", "upgDmgE008C", "upgArmR034", "upgArmR013C"],
+                ["upgHpR002", "upgHpE001C", "upgDmgE034C", "upgDmgR015C", "upgArmE034C", "upgArmE010"],
+                ["upgHpE034C", "upgHpE012", "upgDmgE034C", "upgDmgE004", "upgArmE034C", "upgArmE002C"],
+                ["upgHpL114", "upgHpE002C", "upgDmgL034C", "upgDmgE008C", "upgArmE034C", "upgArmE011C"],
+                ["upgHpE034C", "upgHpL017C", "upgDmgE034C", "upgDmgL015C", "upgArmL203", "upgArmL002C"],
+                ["upgHpL034C", "upgHpL001C", "upgDmgL003", "upgDmgL006C", "upgArmL034C", "upgArmL011C"],
+                ["upgHpL134C", "upgHpL002C", "upgDmgL034C", "upgDmgL015C", "upgArmL034C", "upgArmL010C"],
+                ["upgHpL034C", "upgHpL009C", "upgDmgL134C", "upgDmgL008C", "upgArmL134C", "upgArmL011C"],
+                ["upgHpL134C", "upgHpL017C", "upgDmgL134C", "upgDmgL005C", "upgArmL134C", "upgArmL002C"],
+                ["upgHpL134C", "upgHpL214C", "upgDmgL134C", "upgDmgL214C", "upgArmL134C", "upgArmL214C"],
+                ["upgHpL134C", "upgHpL214C", "upgDmgM213C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpM134C", "upgHpL214C", "upgDmgM213C", "upgDmgL214C", "upgArmM213C", "upgArmL214C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [11, 11, 5, 5, 2, 2],
+                [13, 13, 4, 6, 3, 3],
+                [14, 20, 7, 7, 3, 3],
+                [25, 17, 9, 9, 3, 4],
+                [17, 35, 13, 8, 6, 4],
+                [44, 22, 12, 15, 7, 7],
+                [42, 42, 19, 15, 7, 7],
+                [57, 45, 16, 26, 9, 11],
+                [48, 81, 30, 24, 13, 11],
+                [90, 72, 37, 29, 15, 15],
+                [102, 102, 46, 38, 20, 20],
+                [115, 138, 47, 57, 21, 25],
+                [159, 159, 60, 71, 30, 30],
+                [199, 199, 82, 82, 38, 38],
+                [249, 249, 103, 103, 47, 47],
+                [312, 312, 128, 128, 58, 58],
+                [390, 390, 161, 161, 74, 74],
+                [213, 213, 94, 80, 43, 36],
+                [228, 196, 94, 81, 43, 37],
+                [188, 236, 78, 97, 36, 44]
+            ]
+        },
+        "admecRuststalker": {
+            "name": "Exitor-Rho",
+            "FactionId": "AdeptusMechanicus",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Uncommon",
+            "powerMultiplier": 117,
+            "Movement": 4,
+            "weapons": [
+                {
+                    "hits": 2,
+                    "DamageProfile": "Energy"
+                }
+            ],
+            "stats": {
+                "Health": 80,
+                "Damage": 30,
+                "FixedArmor": 17,
+                "ProgressionIndex": 3
+            },
+            "traits": ["Hero", "Mechanical", "Camouflage", "Infiltrate", "Unstoppable"],
+            "activeAbilities": ["CordClaw"],
+            "passiveAbilities": ["OptimizedGait"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [2],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_admecRuststalker_01"],
+            "upgrades": [
+                ["upgHpC015", "upgHpC004", "upgDmgC003", "upgDmgC011", "upgArmC005", "upgArmC004"],
+                ["upgHpC014", "upgHpC002", "upgDmgU014", "upgDmgU015C", "upgArmC001", "upgArmC006"],
+                ["upgHpU014", "upgHpU004C", "upgDmgC013", "upgDmgC010", "upgArmU006", "upgArmU013"],
+                ["upgHpU018C", "upgHpU014", "upgDmgU014", "upgDmgU010", "upgArmU001", "upgArmU003C"],
+                ["upgHpU014", "upgHpR012C", "upgDmgU018C", "upgDmgU011", "upgArmR006", "upgArmU013"],
+                ["upgHpR012C", "upgHpU006", "upgDmgR034", "upgDmgR010C", "upgArmU004C", "upgArmR010"],
+                ["upgHpR001", "upgHpR005", "upgDmgR13C", "upgDmgR005", "upgArmR001C", "upgArmR007C"],
+                ["upgHpE034C", "upgHpR004C", "upgDmgR006", "upgDmgE006C", "upgArmR034", "upgArmR013C"],
+                ["upgHpR018", "upgHpE001C", "upgDmgE034C", "upgDmgR015C", "upgArmE034C", "upgArmE010"],
+                ["upgHpE034C", "upgHpE017", "upgDmgE034C", "upgDmgE004", "upgArmE034C", "upgArmE002C"],
+                ["upgHpL114", "upgHpE002C", "upgDmgL034C", "upgDmgE006C", "upgArmE034C", "upgArmE011C"],
+                ["upgHpE034C", "upgHpL017C", "upgDmgE034C", "upgDmgL015C", "upgArmL203", "upgArmL002C"],
+                ["upgHpL034C", "upgHpL001C", "upgDmgL003", "upgDmgL005C", "upgArmL034C", "upgArmL011C"],
+                ["upgHpL134C", "upgHpL002C", "upgDmgL034C", "upgDmgL015C", "upgArmL034C", "upgArmL010C"],
+                ["upgHpL034C", "upgHpL009C", "upgDmgL134C", "upgDmgL008C", "upgArmL134C", "upgArmL011C"],
+                ["upgHpL134C", "upgHpL013C", "upgDmgL134C", "upgDmgL009C", "upgArmL134C", "upgArmL002C"],
+                ["upgHpL134C", "upgHpL214C", "upgDmgL134C", "upgDmgL214C", "upgArmL134C", "upgArmL214C"],
+                ["upgHpL134C", "upgHpL214C", "upgDmgM213C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpM134C", "upgHpL214C", "upgDmgM213C", "upgDmgL214C", "upgArmM213C", "upgArmL214C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [10, 10, 4, 4, 2, 2],
+                [13, 13, 4, 5, 3, 3],
+                [12, 19, 6, 6, 3, 3],
+                [24, 16, 8, 8, 4, 5],
+                [16, 33, 10, 7, 6, 4],
+                [41, 21, 10, 14, 7, 7],
+                [39, 39, 17, 12, 8, 8],
+                [54, 43, 14, 23, 9, 12],
+                [46, 76, 25, 20, 14, 11],
+                [84, 68, 32, 25, 17, 17],
+                [96, 96, 39, 32, 20, 20],
+                [108, 130, 41, 49, 23, 27],
+                [150, 150, 51, 61, 32, 32],
+                [187, 187, 71, 71, 40, 40],
+                [234, 234, 87, 87, 50, 50],
+                [294, 294, 110, 110, 62, 62],
+                [367, 367, 138, 138, 78, 78],
+                [200, 200, 81, 69, 46, 39],
+                [215, 185, 81, 69, 46, 39],
+                [177, 222, 67, 83, 38, 47]
+            ]
+        },
+        "admecDestroyer": {
+            "name": "Sy-gex",
+            "FactionId": "AdeptusMechanicus",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Uncommon",
+            "powerMultiplier": 98,
+            "Movement": 2,
+            "weapons": [
+                {
+                    "hits": 4,
+                    "DamageProfile": "Flame"
+                },
+                {
+                    "hits": 4,
+                    "DamageProfile": "Physical",
+                    "Range": 3
+                }
+            ],
+            "stats": {
+                "Health": 95,
+                "Damage": 25,
+                "FixedArmor": 17,
+                "ProgressionIndex": 3
+            },
+            "traits": ["Hero", "Mechanical", "HeavyWeapon", "Overwatch", "Vehicle"],
+            "activeAbilities": ["SentinelDirectives"],
+            "passiveAbilities": ["HeavyGravCannon"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [2],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_admecDestroyer_01"],
+            "upgrades": [
+                ["upgHpC015", "upgHpC004", "upgDmgC010", "upgDmgC011", "upgArmC005", "upgArmC004"],
+                ["upgHpC014", "upgHpC002", "upgDmgU010", "upgDmgU015C", "upgArmC012", "upgArmC001"],
+                ["upgHpU014", "upgHpU004C", "upgDmgC007", "upgDmgC009", "upgArmU006", "upgArmU001"],
+                ["upgHpU018C", "upgHpU014", "upgDmgU010", "upgDmgU012", "upgArmU012", "upgArmU003C"],
+                ["upgHpU014", "upgHpR012C", "upgDmgU007C", "upgDmgU011", "upgArmR006", "upgArmU001"],
+                ["upgHpR012C", "upgHpU006", "upgDmgR034", "upgDmgR011C", "upgArmU004C", "upgArmR015"],
+                ["upgHpR001", "upgHpR005", "upgDmgR008C", "upgDmgR003", "upgArmR008C", "upgArmR007C"],
+                ["upgHpE034C", "upgHpR004C", "upgDmgR006", "upgDmgE008C", "upgArmR034", "upgArmR001C"],
+                ["upgHpR002", "upgHpE001C", "upgDmgE034C", "upgDmgR015C", "upgArmE034C", "upgArmE010"],
+                ["upgHpE034C", "upgHpE015", "upgDmgE034C", "upgDmgE004", "upgArmE034C", "upgArmE002C"],
+                ["upgHpL114", "upgHpE002C", "upgDmgL034C", "upgDmgE008C", "upgArmE034C", "upgArmE001C"],
+                ["upgHpE034C", "upgHpL017C", "upgDmgE034C", "upgDmgL015C", "upgArmL203", "upgArmL002C"],
+                ["upgHpL034C", "upgHpL001C", "upgDmgL003", "upgDmgL006C", "upgArmL034C", "upgArmL010C"],
+                ["upgHpL134C", "upgHpL002C", "upgDmgL034C", "upgDmgL015C", "upgArmL034C", "upgArmL009C"],
+                ["upgHpL034C", "upgHpL009C", "upgDmgL134C", "upgDmgL012C", "upgArmL134C", "upgArmL010C"],
+                ["upgHpL134C", "upgHpL013C", "upgDmgL134C", "upgDmgL005C", "upgArmL134C", "upgArmL002C"],
+                ["upgHpL134C", "upgHpL214C", "upgDmgL134C", "upgDmgL214C", "upgArmL134C", "upgArmL214C"],
+                ["upgHpL134C", "upgHpL214C", "upgDmgM214C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpM134C", "upgHpL214C", "upgDmgM214C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 3, 3, 2, 2],
+                [15, 15, 3, 5, 3, 3],
+                [15, 22, 5, 5, 3, 3],
+                [28, 19, 6, 6, 4, 5],
+                [20, 39, 10, 6, 6, 4],
+                [49, 25, 8, 11, 7, 7],
+                [46, 46, 14, 11, 8, 8],
+                [64, 52, 11, 19, 9, 12],
+                [54, 90, 21, 17, 14, 11],
+                [101, 80, 27, 21, 17, 17],
+                [114, 114, 32, 27, 20, 20],
+                [128, 154, 34, 41, 23, 27],
+                [178, 178, 42, 51, 32, 32],
+                [222, 222, 59, 59, 40, 40],
+                [279, 279, 73, 73, 50, 50],
+                [348, 348, 92, 92, 62, 62],
+                [436, 436, 115, 115, 78, 78],
+                [238, 238, 67, 57, 46, 39],
+                [255, 219, 67, 58, 46, 39],
+                [211, 263, 56, 69, 38, 47]
+            ]
+        },
+        "worldTerminator": {
+            "name": "Wrask",
+            "FactionId": "WorldEaters",
+            "GrandAllianceId": "Chaos",
+            "BaseRarity": "Uncommon",
+            "powerMultiplier": 97,
+            "Movement": 2,
+            "weapons": [
+                {
+                    "hits": 4,
+                    "DamageProfile": "Flame"
+                }
+            ],
+            "stats": {
+                "Health": 95,
+                "Damage": 20,
+                "FixedArmor": 28,
+                "ProgressionIndex": 3
+            },
+            "traits": [
+                "Hero",
+                "BlessingsOfKhorne",
+                "TeleportStrike",
+                "RapidAssault",
+                "TerminatorArmour",
+                "Unstoppable"
+            ],
+            "activeAbilities": ["BloodyFury"],
+            "passiveAbilities": ["WrathfulDevotion"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Block"],
+            "itemSlotsRelic": [1],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_worldTerminator_01"],
+            "upgrades": [
+                ["upgHpC002", "upgHpC010", "upgDmgC009", "upgDmgC014", "upgArmC013", "upgArmC006"],
+                ["upgHpC014", "upgHpC002", "upgDmgU012", "upgDmgU016C", "upgArmC007", "upgArmC007"],
+                ["upgHpU014", "upgHpU004C", "upgDmgC013", "upgDmgC003", "upgArmU009", "upgArmU007"],
+                ["upgHpU004C", "upgHpU012", "upgDmgU012", "upgDmgU014", "upgArmU007", "upgArmU003C"],
+                ["upgHpU014", "upgHpR015C", "upgDmgU018C", "upgDmgU019", "upgArmR005", "upgArmU007"],
+                ["upgHpR012C", "upgHpU009", "upgDmgR038", "upgDmgR012C", "upgArmU003C", "upgArmR015"],
+                ["upgHpR038", "upgHpR008", "upgDmgR13C", "upgDmgR006", "upgArmR004C", "upgArmR003C"],
+                ["upgHpE038C", "upgHpR004C", "upgDmgR005", "upgDmgE009C", "upgArmR038", "upgArmR004C"],
+                ["upgHpR018", "upgHpE001C", "upgDmgE038C", "upgDmgR016C", "upgArmE038C", "upgArmE013"],
+                ["upgHpE038C", "upgHpE003", "upgDmgE038C", "upgDmgE004", "upgArmE038C", "upgArmE004C"],
+                ["upgHpL118", "upgHpE008C", "upgDmgL038C", "upgDmgE009C", "upgArmE038C", "upgArmE005C"],
+                ["upgHpE038C", "upgHpL009C", "upgDmgE038C", "upgDmgL016C", "upgArmL203", "upgArmL004C"],
+                ["upgHpL038C", "upgHpL001C", "upgDmgL003", "upgDmgL009C", "upgArmL038C", "upgArmL005C"],
+                ["upgHpL138C", "upgHpL012C", "upgDmgL038C", "upgDmgL016C", "upgArmL038C", "upgArmL005C"],
+                ["upgHpL038C", "upgHpL001C", "upgDmgL138C", "upgDmgL008C", "upgArmL138C", "upgArmL005C"],
+                ["upgHpL138C", "upgHpL017C", "upgDmgL138C", "upgDmgL006C", "upgArmL138C", "upgArmL004C"],
+                ["upgHpL138C", "upgHpL213C", "upgDmgL138C", "upgDmgL213C", "upgArmL138C", "upgArmL213C"],
+                ["upgHpL138C", "upgHpL213C", "upgDmgM214C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpM138C", "upgHpL213C", "upgDmgM214C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 3, 3, 4, 4],
+                [15, 15, 2, 3, 4, 4],
+                [15, 22, 4, 4, 6, 6],
+                [28, 19, 5, 5, 5, 8],
+                [20, 39, 8, 5, 10, 7],
+                [49, 25, 6, 9, 11, 11],
+                [46, 46, 11, 8, 14, 14],
+                [64, 52, 9, 16, 14, 19],
+                [54, 90, 17, 13, 24, 19],
+                [101, 80, 21, 17, 27, 27],
+                [114, 114, 26, 22, 33, 33],
+                [128, 154, 27, 33, 38, 45],
+                [178, 178, 34, 40, 53, 53],
+                [222, 222, 47, 47, 65, 65],
+                [279, 279, 59, 59, 82, 82],
+                [348, 348, 73, 73, 103, 103],
+                [436, 436, 92, 92, 129, 129],
+                [238, 238, 54, 46, 75, 64],
+                [255, 219, 54, 46, 75, 65],
+                [211, 263, 44, 56, 62, 78]
+            ]
+        },
+        "worldJakhal": {
+            "name": "Macer",
+            "FactionId": "WorldEaters",
+            "GrandAllianceId": "Chaos",
+            "BaseRarity": "Uncommon",
+            "powerMultiplier": 116,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 3,
+                    "DamageProfile": "Chain"
+                }
+            ],
+            "stats": {
+                "Health": 90,
+                "Damage": 30,
+                "FixedArmor": 10,
+                "ProgressionIndex": 3
+            },
+            "traits": ["Hero", "BlessingsOfKhorne", "Resilient"],
+            "activeAbilities": ["JakhalStimms"],
+            "passiveAbilities": ["Skullsmasher"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [2],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_worldJakhal_01"],
+            "upgrades": [
+                ["upgHpC015", "upgHpC010", "upgDmgC003", "upgDmgC014", "upgArmC003", "upgArmC003"],
+                ["upgHpC001", "upgHpC002", "upgDmgU014", "upgDmgU016C", "upgArmC007", "upgArmC007"],
+                ["upgHpU001", "upgHpU004C", "upgDmgC013", "upgDmgC003", "upgArmU002", "upgArmU007"],
+                ["upgHpU018C", "upgHpU012", "upgDmgU014", "upgDmgU014", "upgArmU007", "upgArmU003C"],
+                ["upgHpU001", "upgHpR015C", "upgDmgU018C", "upgDmgU019", "upgArmR006", "upgArmU007"],
+                ["upgHpR003C", "upgHpU009", "upgDmgR038", "upgDmgR012C", "upgArmU003C", "upgArmR006"],
+                ["upgHpR038", "upgHpR008", "upgDmgR13C", "upgDmgR006", "upgArmR004C", "upgArmR007C"],
+                ["upgHpE038C", "upgHpR004C", "upgDmgR003", "upgDmgE009C", "upgArmR038", "upgArmR004C"],
+                ["upgHpR018", "upgHpE001C", "upgDmgE038C", "upgDmgR016C", "upgArmE038C", "upgArmE009"],
+                ["upgHpE038C", "upgHpE015", "upgDmgE038C", "upgDmgE004", "upgArmE038C", "upgArmE002C"],
+                ["upgHpL118", "upgHpE008C", "upgDmgL038C", "upgDmgE009C", "upgArmE038C", "upgArmE005C"],
+                ["upgHpE038C", "upgHpL009C", "upgDmgE038C", "upgDmgL016C", "upgArmL203", "upgArmL002C"],
+                ["upgHpL038C", "upgHpL001C", "upgDmgL003", "upgDmgL009C", "upgArmL038C", "upgArmL005C"],
+                ["upgHpL138C", "upgHpL012C", "upgDmgL038C", "upgDmgL016C", "upgArmL038C", "upgArmL005C"],
+                ["upgHpL038C", "upgHpL009C", "upgDmgL138C", "upgDmgL008C", "upgArmL138C", "upgArmL005C"],
+                ["upgHpL138C", "upgHpL017C", "upgDmgL138C", "upgDmgL009C", "upgArmL138C", "upgArmL002C"],
+                ["upgHpL138C", "upgHpL211C", "upgDmgL138C", "upgDmgL211C", "upgArmL138C", "upgArmL211C"],
+                ["upgHpL138C", "upgHpL211C", "upgDmgM212C", "upgDmgL211C", "upgArmM212C", "upgArmL211C"],
+                ["upgHpM138C", "upgHpL211C", "upgDmgM212C", "upgDmgL211C", "upgArmM212C", "upgArmL211C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 4, 4, 2, 2],
+                [14, 14, 4, 5, 1, 1],
+                [14, 21, 6, 6, 2, 2],
+                [26, 18, 8, 8, 2, 3],
+                [19, 37, 10, 7, 4, 2],
+                [47, 23, 10, 14, 4, 4],
+                [44, 44, 17, 12, 5, 5],
+                [60, 48, 14, 23, 5, 6],
+                [51, 86, 25, 20, 9, 7],
+                [96, 76, 32, 25, 10, 10],
+                [107, 107, 39, 32, 11, 11],
+                [122, 147, 41, 49, 14, 16],
+                [168, 168, 51, 61, 19, 19],
+                [211, 211, 71, 71, 24, 24],
+                [264, 264, 87, 87, 29, 29],
+                [330, 330, 110, 110, 36, 36],
+                [413, 413, 138, 138, 46, 46],
+                [225, 225, 81, 69, 27, 23],
+                [242, 208, 81, 69, 27, 23],
+                [200, 249, 67, 83, 22, 28]
+            ]
+        },
+        "worldEightbound": {
+            "name": "Azkor",
+            "FactionId": "WorldEaters",
+            "GrandAllianceId": "Chaos",
+            "BaseRarity": "Rare",
+            "powerMultiplier": 90,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 2,
+                    "DamageProfile": "Eviscerate"
+                }
+            ],
+            "stats": {
+                "Health": 100,
+                "Damage": 24,
+                "FixedArmor": 20,
+                "ProgressionIndex": 6
+            },
+            "traits": ["Hero", "BlessingsOfKhorne", "Daemon", "Resilient", "Terrifying", "Unstoppable"],
+            "activeAbilities": ["OverwhelmingWrath"],
+            "passiveAbilities": ["BeaconOfRage"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [2],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_worldEightbound_01"],
+            "upgrades": [
+                ["upgHpC015", "upgHpC010", "upgDmgC003", "upgDmgC014", "upgArmC013", "upgArmC006"],
+                ["upgHpC013", "upgHpC002", "upgDmgU014", "upgDmgU016C", "upgArmC007", "upgArmC007"],
+                ["upgHpU012", "upgHpU004C", "upgDmgC008", "upgDmgC003", "upgArmU009", "upgArmU007"],
+                ["upgHpU018C", "upgHpU012", "upgDmgU014", "upgDmgU014", "upgArmU007", "upgArmU003C"],
+                ["upgHpU012", "upgHpR015C", "upgDmgU008C", "upgDmgU019", "upgArmR006", "upgArmU007"],
+                ["upgHpR015C", "upgHpU009", "upgDmgR038", "upgDmgR012C", "upgArmU003C", "upgArmR015"],
+                ["upgHpR038", "upgHpR008", "upgDmgR14C", "upgDmgR006", "upgArmR004C", "upgArmR003C"],
+                ["upgHpE038C", "upgHpR004C", "upgDmgR005", "upgDmgE009C", "upgArmR038", "upgArmR004C"],
+                ["upgHpR018", "upgHpE001C", "upgDmgE038C", "upgDmgR016C", "upgArmE038C", "upgArmE013"],
+                ["upgHpE038C", "upgHpE015", "upgDmgE038C", "upgDmgE004", "upgArmE038C", "upgArmE004C"],
+                ["upgHpL118", "upgHpE008C", "upgDmgL038C", "upgDmgE009C", "upgArmE038C", "upgArmE005C"],
+                ["upgHpE038C", "upgHpL009C", "upgDmgE038C", "upgDmgL016C", "upgArmL203", "upgArmL004C"],
+                ["upgHpL038C", "upgHpL001C", "upgDmgL003", "upgDmgL009C", "upgArmL038C", "upgArmL005C"],
+                ["upgHpL138C", "upgHpL012C", "upgDmgL038C", "upgDmgL016C", "upgArmL038C", "upgArmL005C"],
+                ["upgHpL038C", "upgHpL009C", "upgDmgL138C", "upgDmgL010C", "upgArmL138C", "upgArmL005C"],
+                ["upgHpL138C", "upgHpL009C", "upgDmgL138C", "upgDmgL009C", "upgArmL138C", "upgArmL004C"],
+                ["upgHpL138C", "upgHpL212C", "upgDmgL138C", "upgDmgL212C", "upgArmL138C", "upgArmL212C"],
+                ["upgHpL138C", "upgHpL212C", "upgDmgM212C", "upgDmgL212C", "upgArmM214C", "upgArmL212C"],
+                ["upgHpM138C", "upgHpL212C", "upgDmgM212C", "upgDmgL212C", "upgArmM214C", "upgArmL212C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [13, 13, 3, 3, 3, 3],
+                [16, 16, 3, 5, 3, 3],
+                [15, 23, 5, 5, 4, 4],
+                [30, 20, 6, 6, 4, 5],
+                [21, 41, 8, 6, 8, 5],
+                [51, 26, 8, 10, 8, 8],
+                [49, 49, 14, 10, 9, 9],
+                [67, 54, 11, 18, 11, 14],
+                [57, 95, 20, 16, 17, 13],
+                [106, 84, 26, 20, 19, 19],
+                [120, 120, 31, 26, 24, 24],
+                [135, 162, 33, 39, 27, 33],
+                [187, 187, 41, 49, 37, 37],
+                [234, 234, 56, 56, 47, 47],
+                [293, 293, 71, 71, 59, 59],
+                [367, 367, 88, 88, 73, 73],
+                [459, 459, 110, 110, 92, 92],
+                [250, 250, 64, 55, 54, 46],
+                [269, 231, 65, 55, 54, 46],
+                [222, 278, 53, 67, 44, 56]
+            ]
+        },
+        "worldExecutions": {
+            "name": "Tarvakh",
+            "FactionId": "WorldEaters",
+            "GrandAllianceId": "Chaos",
+            "BaseRarity": "Rare",
+            "powerMultiplier": 112,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 1,
+                    "DamageProfile": "Piercing"
+                }
+            ],
+            "stats": {
+                "Health": 95,
+                "Damage": 48,
+                "FixedArmor": 24,
+                "ProgressionIndex": 6
+            },
+            "traits": ["Hero", "BlessingsOfKhorne", "RapidAssault"],
+            "activeAbilities": ["MurderousSwing"],
+            "passiveAbilities": ["TrophyTaker"],
+            "itemSlots": ["I_Crit", "I_Crit", "I_Booster_Crit"],
+            "itemSlotsRelic": [2],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_worldExecutions_01"],
+            "upgrades": [
+                ["upgHpC015", "upgHpC010", "upgDmgC010", "upgDmgC014", "upgArmC013", "upgArmC006"],
+                ["upgHpC013", "upgHpC002", "upgDmgU010", "upgDmgU016C", "upgArmC007", "upgArmC007"],
+                ["upgHpU012", "upgHpU004C", "upgDmgC008", "upgDmgC003", "upgArmU009", "upgArmU007"],
+                ["upgHpU018C", "upgHpU012", "upgDmgU010", "upgDmgU014", "upgArmU007", "upgArmU003C"],
+                ["upgHpU012", "upgHpR015C", "upgDmgU008C", "upgDmgU019", "upgArmR005", "upgArmU007"],
+                ["upgHpR015C", "upgHpU009", "upgDmgR038", "upgDmgR012C", "upgArmU003C", "upgArmR015"],
+                ["upgHpR038", "upgHpR008", "upgDmgR14C", "upgDmgR006", "upgArmR004C", "upgArmR003C"],
+                ["upgHpE038C", "upgHpR004C", "upgDmgR002", "upgDmgE009C", "upgArmR038", "upgArmR004C"],
+                ["upgHpR018", "upgHpE001C", "upgDmgE038C", "upgDmgR016C", "upgArmE038C", "upgArmE013"],
+                ["upgHpE038C", "upgHpE012", "upgDmgE038C", "upgDmgE004", "upgArmE038C", "upgArmE004C"],
+                ["upgHpL118", "upgHpE008C", "upgDmgL038C", "upgDmgE009C", "upgArmE038C", "upgArmE005C"],
+                ["upgHpE038C", "upgHpL009C", "upgDmgE038C", "upgDmgL016C", "upgArmL203", "upgArmL004C"],
+                ["upgHpL038C", "upgHpL001C", "upgDmgL003", "upgDmgL009C", "upgArmL038C", "upgArmL005C"],
+                ["upgHpL138C", "upgHpL012C", "upgDmgL038C", "upgDmgL016C", "upgArmL038C", "upgArmL005C"],
+                ["upgHpL038C", "upgHpL009C", "upgDmgL138C", "upgDmgL010C", "upgArmL138C", "upgArmL005C"],
+                ["upgHpL138C", "upgHpL009C", "upgDmgL138C", "upgDmgL005C", "upgArmL138C", "upgArmL004C"],
+                ["upgHpL138C", "upgHpL213C", "upgDmgL138C", "upgDmgL213C", "upgArmL138C", "upgArmL213C"],
+                ["upgHpL138C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpM138C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 6, 6, 3, 3],
+                [15, 15, 6, 9, 4, 4],
+                [15, 22, 10, 10, 5, 5],
+                [28, 19, 12, 12, 4, 7],
+                [20, 39, 17, 12, 9, 6],
+                [49, 25, 16, 21, 9, 9],
+                [46, 46, 26, 20, 12, 12],
+                [64, 52, 22, 37, 12, 17],
+                [54, 90, 41, 32, 20, 16],
+                [101, 80, 51, 40, 23, 23],
+                [114, 114, 63, 52, 29, 29],
+                [128, 154, 65, 78, 32, 39],
+                [178, 178, 81, 98, 45, 45],
+                [222, 222, 113, 113, 56, 56],
+                [279, 279, 140, 140, 71, 71],
+                [348, 348, 176, 176, 88, 88],
+                [436, 436, 221, 221, 110, 110],
+                [238, 238, 129, 110, 64, 55],
+                [255, 219, 129, 111, 65, 55],
+                [211, 263, 107, 133, 53, 67]
+            ]
+        },
+        "worldKharn": {
+            "name": "Kharn",
+            "FactionId": "WorldEaters",
+            "GrandAllianceId": "Chaos",
+            "BaseRarity": "Legendary",
+            "powerMultiplier": 91,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 4,
+                    "DamageProfile": "Eviscerate"
+                }
+            ],
+            "stats": {
+                "Health": 90,
+                "Damage": 25,
+                "FixedArmor": 20,
+                "ProgressionIndex": 12
+            },
+            "traits": ["Hero", "BlessingsOfKhorne", "RapidAssault", "FinalJustice"],
+            "activeAbilities": ["KillMaimBurn"],
+            "passiveAbilities": ["TheBetrayer"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "timestampIfHeroUnlocked": 1746403200000,
+                "timestampIfHeroNotUnlocked": 1749340800000
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_worldKharn_01"],
+            "eventMetadata": {
+                "leg": {
+                    "finalEventEndDate": 1746403200000
+                }
+            },
+            "upgrades": [
+                ["upgHpC015", "upgHpC010", "upgDmgC012", "upgDmgC014", "upgArmC013", "upgArmC006"],
+                ["upgHpC013", "upgHpC002", "upgDmgU009", "upgDmgU016C", "upgArmC007", "upgArmC007"],
+                ["upgHpU012", "upgHpU004C", "upgDmgC013", "upgDmgC003", "upgArmU009", "upgArmU007"],
+                ["upgHpU018C", "upgHpU012", "upgDmgU009", "upgDmgU014", "upgArmU007", "upgArmU003C"],
+                ["upgHpU012", "upgHpR015C", "upgDmgU018C", "upgDmgU019", "upgArmR005", "upgArmU007"],
+                ["upgHpR015C", "upgHpU009", "upgDmgR038", "upgDmgR012C", "upgArmU003C", "upgArmR015"],
+                ["upgHpR038", "upgHpR008", "upgDmgR13C", "upgDmgR006", "upgArmR004C", "upgArmR003C"],
+                ["upgHpE038C", "upgHpR004C", "upgDmgR002", "upgDmgE009C", "upgArmR038", "upgArmR004C"],
+                ["upgHpR018", "upgHpE001C", "upgDmgE038C", "upgDmgR016C", "upgArmE038C", "upgArmE013"],
+                ["upgHpE038C", "upgHpE012", "upgDmgE038C", "upgDmgE004", "upgArmE038C", "upgArmE004C"],
+                ["upgHpL118", "upgHpE008C", "upgDmgL038C", "upgDmgE009C", "upgArmE038C", "upgArmE005C"],
+                ["upgHpE038C", "upgHpL009C", "upgDmgE038C", "upgDmgL016C", "upgArmL203", "upgArmL004C"],
+                ["upgHpL038C", "upgHpL001C", "upgDmgL003", "upgDmgL009C", "upgArmL038C", "upgArmL005C"],
+                ["upgHpL138C", "upgHpL012C", "upgDmgL038C", "upgDmgL016C", "upgArmL038C", "upgArmL005C"],
+                ["upgHpL038C", "upgHpL009C", "upgDmgL138C", "upgDmgL008C", "upgArmL138C", "upgArmL005C"],
+                ["upgHpL138C", "upgHpL009C", "upgDmgL138C", "upgDmgL012C", "upgArmL138C", "upgArmL004C"],
+                ["upgHpL138C", "upgHpL211C", "upgDmgL138C", "upgDmgL211C", "upgArmL138C", "upgArmL211C"],
+                ["upgHpL138C", "upgHpL211C", "upgDmgM213C", "upgDmgL211C", "upgArmM214C", "upgArmL211C"],
+                ["upgHpM138C", "upgHpL211C", "upgDmgM213C", "upgDmgL211C", "upgArmM214C", "upgArmL211C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 3, 3, 3, 3],
+                [14, 14, 3, 5, 3, 3],
+                [14, 21, 5, 5, 4, 4],
+                [26, 18, 6, 6, 4, 5],
+                [19, 37, 10, 6, 8, 5],
+                [47, 23, 8, 11, 8, 8],
+                [44, 44, 14, 11, 9, 9],
+                [60, 48, 11, 19, 11, 14],
+                [51, 86, 21, 17, 17, 13],
+                [96, 76, 27, 21, 19, 19],
+                [107, 107, 32, 27, 24, 24],
+                [122, 147, 34, 41, 27, 33],
+                [168, 168, 42, 51, 37, 37],
+                [211, 211, 59, 59, 47, 47],
+                [264, 264, 73, 73, 59, 59],
+                [330, 330, 92, 92, 73, 73],
+                [413, 413, 115, 115, 92, 92],
+                [225, 225, 67, 57, 54, 46],
+                [242, 208, 67, 58, 54, 46],
+                [200, 249, 56, 69, 44, 56]
+            ]
+        },
+        "bloodIntercessor": {
+            "name": "Mataneo",
+            "FactionId": "BloodAngels",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Uncommon",
+            "powerMultiplier": 107,
+            "Movement": 4,
+            "weapons": [
+                {
+                    "hits": 1,
+                    "DamageProfile": "Plasma"
+                }
+            ],
+            "stats": {
+                "Health": 90,
+                "Damage": 40,
+                "FixedArmor": 22,
+                "ProgressionIndex": 3
+            },
+            "traits": ["Hero", "TeleportStrike", "Flying", "RapidAssault"],
+            "activeAbilities": ["HammerOfWrath"],
+            "passiveAbilities": ["AggressiveOnslaught"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_bloodIntercessor_01"],
+            "upgrades": [
+                ["upgHpC015", "upgHpC004", "upgDmgC010", "upgDmgC011", "upgArmC013", "upgArmC002"],
+                ["upgHpC001", "upgHpC002", "upgDmgU010", "upgDmgU015C", "upgArmC001", "upgArmC001"],
+                ["upgHpU001", "upgHpU004C", "upgDmgC013", "upgDmgC012", "upgArmU009", "upgArmU001"],
+                ["upgHpU018C", "upgHpU017", "upgDmgU010", "upgDmgU009", "upgArmU001", "upgArmU010C"],
+                ["upgHpU001", "upgHpR017C", "upgDmgU018C", "upgDmgU011", "upgArmR005", "upgArmU001"],
+                ["upgHpR003C", "upgHpU006", "upgDmgR035", "upgDmgR004C", "upgArmU003C", "upgArmR015"],
+                ["upgHpR035", "upgHpR005", "upgDmgR13C", "upgDmgR002", "upgArmR001C", "upgArmR003C"],
+                ["upgHpE035C", "upgHpR004C", "upgDmgR006", "upgDmgE007C", "upgArmR035", "upgArmR001C"],
+                ["upgHpR018", "upgHpE001C", "upgDmgE035C", "upgDmgR015C", "upgArmE035C", "upgArmE013"],
+                ["upgHpE035C", "upgHpE012", "upgDmgE035C", "upgDmgE011", "upgArmE035C", "upgArmE004C"],
+                ["upgHpL115", "upgHpE002C", "upgDmgL035C", "upgDmgE007C", "upgArmE035C", "upgArmE001C"],
+                ["upgHpE035C", "upgHpL017C", "upgDmgE035C", "upgDmgL015C", "upgArmL001", "upgArmL004C"],
+                ["upgHpL035C", "upgHpL001C", "upgDmgL003", "upgDmgL012C", "upgArmL035C", "upgArmL010C"],
+                ["upgHpL135C", "upgHpL002C", "upgDmgL035C", "upgDmgL015C", "upgArmL035C", "upgArmL010C"],
+                ["upgHpL035C", "upgHpL009C", "upgDmgL135C", "upgDmgL008C", "upgArmL135C", "upgArmL010C"],
+                ["upgHpL135C", "upgHpL017C", "upgDmgL135C", "upgDmgL005C", "upgArmL135C", "upgArmL004C"],
+                ["upgHpL135C", "upgHpL213C", "upgDmgL135C", "upgDmgL213C", "upgArmL135C", "upgArmL213C"],
+                ["upgHpL135C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpM135C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 5, 5, 3, 3],
+                [14, 14, 5, 8, 3, 3],
+                [14, 21, 8, 8, 5, 5],
+                [26, 18, 10, 10, 4, 6],
+                [19, 37, 14, 10, 8, 6],
+                [47, 23, 13, 18, 9, 9],
+                [44, 44, 22, 17, 10, 10],
+                [60, 48, 18, 30, 12, 15],
+                [51, 86, 34, 27, 18, 15],
+                [96, 76, 43, 34, 21, 21],
+                [107, 107, 52, 43, 27, 27],
+                [122, 147, 54, 65, 29, 35],
+                [168, 168, 68, 82, 42, 42],
+                [211, 211, 94, 94, 51, 51],
+                [264, 264, 117, 117, 64, 64],
+                [330, 330, 147, 147, 81, 81],
+                [413, 413, 183, 183, 101, 101],
+                [225, 225, 108, 92, 59, 51],
+                [242, 208, 108, 92, 59, 51],
+                [200, 249, 89, 111, 49, 61]
+            ]
+        },
+        "bloodDeathCompany": {
+            "name": "Lucien",
+            "FactionId": "BloodAngels",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Uncommon",
+            "powerMultiplier": 88,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 4,
+                    "DamageProfile": "Physical"
+                },
+                {
+                    "hits": 3,
+                    "DamageProfile": "Blast",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 90,
+                "Damage": 30,
+                "FixedArmor": 21,
+                "ProgressionIndex": 3
+            },
+            "traits": ["Hero", "RapidAssault", "Resilient", "Unstoppable"],
+            "activeAbilities": ["BlackRage"],
+            "passiveAbilities": ["VisionsOfHeresy"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_bloodDeathCompany_01"],
+            "upgrades": [
+                ["upgHpC015", "upgHpC004", "upgDmgC003", "upgDmgC011", "upgArmC003", "upgArmC002"],
+                ["upgHpC001", "upgHpC002", "upgDmgU014", "upgDmgU015C", "upgArmC001", "upgArmC001"],
+                ["upgHpU001", "upgHpU004C", "upgDmgC002", "upgDmgC004", "upgArmU002", "upgArmU001"],
+                ["upgHpU018C", "upgHpU002", "upgDmgU014", "upgDmgU003", "upgArmU001", "upgArmU010C"],
+                ["upgHpU001", "upgHpR020C", "upgDmgU002C", "upgDmgU011", "upgArmR005", "upgArmU001"],
+                ["upgHpR003C", "upgHpU006", "upgDmgR035", "upgDmgR012C", "upgArmU003C", "upgArmR015"],
+                ["upgHpR035", "upgHpR005", "upgDmgR001C", "upgDmgR003", "upgArmR001C", "upgArmR003C"],
+                ["upgHpE035C", "upgHpR004C", "upgDmgR002", "upgDmgE002C", "upgArmR035", "upgArmR001C"],
+                ["upgHpR019", "upgHpE001C", "upgDmgE035C", "upgDmgR015C", "upgArmE035C", "upgArmE013"],
+                ["upgHpE035C", "upgHpE015", "upgDmgE035C", "upgDmgE001", "upgArmE035C", "upgArmE004C"],
+                ["upgHpL115", "upgHpE002C", "upgDmgL035C", "upgDmgE002C", "upgArmE035C", "upgArmE001C"],
+                ["upgHpE035C", "upgHpL002C", "upgDmgE035C", "upgDmgL015C", "upgArmL001", "upgArmL004C"],
+                ["upgHpL035C", "upgHpL001C", "upgDmgL001", "upgDmgL002C", "upgArmL035C", "upgArmL010C"],
+                ["upgHpL135C", "upgHpL002C", "upgDmgL035C", "upgDmgL015C", "upgArmL035C", "upgArmL010C"],
+                ["upgHpL035C", "upgHpL009C", "upgDmgL135C", "upgDmgE003", "upgArmL135C", "upgArmL010C"],
+                ["upgHpL135C", "upgHpL017C", "upgDmgL135C", "upgDmgL009C", "upgArmL135C", "upgArmL004C"],
+                ["upgHpL135C", "upgHpL213C", "upgDmgL135C", "upgDmgL213C", "upgArmL135C", "upgArmL213C"],
+                ["upgHpL135C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpM135C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 4, 4, 3, 3],
+                [14, 14, 4, 5, 3, 3],
+                [14, 21, 6, 6, 4, 4],
+                [26, 18, 8, 8, 4, 7],
+                [19, 37, 10, 7, 8, 5],
+                [47, 23, 10, 14, 8, 8],
+                [44, 44, 17, 12, 10, 10],
+                [60, 48, 14, 23, 11, 15],
+                [51, 86, 25, 20, 18, 14],
+                [96, 76, 32, 25, 20, 20],
+                [107, 107, 39, 32, 25, 25],
+                [122, 147, 41, 49, 29, 34],
+                [168, 168, 51, 61, 39, 39],
+                [211, 211, 71, 71, 49, 49],
+                [264, 264, 104, 70, 62, 62],
+                [330, 330, 110, 110, 77, 77],
+                [413, 413, 138, 138, 96, 96],
+                [225, 225, 81, 69, 57, 48],
+                [242, 208, 81, 69, 57, 48],
+                [200, 249, 67, 83, 47, 58]
+            ]
+        },
+        "bloodSanguinary": {
+            "name": "Nicodemus",
+            "FactionId": "BloodAngels",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Rare",
+            "powerMultiplier": 129,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 3,
+                    "DamageProfile": "Chain"
+                }
+            ],
+            "stats": {
+                "Health": 90,
+                "Damage": 23,
+                "FixedArmor": 23,
+                "ProgressionIndex": 6
+            },
+            "traits": ["Hero", "Healer", "RapidAssault"],
+            "activeAbilities": ["BloodChalice"],
+            "passiveAbilities": ["SanguinaryPriest"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [2],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_bloodSanguinary_01"],
+            "upgrades": [
+                ["upgHpC007", "upgHpC004", "upgDmgC003", "upgDmgC011", "upgArmC013", "upgArmC002"],
+                ["upgHpC001", "upgHpC007", "upgDmgU014", "upgDmgU015C", "upgArmC001", "upgArmC006"],
+                ["upgHpU001", "upgHpU005C", "upgDmgC002", "upgDmgC009", "upgArmU009", "upgArmU013"],
+                ["upgHpU005C", "upgHpU002", "upgDmgU014", "upgDmgU012", "upgArmU001", "upgArmU010C"],
+                ["upgHpU001", "upgHpR020C", "upgDmgU002C", "upgDmgU011", "upgArmR005", "upgArmU013"],
+                ["upgHpR003C", "upgHpU006", "upgDmgR035", "upgDmgR011C", "upgArmU003C", "upgArmR015"],
+                ["upgHpR035", "upgHpR005", "upgDmgR001C", "upgDmgR005", "upgArmR001C", "upgArmR003C"],
+                ["upgHpE035C", "upgHpR006C", "upgDmgR002", "upgDmgE008C", "upgArmR035", "upgArmR013C"],
+                ["upgHpR002", "upgHpE006C", "upgDmgE035C", "upgDmgR015C", "upgArmE035C", "upgArmE013"],
+                ["upgHpE035C", "upgHpE012", "upgDmgE035C", "upgDmgE003", "upgArmE035C", "upgArmE004C"],
+                ["upgHpL115", "upgHpE002C", "upgDmgL035C", "upgDmgE008C", "upgArmE035C", "upgArmE011C"],
+                ["upgHpE035C", "upgHpL002C", "upgDmgE035C", "upgDmgL015C", "upgArmL001", "upgArmL004C"],
+                ["upgHpL035C", "upgHpL011C", "upgDmgL003", "upgDmgL006C", "upgArmL035C", "upgArmL011C"],
+                ["upgHpL135C", "upgHpL002C", "upgDmgL035C", "upgDmgL015C", "upgArmL035C", "upgArmL010C"],
+                ["upgHpL035C", "upgHpL011C", "upgDmgL135C", "upgDmgE003", "upgArmL135C", "upgArmL011C"],
+                ["upgHpL135C", "upgHpL017C", "upgDmgL135C", "upgDmgL009C", "upgArmL135C", "upgArmL004C"],
+                ["upgHpL135C", "upgHpL213C", "upgDmgL135C", "upgDmgL213C", "upgArmL135C", "upgArmL213C"],
+                ["upgHpL135C", "upgHpL213C", "upgDmgM211C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpM135C", "upgHpL213C", "upgDmgM211C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 3, 3, 3, 3],
+                [14, 14, 3, 4, 4, 4],
+                [14, 21, 5, 5, 4, 4],
+                [26, 18, 6, 6, 5, 7],
+                [19, 37, 8, 5, 8, 6],
+                [47, 23, 8, 10, 9, 9],
+                [44, 44, 13, 9, 11, 11],
+                [60, 48, 11, 18, 12, 16],
+                [51, 86, 19, 15, 19, 16],
+                [96, 76, 24, 20, 22, 22],
+                [107, 107, 30, 25, 28, 28],
+                [122, 147, 31, 37, 30, 37],
+                [168, 168, 39, 47, 43, 43],
+                [211, 211, 54, 54, 54, 54],
+                [264, 264, 81, 54, 68, 68],
+                [330, 330, 84, 84, 84, 84],
+                [413, 413, 106, 106, 106, 106],
+                [225, 225, 62, 53, 61, 53],
+                [242, 208, 62, 53, 62, 53],
+                [200, 249, 51, 63, 51, 63]
+            ]
+        },
+        "bloodMephiston": {
+            "name": "Mephiston",
+            "FactionId": "BloodAngels",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Legendary",
+            "powerMultiplier": 73,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 3,
+                    "DamageProfile": "Psychic"
+                },
+                {
+                    "hits": 2,
+                    "DamageProfile": "Psychic",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 95,
+                "Damage": 10,
+                "FixedArmor": 20,
+                "ProgressionIndex": 12
+            },
+            "traits": ["Hero", "Psyker", "RapidAssault", "Terrifying"],
+            "activeAbilities": ["TheQuickening"],
+            "passiveAbilities": ["FuryOfTheAncients"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "timestampIfHeroUnlocked": 1752451200000,
+                "timestampIfHeroNotUnlocked": 1755388800000
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_bloodMephiston_01"],
+            "eventMetadata": {
+                "leg": {
+                    "finalEventEndDate": 1752451200000
+                }
+            },
+            "upgrades": [
+                ["upgHpC007", "upgHpC004", "upgDmgC010", "upgDmgC011", "upgArmC002", "upgArmC013"],
+                ["upgHpC001", "upgHpC002", "upgDmgU010", "upgDmgU015C", "upgArmC001", "upgArmC006"],
+                ["upgHpU001", "upgHpU004C", "upgDmgC008", "upgDmgC012", "upgArmU005", "upgArmU013"],
+                ["upgHpU005C", "upgHpU016", "upgDmgU010", "upgDmgU009", "upgArmU001", "upgArmU003C"],
+                ["upgHpU001", "upgHpR016C", "upgDmgU008C", "upgDmgU011", "upgArmR010", "upgArmU013"],
+                ["upgHpR003C", "upgHpU006", "upgDmgR035", "upgDmgR004C", "upgArmU010C", "upgArmR015"],
+                ["upgHpR035", "upgHpR005", "upgDmgR14C", "upgDmgR005", "upgArmR001C", "upgArmR012C"],
+                ["upgHpE035C", "upgHpR004C", "upgDmgR003", "upgDmgE007C", "upgArmR035", "upgArmR013C"],
+                ["upgHpR002", "upgHpE001C", "upgDmgE035C", "upgDmgR015C", "upgArmE035C", "upgArmE013"],
+                ["upgHpE035C", "upgHpE003", "upgDmgE035C", "upgDmgE010", "upgArmE035C", "upgArmE006C"],
+                ["upgHpL115", "upgHpE002C", "upgDmgL035C", "upgDmgE007C", "upgArmE035C", "upgArmE011C"],
+                ["upgHpE035C", "upgHpL011C", "upgDmgE035C", "upgDmgL015C", "upgArmL202", "upgArmL006C"],
+                ["upgHpL035C", "upgHpL001C", "upgDmgL202", "upgDmgL012C", "upgArmL035C", "upgArmL011C"],
+                ["upgHpL135C", "upgHpL002C", "upgDmgL035C", "upgDmgL015C", "upgArmL035C", "upgArmL010C"],
+                ["upgHpL035C", "upgHpL011C", "upgDmgL135C", "upgDmgL010C", "upgArmL135C", "upgArmL011C"],
+                ["upgHpL135C", "upgHpL017C", "upgDmgL135C", "upgDmgL005C", "upgArmL135C", "upgArmL006C"],
+                ["upgHpL135C", "upgHpL212C", "upgDmgL135C", "upgDmgL212C", "upgArmL135C", "upgArmL212C"],
+                ["upgHpL135C", "upgHpL212C", "upgDmgM214C", "upgDmgL212C", "upgArmM214C", "upgArmL212C"],
+                ["upgHpM135C", "upgHpL212C", "upgDmgM214C", "upgDmgL212C", "upgArmM214C", "upgArmL212C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 2, 2, 3, 3],
+                [15, 15, 1, 1, 3, 3],
+                [15, 22, 2, 2, 4, 4],
+                [28, 19, 3, 3, 4, 5],
+                [20, 39, 3, 2, 8, 5],
+                [49, 25, 3, 5, 8, 8],
+                [46, 46, 5, 4, 9, 9],
+                [64, 52, 5, 8, 11, 14],
+                [54, 90, 8, 7, 17, 13],
+                [101, 80, 11, 8, 19, 19],
+                [114, 114, 13, 10, 24, 24],
+                [128, 154, 14, 16, 27, 33],
+                [178, 178, 17, 21, 37, 37],
+                [222, 222, 24, 24, 47, 47],
+                [279, 279, 29, 29, 59, 59],
+                [348, 348, 36, 36, 73, 73],
+                [436, 436, 46, 46, 92, 92],
+                [238, 238, 27, 23, 54, 46],
+                [255, 219, 27, 23, 54, 46],
+                [211, 263, 22, 28, 44, 56]
+            ]
+        },
+        "bloodDante": {
+            "name": "Dante",
+            "FactionId": "BloodAngels",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Legendary",
+            "powerMultiplier": 77,
+            "Movement": 4,
+            "weapons": [
+                {
+                    "hits": 4,
+                    "DamageProfile": "Piercing"
+                }
+            ],
+            "stats": {
+                "Health": 90,
+                "Damage": 11,
+                "FixedArmor": 23,
+                "ProgressionIndex": 12
+            },
+            "traits": ["Hero", "TeleportStrike", "FinalJustice", "Flying", "RapidAssault", "Terrifying"],
+            "activeAbilities": ["LightOfSanguinius"],
+            "passiveAbilities": ["LordOfTheHost"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Block"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "timestampIfHeroUnlocked": 1776643200000,
+                "timestampIfHeroNotUnlocked": 1779580800000
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_bloodDante_01"],
+            "eventMetadata": {
+                "leg": {
+                    "finalEventEndDate": 1776643200000
+                }
+            },
+            "upgrades": [
+                ["upgHpC015", "upgHpC004", "upgDmgC010", "upgDmgC011", "upgArmC002", "upgArmC013"],
+                ["upgHpC003", "upgHpC002", "upgDmgU010", "upgDmgU015C", "upgArmC001", "upgArmC001"],
+                ["upgHpU002", "upgHpU004C", "upgDmgC013", "upgDmgC009", "upgArmU005", "upgArmU001"],
+                ["upgHpU018C", "upgHpU017", "upgDmgU010", "upgDmgU012", "upgArmU001", "upgArmU003C"],
+                ["upgHpU002", "upgHpR017C", "upgDmgU018C", "upgDmgU011", "upgArmR005", "upgArmU001"],
+                ["upgHpR020C", "upgHpU006", "upgDmgR035", "upgDmgR011C", "upgArmU010C", "upgArmR015"],
+                ["upgHpR035", "upgHpR005", "upgDmgR13C", "upgDmgR005", "upgArmR001C", "upgArmR012C"],
+                ["upgHpE035C", "upgHpR004C", "upgDmgR002", "upgDmgE008C", "upgArmR035", "upgArmR001C"],
+                ["upgHpR019", "upgHpE001C", "upgDmgE035C", "upgDmgR015C", "upgArmE035C", "upgArmE013"],
+                ["upgHpE035C", "upgHpE003", "upgDmgE035C", "upgDmgE011", "upgArmE035C", "upgArmE006C"],
+                ["upgHpL115", "upgHpE002C", "upgDmgL035C", "upgDmgE008C", "upgArmE035C", "upgArmE001C"],
+                ["upgHpE035C", "upgHpL017C", "upgDmgE035C", "upgDmgL015C", "upgArmL001", "upgArmL006C"],
+                ["upgHpL035C", "upgHpL001C", "upgDmgL003", "upgDmgL006C", "upgArmL035C", "upgArmL010C"],
+                ["upgHpL135C", "upgHpL002C", "upgDmgL035C", "upgDmgL015C", "upgArmL035C", "upgArmL010C"],
+                ["upgHpL035C", "upgHpL009C", "upgDmgL135C", "upgDmgL008C", "upgArmL135C", "upgArmL010C"],
+                ["upgHpL135C", "upgHpL002C", "upgDmgL135C", "upgDmgL005C", "upgArmL135C", "upgArmL006C"],
+                ["upgHpL135C", "upgHpL213C", "upgDmgL135C", "upgDmgL213C", "upgArmL135C", "upgArmL213C"],
+                ["upgHpL135C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpM135C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 2, 2, 3, 3],
+                [14, 14, 1, 1, 4, 4],
+                [14, 21, 3, 3, 4, 4],
+                [26, 18, 2, 2, 5, 7],
+                [19, 37, 4, 3, 8, 6],
+                [47, 23, 3, 5, 9, 9],
+                [44, 44, 6, 5, 11, 11],
+                [60, 48, 5, 8, 12, 16],
+                [51, 86, 9, 8, 19, 16],
+                [96, 76, 12, 9, 22, 22],
+                [107, 107, 14, 12, 28, 28],
+                [122, 147, 15, 18, 30, 37],
+                [168, 168, 19, 22, 43, 43],
+                [211, 211, 26, 26, 54, 54],
+                [264, 264, 32, 32, 68, 68],
+                [330, 330, 41, 41, 84, 84],
+                [413, 413, 50, 50, 106, 106],
+                [225, 225, 30, 25, 61, 53],
+                [242, 208, 30, 25, 62, 53],
+                [200, 249, 24, 31, 51, 63]
+            ]
+        },
+        "bloodTerminator": {
+            "name": "Cezare",
+            "FactionId": "BloodAngels",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Uncommon",
+            "powerMultiplier": 105,
+            "Movement": 2,
+            "weapons": [
+                {
+                    "hits": 4,
+                    "DamageProfile": "Power"
+                }
+            ],
+            "stats": {
+                "Health": 105,
+                "Damage": 19,
+                "FixedArmor": 27,
+                "ProgressionIndex": 3
+            },
+            "traits": ["Hero", "TeleportStrike", "TerminatorArmour", "RapidAssault"],
+            "activeAbilities": ["SavageEchoes"],
+            "passiveAbilities": ["RedRampage"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Block"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_bloodTerminator_01"],
+            "upgrades": [
+                ["upgHpC002", "upgHpC004", "upgDmgC010", "upgDmgC011", "upgArmC004", "upgArmC013"],
+                ["upgHpC014", "upgHpC002", "upgDmgU010", "upgDmgU015C", "upgArmC013", "upgArmC001"],
+                ["upgHpU014", "upgHpU004C", "upgDmgC013", "upgDmgC009", "upgArmU008", "upgArmU009"],
+                ["upgHpU004C", "upgHpU002", "upgDmgU010", "upgDmgU012", "upgArmU009", "upgArmU003C"],
+                ["upgHpU014", "upgHpR020C", "upgDmgU018C", "upgDmgU011", "upgArmR005", "upgArmU001"],
+                ["upgHpR012C", "upgHpU006", "upgDmgR035", "upgDmgR011C", "upgArmU003C", "upgArmR015"],
+                ["upgHpR035", "upgHpR005", "upgDmgR13C", "upgDmgR005", "upgArmR007C", "upgArmR012C"],
+                ["upgHpE035C", "upgHpR004C", "upgDmgR006", "upgDmgE008C", "upgArmR035", "upgArmR001C"],
+                ["upgHpR018", "upgHpE001C", "upgDmgE035C", "upgDmgR015C", "upgArmE035C", "upgArmE013"],
+                ["upgHpE035C", "upgHpE003", "upgDmgE035C", "upgDmgE004", "upgArmE035C", "upgArmE002C"],
+                ["upgHpL115", "upgHpE002C", "upgDmgL035C", "upgDmgE008C", "upgArmE035C", "upgArmE006C"],
+                ["upgHpE035C", "upgHpL002C", "upgDmgE035C", "upgDmgL015C", "upgArmL001", "upgArmL002C"],
+                ["upgHpL035C", "upgHpL001C", "upgDmgL003", "upgDmgL006C", "upgArmL035C", "upgArmL006C"],
+                ["upgHpL135C", "upgHpL002C", "upgDmgL035C", "upgDmgL015C", "upgArmL035C", "upgArmL010C"],
+                ["upgHpL035C", "upgHpL001C", "upgDmgL135C", "upgDmgL008C", "upgArmL135C", "upgArmL006C"],
+                ["upgHpL135C", "upgHpL013C", "upgDmgL135C", "upgDmgL005C", "upgArmL135C", "upgArmL002C"],
+                ["upgHpL135C", "upgHpL213C", "upgDmgL135C", "upgDmgL213C", "upgArmL135C", "upgArmL213C"],
+                ["upgHpL135C", "upgHpL213C", "upgDmgM214C", "upgDmgL213C", "upgArmM211C", "upgArmL213C"],
+                ["upgHpM135C", "upgHpL213C", "upgDmgM214C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [13, 13, 3, 3, 4, 4],
+                [17, 17, 2, 3, 4, 4],
+                [16, 25, 4, 4, 5, 5],
+                [31, 21, 5, 5, 5, 8],
+                [22, 43, 6, 4, 10, 7],
+                [54, 27, 6, 9, 11, 11],
+                [51, 51, 11, 8, 13, 13],
+                [71, 57, 9, 14, 14, 18],
+                [60, 100, 16, 13, 23, 18],
+                [111, 89, 20, 16, 26, 26],
+                [125, 125, 25, 20, 32, 32],
+                [143, 171, 26, 31, 37, 44],
+                [196, 196, 32, 39, 50, 50],
+                [246, 246, 45, 45, 64, 64],
+                [308, 308, 55, 55, 79, 79],
+                [385, 385, 70, 70, 99, 99],
+                [482, 482, 87, 87, 124, 124],
+                [262, 262, 51, 44, 72, 62],
+                [283, 242, 51, 44, 73, 62],
+                [233, 292, 42, 53, 60, 75]
+            ]
+        },
+        "genesBiophagus": {
+            "name": "Hollan",
+            "FactionId": "Genestealers",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Uncommon",
+            "powerMultiplier": 127,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 1,
+                    "DamageProfile": "Toxic"
+                }
+            ],
+            "stats": {
+                "Health": 55,
+                "Damage": 36,
+                "FixedArmor": 12,
+                "ProgressionIndex": 3
+            },
+            "traits": ["Hero", "Ambush", "Healer"],
+            "activeAbilities": ["AberrantHypermorph"],
+            "passiveAbilities": ["TwistedScience"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [2],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_genesBiophagus_01"],
+            "upgrades": [
+                ["upgHpC009", "upgHpC004", "upgDmgC003", "upgDmgC014", "upgArmC003", "upgArmC005"],
+                ["upgHpC016", "upgHpC007", "upgDmgU014", "upgDmgU016C", "upgArmC007", "upgArmC006"],
+                ["upgHpU016", "upgHpU005C", "upgDmgC007", "upgDmgC003", "upgArmU002", "upgArmU013"],
+                ["upgHpU010C", "upgHpU001", "upgDmgU014", "upgDmgU014", "upgArmU007", "upgArmU004C"],
+                ["upgHpU016", "upgHpR003C", "upgDmgU007C", "upgDmgU019", "upgArmR006", "upgArmU013"],
+                ["upgHpR016C", "upgHpU006", "upgDmgR036", "upgDmgR012C", "upgArmU003C", "upgArmR010"],
+                ["upgHpR036", "upgHpR005", "upgDmgR008C", "upgDmgR005", "upgArmR004C", "upgArmR002C"],
+                ["upgHpE036C", "upgHpR006C", "upgDmgR005", "upgDmgE009C", "upgArmR036", "upgArmR013C"],
+                ["upgHpR002", "upgHpE006C", "upgDmgE036C", "upgDmgR016C", "upgArmE036C", "upgArmE009"],
+                ["upgHpE036C", "upgHpE017", "upgDmgE036C", "upgDmgE004", "upgArmE036C", "upgArmE003C"],
+                ["upgHpL116", "upgHpE002C", "upgDmgL036C", "upgDmgE009C", "upgArmE036C", "upgArmE011C"],
+                ["upgHpE036C", "upgHpL017C", "upgDmgE036C", "upgDmgL016C", "upgArmL203", "upgArmL003C"],
+                ["upgHpL036C", "upgHpL011C", "upgDmgL003", "upgDmgL009C", "upgArmL036C", "upgArmL011C"],
+                ["upgHpL136C", "upgHpL002C", "upgDmgL036C", "upgDmgL016C", "upgArmL036C", "upgArmL005C"],
+                ["upgHpL036C", "upgHpL013C", "upgDmgL136C", "upgDmgL012C", "upgArmL136C", "upgArmL011C"],
+                ["upgHpL136C", "upgHpL011C", "upgDmgL136C", "upgDmgL009C", "upgArmL136C", "upgArmL003C"],
+                ["upgHpL136C", "upgHpL212C", "upgDmgL136C", "upgDmgL212C", "upgArmL136C", "upgArmL212C"],
+                ["upgHpL136C", "upgHpL212C", "upgDmgM211C", "upgDmgL212C", "upgArmM212C", "upgArmL212C"],
+                ["upgHpM136C", "upgHpL212C", "upgDmgM211C", "upgDmgL212C", "upgArmM213C", "upgArmL212C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [7, 7, 5, 5, 2, 2],
+                [9, 9, 4, 6, 2, 2],
+                [8, 13, 8, 8, 2, 2],
+                [16, 11, 8, 8, 2, 3],
+                [11, 23, 14, 9, 5, 3],
+                [29, 14, 12, 16, 5, 5],
+                [27, 27, 20, 15, 6, 6],
+                [37, 29, 16, 27, 6, 7],
+                [32, 53, 31, 24, 11, 8],
+                [57, 46, 38, 31, 12, 12],
+                [66, 66, 47, 39, 14, 14],
+                [75, 89, 49, 58, 16, 19],
+                [103, 103, 61, 74, 23, 23],
+                [129, 129, 84, 84, 28, 28],
+                [161, 161, 106, 106, 35, 35],
+                [202, 202, 132, 132, 44, 44],
+                [252, 252, 165, 165, 55, 55],
+                [138, 138, 97, 83, 32, 28],
+                [148, 126, 97, 83, 32, 28],
+                [122, 152, 80, 100, 27, 33]
+            ]
+        },
+        "genesMagus": {
+            "name": "Xybia",
+            "FactionId": "Genestealers",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Rare",
+            "powerMultiplier": 93,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 2,
+                    "DamageProfile": "Psychic"
+                },
+                {
+                    "hits": 2,
+                    "DamageProfile": "Psychic",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 55,
+                "Damage": 15,
+                "FixedArmor": 11,
+                "ProgressionIndex": 6
+            },
+            "traits": ["Hero", "Ambush", "Psyker"],
+            "activeAbilities": ["MindControl"],
+            "passiveAbilities": ["SpiritualLeader"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Block"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_genesMagus_01"],
+            "upgrades": [
+                ["upgHpC009", "upgHpC004", "upgDmgC003", "upgDmgC014", "upgArmC003", "upgArmC005"],
+                ["upgHpC017", "upgHpC007", "upgDmgU014", "upgDmgU016C", "upgArmC007", "upgArmC006"],
+                ["upgHpU017", "upgHpU005C", "upgDmgC008", "upgDmgC004", "upgArmU002", "upgArmU013"],
+                ["upgHpU010C", "upgHpU016", "upgDmgU014", "upgDmgU003", "upgArmU007", "upgArmU004C"],
+                ["upgHpU017", "upgHpR016C", "upgDmgU008C", "upgDmgU019", "upgArmR006", "upgArmU013"],
+                ["upgHpR017C", "upgHpU006", "upgDmgR036", "upgDmgR012C", "upgArmU003C", "upgArmR010"],
+                ["upgHpR036", "upgHpR005", "upgDmgR14C", "upgDmgR005", "upgArmR004C", "upgArmR002C"],
+                ["upgHpE036C", "upgHpR006C", "upgDmgR005", "upgDmgE002C", "upgArmR036", "upgArmR013C"],
+                ["upgHpR005", "upgHpE006C", "upgDmgE036C", "upgDmgR016C", "upgArmE036C", "upgArmE009"],
+                ["upgHpE036C", "upgHpE017", "upgDmgE036C", "upgDmgE010", "upgArmE036C", "upgArmE003C"],
+                ["upgHpL116", "upgHpE002C", "upgDmgL036C", "upgDmgE002C", "upgArmE036C", "upgArmE011C"],
+                ["upgHpE036C", "upgHpL011C", "upgDmgE036C", "upgDmgL016C", "upgArmL202", "upgArmL003C"],
+                ["upgHpL036C", "upgHpL011C", "upgDmgL202", "upgDmgL002C", "upgArmL036C", "upgArmL011C"],
+                ["upgHpL136C", "upgHpL002C", "upgDmgL036C", "upgDmgL016C", "upgArmL036C", "upgArmL005C"],
+                ["upgHpL036C", "upgHpL013C", "upgDmgL136C", "upgDmgL010C", "upgArmL136C", "upgArmL011C"],
+                ["upgHpL136C", "upgHpL017C", "upgDmgL136C", "upgDmgL009C", "upgArmL136C", "upgArmL003C"],
+                ["upgHpL136C", "upgHpL212C", "upgDmgL136C", "upgDmgL212C", "upgArmL136C", "upgArmL212C"],
+                ["upgHpL136C", "upgHpL212C", "upgDmgM211C", "upgDmgL212C", "upgArmM212C", "upgArmL212C"],
+                ["upgHpM136C", "upgHpL212C", "upgDmgM211C", "upgDmgL212C", "upgArmM212C", "upgArmL212C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [7, 7, 2, 2, 2, 2],
+                [9, 9, 2, 3, 1, 1],
+                [8, 13, 3, 3, 3, 3],
+                [16, 11, 4, 4, 2, 2],
+                [11, 23, 5, 3, 4, 3],
+                [29, 14, 5, 7, 4, 4],
+                [27, 27, 8, 6, 6, 6],
+                [37, 29, 7, 12, 5, 7],
+                [32, 53, 12, 10, 9, 8],
+                [57, 46, 16, 13, 11, 11],
+                [66, 66, 20, 16, 13, 13],
+                [75, 89, 20, 25, 15, 17],
+                [103, 103, 25, 31, 21, 21],
+                [129, 129, 35, 35, 26, 26],
+                [161, 161, 44, 44, 32, 32],
+                [202, 202, 55, 55, 40, 40],
+                [252, 252, 69, 69, 51, 51],
+                [138, 138, 40, 34, 29, 25],
+                [148, 126, 40, 35, 30, 25],
+                [122, 152, 33, 42, 24, 31]
+            ]
+        },
+        "genesPrimus": {
+            "name": "Isaak",
+            "FactionId": "Genestealers",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Rare",
+            "powerMultiplier": 115,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 3,
+                    "DamageProfile": "Bio"
+                },
+                {
+                    "hits": 1,
+                    "DamageProfile": "Bio",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 70,
+                "Damage": 30,
+                "FixedArmor": 14,
+                "ProgressionIndex": 6
+            },
+            "traits": ["Hero", "Ambush"],
+            "activeAbilities": ["CultDemagogue"],
+            "passiveAbilities": ["DecoysAndMisdirection"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [2],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_genesPrimus_01"],
+            "upgrades": [
+                ["upgHpC009", "upgHpC010", "upgDmgC003", "upgDmgC014", "upgArmC003", "upgArmC005"],
+                ["upgHpC017", "upgHpC015", "upgDmgU014", "upgDmgU016C", "upgArmC007", "upgArmC006"],
+                ["upgHpU017", "upgHpU018C", "upgDmgC013", "upgDmgC010", "upgArmU002", "upgArmU013"],
+                ["upgHpU010C", "upgHpU017", "upgDmgU014", "upgDmgU010", "upgArmU007", "upgArmU004C"],
+                ["upgHpU017", "upgHpR017C", "upgDmgU018C", "upgDmgU019", "upgArmR006", "upgArmU013"],
+                ["upgHpR017C", "upgHpU009", "upgDmgR036", "upgDmgR010C", "upgArmU003C", "upgArmR015"],
+                ["upgHpR036", "upgHpR008", "upgDmgR13C", "upgDmgR002", "upgArmR004C", "upgArmR002C"],
+                ["upgHpE036C", "upgHpR013C", "upgDmgR005", "upgDmgE006C", "upgArmR036", "upgArmR013C"],
+                ["upgHpR019", "upgHpE007C", "upgDmgE036C", "upgDmgR016C", "upgArmE036C", "upgArmE009"],
+                ["upgHpE036C", "upgHpE017", "upgDmgE036C", "upgDmgE011", "upgArmE036C", "upgArmE003C"],
+                ["upgHpL116", "upgHpE008C", "upgDmgL036C", "upgDmgE006C", "upgArmE036C", "upgArmE011C"],
+                ["upgHpE036C", "upgHpL017C", "upgDmgE036C", "upgDmgL016C", "upgArmL203", "upgArmL003C"],
+                ["upgHpL036C", "upgHpL009C", "upgDmgL003", "upgDmgL005C", "upgArmL036C", "upgArmL011C"],
+                ["upgHpL136C", "upgHpL012C", "upgDmgL036C", "upgDmgL016C", "upgArmL036C", "upgArmL005C"],
+                ["upgHpL036C", "upgHpL013C", "upgDmgL136C", "upgDmgL008C", "upgArmL136C", "upgArmL011C"],
+                ["upgHpL136C", "upgHpL017C", "upgDmgL136C", "upgDmgL009C", "upgArmL136C", "upgArmL003C"],
+                ["upgHpL136C", "upgHpL212C", "upgDmgL136C", "upgDmgL212C", "upgArmL136C", "upgArmL212C"],
+                ["upgHpL136C", "upgHpL212C", "upgDmgM213C", "upgDmgL212C", "upgArmM212C", "upgArmL212C"],
+                ["upgHpM136C", "upgHpL212C", "upgDmgM213C", "upgDmgL212C", "upgArmM213C", "upgArmL212C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [9, 9, 4, 4, 2, 2],
+                [11, 11, 4, 5, 2, 2],
+                [11, 16, 6, 6, 3, 3],
+                [21, 14, 8, 8, 2, 4],
+                [14, 29, 10, 7, 5, 4],
+                [37, 18, 10, 14, 6, 6],
+                [34, 34, 17, 12, 7, 7],
+                [47, 38, 14, 23, 7, 9],
+                [40, 66, 25, 20, 12, 9],
+                [74, 59, 32, 25, 13, 13],
+                [84, 84, 39, 32, 17, 17],
+                [95, 113, 41, 49, 19, 23],
+                [131, 131, 51, 61, 26, 26],
+                [164, 164, 71, 71, 33, 33],
+                [205, 205, 87, 87, 41, 41],
+                [257, 257, 110, 110, 51, 51],
+                [321, 321, 138, 138, 65, 65],
+                [175, 175, 81, 69, 37, 32],
+                [188, 162, 81, 69, 38, 32],
+                [156, 194, 67, 83, 31, 39]
+            ]
+        },
+        "genesKelermorph": {
+            "name": "Judh",
+            "FactionId": "Genestealers",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Epic",
+            "powerMultiplier": 126,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 3,
+                    "DamageProfile": "Projectile"
+                },
+                {
+                    "hits": 3,
+                    "DamageProfile": "Projectile",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 60,
+                "Damage": 25,
+                "FixedArmor": 13,
+                "ProgressionIndex": 9
+            },
+            "traits": ["Hero", "Ambush", "BeastSlayer"],
+            "activeAbilities": ["HeroicFusillade"],
+            "passiveAbilities": ["HypersensoryAbilities"],
+            "itemSlots": ["I_Crit", "I_Crit", "I_Booster_Crit"],
+            "itemSlotsRelic": [2],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "timestampIfHeroUnlocked": 1743292800000,
+                "timestampIfHeroNotUnlocked": 1746316800000
+            },
+            "releaseStatus": "1743292800000",
+            "unlockQuestIds": ["hero_genesKelermorph_01"],
+            "upgrades": [
+                ["upgHpC009", "upgHpC010", "upgDmgC003", "upgDmgC014", "upgArmC003", "upgArmC005"],
+                ["upgHpC013", "upgHpC015", "upgDmgU014", "upgDmgU016C", "upgArmC007", "upgArmC006"],
+                ["upgHpU012", "upgHpU018C", "upgDmgC001", "upgDmgC003", "upgArmU002", "upgArmU013"],
+                ["upgHpU010C", "upgHpU017", "upgDmgU014", "upgDmgU014", "upgArmU007", "upgArmU004C"],
+                ["upgHpU012", "upgHpR017C", "upgDmgU001C", "upgDmgU019", "upgArmR006", "upgArmU013"],
+                ["upgHpR015C", "upgHpU009", "upgDmgR036", "upgDmgR012C", "upgArmU003C", "upgArmR015"],
+                ["upgHpR036", "upgHpR008", "upgDmgR001C", "upgDmgR002", "upgArmR004C", "upgArmR002C"],
+                ["upgHpE036C", "upgHpR013C", "upgDmgR005", "upgDmgE009C", "upgArmR036", "upgArmR013C"],
+                ["upgHpR018", "upgHpE007C", "upgDmgE036C", "upgDmgR016C", "upgArmE036C", "upgArmE009"],
+                ["upgHpE036C", "upgHpE017", "upgDmgE036C", "upgDmgE001", "upgArmE036C", "upgArmE003C"],
+                ["upgHpL116", "upgHpE008C", "upgDmgL036C", "upgDmgE009C", "upgArmE036C", "upgArmE011C"],
+                ["upgHpE036C", "upgHpL017C", "upgDmgE036C", "upgDmgL016C", "upgArmL203", "upgArmL003C"],
+                ["upgHpL036C", "upgHpL009C", "upgDmgL001", "upgDmgL009C", "upgArmL036C", "upgArmL011C"],
+                ["upgHpL136C", "upgHpL012C", "upgDmgL036C", "upgDmgL016C", "upgArmL036C", "upgArmL005C"],
+                ["upgHpL036C", "upgHpL013C", "upgDmgL136C", "upgDmgL007C", "upgArmL136C", "upgArmL011C"],
+                ["upgHpL136C", "upgHpL009C", "upgDmgL136C", "upgDmgL009C", "upgArmL136C", "upgArmL003C"],
+                ["upgHpL136C", "upgHpL212C", "upgDmgL136C", "upgDmgL212C", "upgArmL136C", "upgArmL212C"],
+                ["upgHpL136C", "upgHpL212C", "upgDmgM213C", "upgDmgL212C", "upgArmM212C", "upgArmL212C"],
+                ["upgHpM136C", "upgHpL212C", "upgDmgM213C", "upgDmgL212C", "upgArmM213C", "upgArmL212C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [8, 8, 3, 3, 2, 2],
+                [9, 9, 3, 5, 2, 2],
+                [10, 14, 5, 5, 3, 3],
+                [17, 12, 6, 6, 2, 3],
+                [13, 25, 10, 6, 5, 3],
+                [31, 15, 8, 11, 5, 5],
+                [29, 29, 14, 11, 7, 7],
+                [41, 32, 11, 19, 6, 8],
+                [35, 58, 21, 17, 11, 9],
+                [63, 50, 27, 21, 13, 13],
+                [72, 72, 32, 27, 15, 15],
+                [81, 97, 34, 41, 18, 21],
+                [112, 112, 42, 51, 24, 24],
+                [141, 141, 59, 59, 31, 31],
+                [176, 176, 73, 73, 38, 38],
+                [220, 220, 92, 92, 48, 48],
+                [275, 275, 115, 115, 59, 59],
+                [150, 150, 67, 57, 35, 30],
+                [162, 138, 67, 58, 35, 30],
+                [133, 167, 56, 69, 29, 36]
+            ]
+        },
+        "genesPatriarch": {
+            "name": "The Patermine",
+            "FactionId": "Genestealers",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Legendary",
+            "powerMultiplier": 84,
+            "Movement": 4,
+            "weapons": [
+                {
+                    "hits": 5,
+                    "DamageProfile": "Eviscerate"
+                }
+            ],
+            "stats": {
+                "Health": 100,
+                "Damage": 14,
+                "FixedArmor": 17,
+                "ProgressionIndex": 12
+            },
+            "traits": ["Hero", "Infiltrate", "Synapse", "Terrifying", "Unstoppable"],
+            "activeAbilities": ["MightFromBelow"],
+            "passiveAbilities": ["CosmicHorror"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "timestampIfHeroUnlocked": 1761523200000,
+                "timestampIfHeroNotUnlocked": 1764460800000
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_genesPatriarch_01"],
+            "eventMetadata": {
+                "leg": {
+                    "finalEventEndDate": 1761523200000
+                }
+            },
+            "upgrades": [
+                ["upgHpC009", "upgHpC004", "upgDmgC003", "upgDmgC014", "upgArmC003", "upgArmC005"],
+                ["upgHpC001", "upgHpC009", "upgDmgU014", "upgDmgU016C", "upgArmC007", "upgArmC007"],
+                ["upgHpU001", "upgHpU010C", "upgDmgC008", "upgDmgC003", "upgArmU002", "upgArmU007"],
+                ["upgHpU010C", "upgHpU012", "upgDmgU014", "upgDmgU014", "upgArmU007", "upgArmU004C"],
+                ["upgHpU001", "upgHpR015C", "upgDmgU008C", "upgDmgU019", "upgArmR015", "upgArmU007"],
+                ["upgHpR003C", "upgHpU006", "upgDmgR036", "upgDmgR012C", "upgArmU003C", "upgArmR015"],
+                ["upgHpR036", "upgHpR005", "upgDmgR14C", "upgDmgR005", "upgArmR004C", "upgArmR002C"],
+                ["upgHpE036C", "upgHpR009C", "upgDmgR005", "upgDmgE009C", "upgArmR036", "upgArmR004C"],
+                ["upgHpR008", "upgHpE013C", "upgDmgE036C", "upgDmgR016C", "upgArmE036C", "upgArmE013"],
+                ["upgHpE036C", "upgHpE017", "upgDmgE036C", "upgDmgE010", "upgArmE036C", "upgArmE003C"],
+                ["upgHpL116", "upgHpE002C", "upgDmgL036C", "upgDmgE009C", "upgArmE036C", "upgArmE005C"],
+                ["upgHpE036C", "upgHpL009C", "upgDmgE036C", "upgDmgL016C", "upgArmL202", "upgArmL003C"],
+                ["upgHpL036C", "upgHpL013C", "upgDmgL202", "upgDmgL009C", "upgArmL036C", "upgArmL005C"],
+                ["upgHpL136C", "upgHpL002C", "upgDmgL036C", "upgDmgL016C", "upgArmL036C", "upgArmL005C"],
+                ["upgHpL036C", "upgHpL013C", "upgDmgL136C", "upgDmgL010C", "upgArmL136C", "upgArmL005C"],
+                ["upgHpL136C", "upgHpL017C", "upgDmgL136C", "upgDmgL009C", "upgArmL136C", "upgArmL003C"],
+                ["upgHpL136C", "upgHpL211C", "upgDmgL136C", "upgDmgL211C", "upgArmL136C", "upgArmL211C"],
+                ["upgHpL136C", "upgHpL211C", "upgDmgM212C", "upgDmgL211C", "upgArmM212C", "upgArmL211C"],
+                ["upgHpM136C", "upgHpL211C", "upgDmgM212C", "upgDmgL211C", "upgArmM212C", "upgArmL211C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [13, 13, 2, 2, 2, 2],
+                [16, 16, 2, 2, 3, 3],
+                [15, 23, 3, 3, 3, 3],
+                [30, 20, 3, 3, 4, 5],
+                [21, 41, 5, 4, 6, 4],
+                [51, 26, 5, 6, 7, 7],
+                [49, 49, 8, 6, 8, 8],
+                [67, 54, 6, 11, 9, 12],
+                [57, 95, 12, 9, 14, 11],
+                [106, 84, 14, 12, 17, 17],
+                [120, 120, 19, 15, 20, 20],
+                [135, 162, 19, 23, 23, 27],
+                [187, 187, 24, 28, 32, 32],
+                [234, 234, 33, 33, 40, 40],
+                [293, 293, 41, 41, 50, 50],
+                [367, 367, 51, 51, 62, 62],
+                [459, 459, 65, 65, 78, 78],
+                [250, 250, 37, 32, 46, 39],
+                [269, 231, 38, 32, 46, 39],
+                [222, 278, 31, 39, 38, 47]
+            ]
+        },
+        "custoVexilusPraetor": {
+            "name": "Aesoth",
+            "FactionId": "Custodes",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Uncommon",
+            "powerMultiplier": 127,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 1,
+                    "DamageProfile": "Physical"
+                }
+            ],
+            "stats": {
+                "Health": 110,
+                "Damage": 58,
+                "FixedArmor": 28,
+                "ProgressionIndex": 3
+            },
+            "traits": ["Hero", "MartialKatah", "BigTarget", "Resilient"],
+            "activeAbilities": ["VexillaMagnifica"],
+            "passiveAbilities": ["StandVigil"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Block"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "1747929600000",
+            "unlockQuestIds": ["hero_custoVexilusPraetor_01"],
+            "upgrades": [
+                ["upgHpC015", "upgHpC004", "upgDmgC009", "upgDmgC011", "upgArmC013", "upgArmC005"],
+                ["upgHpC003", "upgHpC002", "upgDmgU012", "upgDmgU015C", "upgArmC001", "upgArmC001"],
+                ["upgHpU002", "upgHpU004C", "upgDmgC007", "upgDmgC010", "upgArmU009", "upgArmU001"],
+                ["upgHpU018C", "upgHpU017", "upgDmgU012", "upgDmgU010", "upgArmU001", "upgArmU004C"],
+                ["upgHpU002", "upgHpR017C", "upgDmgU007C", "upgDmgU011", "upgArmR005", "upgArmU001"],
+                ["upgHpR020C", "upgHpU006", "upgDmgR037", "upgDmgR010C", "upgArmU003C", "upgArmR015"],
+                ["upgHpR037", "upgHpR005", "upgDmgR008C", "upgDmgR002", "upgArmR001C", "upgArmR002C"],
+                ["upgHpE037C", "upgHpR004C", "upgDmgR005", "upgDmgE006C", "upgArmR037", "upgArmR001C"],
+                ["upgHpR005", "upgHpE001C", "upgDmgE037C", "upgDmgR015C", "upgArmE037C", "upgArmE013"],
+                ["upgHpE037C", "upgHpE017", "upgDmgE037C", "upgDmgE004", "upgArmE037C", "upgArmE003C"],
+                ["upgHpL117", "upgHpE002C", "upgDmgL037C", "upgDmgE006C", "upgArmE037C", "upgArmE001C"],
+                ["upgHpE037C", "upgHpL017C", "upgDmgE037C", "upgDmgL015C", "upgArmL203", "upgArmL003C"],
+                ["upgHpL037C", "upgHpL001C", "upgDmgL003", "upgDmgL005C", "upgArmL037C", "upgArmL010C"],
+                ["upgHpL137C", "upgHpL002C", "upgDmgL037C", "upgDmgL015C", "upgArmL037C", "upgArmL010C"],
+                ["upgHpL037C", "upgHpL009C", "upgDmgL137C", "upgDmgL012C", "upgArmL137C", "upgArmL010C"],
+                ["upgHpL137C", "upgHpL002C", "upgDmgL137C", "upgDmgL006C", "upgArmL137C", "upgArmL003C"],
+                ["upgHpL137C", "upgHpL213C", "upgDmgL137C", "upgDmgL213C", "upgArmL137C", "upgArmL213C"],
+                ["upgHpL137C", "upgHpL213C", "upgDmgM214C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpM137C", "upgHpL213C", "upgDmgM214C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [14, 14, 8, 8, 4, 4],
+                [17, 17, 7, 10, 4, 4],
+                [18, 26, 12, 12, 6, 6],
+                [32, 22, 14, 14, 5, 8],
+                [23, 45, 21, 14, 10, 7],
+                [57, 29, 19, 26, 11, 11],
+                [53, 53, 33, 24, 14, 14],
+                [74, 60, 26, 44, 14, 19],
+                [63, 104, 49, 39, 24, 19],
+                [117, 93, 62, 49, 27, 27],
+                [131, 131, 75, 63, 33, 33],
+                [150, 179, 79, 94, 38, 45],
+                [206, 206, 99, 118, 53, 53],
+                [257, 257, 136, 136, 65, 65],
+                [322, 322, 170, 170, 82, 82],
+                [404, 404, 213, 213, 103, 103],
+                [505, 505, 266, 266, 129, 129],
+                [275, 275, 156, 134, 75, 64],
+                [296, 254, 156, 134, 75, 65],
+                [244, 305, 128, 161, 62, 78]
+            ]
+        },
+        "custoAtlacoya": {
+            "name": "Atlacoya",
+            "FactionId": "Custodes",
+            "Subfaction": "SistersSilence",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Rare",
+            "powerMultiplier": 105,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 3,
+                    "DamageProfile": "Power"
+                }
+            ],
+            "stats": {
+                "Health": 80,
+                "Damage": 30,
+                "FixedArmor": 19,
+                "ProgressionIndex": 6
+            },
+            "traits": ["Hero", "Parry", "Terrifying"],
+            "activeAbilities": ["TalonsOfTheEmperor"],
+            "passiveAbilities": ["DaughterOfTheAbyss"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_custoAtlacoya_01"],
+            "upgrades": [
+                ["upgHpC015", "upgHpC004", "upgDmgC010", "upgDmgC011", "upgArmC013", "upgArmC005"],
+                ["upgHpC013", "upgHpC002", "upgDmgU010", "upgDmgU015C", "upgArmC001", "upgArmC006"],
+                ["upgHpU012", "upgHpU004C", "upgDmgC013", "upgDmgC004", "upgArmU009", "upgArmU013"],
+                ["upgHpU018C", "upgHpU002", "upgDmgU010", "upgDmgU003", "upgArmU001", "upgArmU004C"],
+                ["upgHpU012", "upgHpR020C", "upgDmgU018C", "upgDmgU011", "upgArmR005", "upgArmU013"],
+                ["upgHpR015C", "upgHpU006", "upgDmgR037", "upgDmgR012C", "upgArmU003C", "upgArmR010"],
+                ["upgHpR037", "upgHpR005", "upgDmgR13C", "upgDmgR003", "upgArmR001C", "upgArmR002C"],
+                ["upgHpE037C", "upgHpR004C", "upgDmgR005", "upgDmgE002C", "upgArmR037", "upgArmR013C"],
+                ["upgHpR005", "upgHpE001C", "upgDmgE037C", "upgDmgR015C", "upgArmE037C", "upgArmE009"],
+                ["upgHpE037C", "upgHpE017", "upgDmgE037C", "upgDmgE010", "upgArmE037C", "upgArmE003C"],
+                ["upgHpL117", "upgHpE002C", "upgDmgL037C", "upgDmgE002C", "upgArmE037C", "upgArmE011C"],
+                ["upgHpE037C", "upgHpL002C", "upgDmgE037C", "upgDmgL015C", "upgArmL202", "upgArmL003C"],
+                ["upgHpL037C", "upgHpL001C", "upgDmgL202", "upgDmgL002C", "upgArmL037C", "upgArmL011C"],
+                ["upgHpL137C", "upgHpL002C", "upgDmgL037C", "upgDmgL015C", "upgArmL037C", "upgArmL010C"],
+                ["upgHpL037C", "upgHpL009C", "upgDmgL137C", "upgDmgL008C", "upgArmL137C", "upgArmL011C"],
+                ["upgHpL137C", "upgHpL009C", "upgDmgL137C", "upgDmgL005C", "upgArmL137C", "upgArmL003C"],
+                ["upgHpL137C", "upgHpL213C", "upgDmgL137C", "upgDmgL213C", "upgArmL137C", "upgArmL213C"],
+                ["upgHpL137C", "upgHpL213C", "upgDmgM211C", "upgDmgL213C", "upgArmM214C", "upgArmL212C"],
+                ["upgHpM137C", "upgHpL212C", "upgDmgM211C", "upgDmgL212C", "upgArmM214C", "upgArmL212C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [10, 10, 4, 4, 3, 3],
+                [13, 13, 4, 5, 3, 3],
+                [12, 19, 6, 6, 3, 3],
+                [24, 16, 8, 8, 4, 6],
+                [16, 33, 10, 7, 7, 4],
+                [41, 21, 10, 14, 8, 8],
+                [39, 39, 17, 12, 9, 9],
+                [54, 43, 14, 23, 10, 13],
+                [46, 76, 25, 20, 16, 13],
+                [84, 68, 32, 25, 18, 18],
+                [96, 96, 39, 32, 23, 23],
+                [108, 130, 41, 49, 25, 31],
+                [150, 150, 51, 61, 36, 36],
+                [187, 187, 71, 71, 44, 44],
+                [234, 234, 87, 87, 56, 56],
+                [294, 294, 110, 110, 70, 70],
+                [367, 367, 138, 138, 87, 87],
+                [200, 200, 81, 69, 51, 43],
+                [215, 185, 81, 69, 51, 44],
+                [177, 222, 67, 83, 42, 53]
+            ]
+        },
+        "custoKyrus": {
+            "name": "Tyrith",
+            "FactionId": "Custodes",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Rare",
+            "powerMultiplier": 82,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 3,
+                    "DamageProfile": "Power"
+                },
+                {
+                    "hits": 2,
+                    "DamageProfile": "Bolter",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 95,
+                "Damage": 25,
+                "FixedArmor": 22,
+                "ProgressionIndex": 6
+            },
+            "traits": ["Hero", "MartialKatah", "Resilient"],
+            "activeAbilities": ["VigilanceEternal"],
+            "passiveAbilities": ["UnwaveringSentinel"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_custoKyrus_01"],
+            "upgrades": [
+                ["upgHpC015", "upgHpC004", "upgDmgC009", "upgDmgC011", "upgArmC005", "upgArmC013"],
+                ["upgHpC003", "upgHpC002", "upgDmgU012", "upgDmgU015C", "upgArmC013", "upgArmC001"],
+                ["upgHpU002", "upgHpU004C", "upgDmgC001", "upgDmgC010", "upgArmU006", "upgArmU009"],
+                ["upgHpU018C", "upgHpU017", "upgDmgU012", "upgDmgU010", "upgArmU009", "upgArmU004C"],
+                ["upgHpU002", "upgHpR017C", "upgDmgU001C", "upgDmgU011", "upgArmR005", "upgArmU001"],
+                ["upgHpR020C", "upgHpU006", "upgDmgR037", "upgDmgR010C", "upgArmU004C", "upgArmR015"],
+                ["upgHpR037", "upgHpR005", "upgDmgR001C", "upgDmgR002", "upgArmR002C", "upgArmR012C"],
+                ["upgHpE037C", "upgHpR004C", "upgDmgR005", "upgDmgE006C", "upgArmR037", "upgArmR001C"],
+                ["upgHpR005", "upgHpE001C", "upgDmgE037C", "upgDmgR015C", "upgArmE037C", "upgArmE013"],
+                ["upgHpE037C", "upgHpE017", "upgDmgE037C", "upgDmgE001", "upgArmE037C", "upgArmE003C"],
+                ["upgHpL117", "upgHpE002C", "upgDmgL037C", "upgDmgE006C", "upgArmE037C", "upgArmE006C"],
+                ["upgHpE037C", "upgHpL017C", "upgDmgE037C", "upgDmgL015C", "upgArmL203", "upgArmL003C"],
+                ["upgHpL037C", "upgHpL001C", "upgDmgL001", "upgDmgL005C", "upgArmL037C", "upgArmL006C"],
+                ["upgHpL137C", "upgHpL002C", "upgDmgL037C", "upgDmgL015C", "upgArmL037C", "upgArmL010C"],
+                ["upgHpL037C", "upgHpL009C", "upgDmgL137C", "upgDmgL007C", "upgArmL137C", "upgArmL006C"],
+                ["upgHpL137C", "upgHpL002C", "upgDmgL137C", "upgDmgL006C", "upgArmL137C", "upgArmL003C"],
+                ["upgHpL137C", "upgHpL213C", "upgDmgL137C", "upgDmgL213C", "upgArmL137C", "upgArmL213C"],
+                ["upgHpL137C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM211C", "upgArmL213C"],
+                ["upgHpM137C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 3, 3, 3, 3],
+                [15, 15, 3, 5, 3, 3],
+                [15, 22, 5, 5, 5, 5],
+                [28, 19, 6, 6, 4, 6],
+                [20, 39, 10, 6, 8, 6],
+                [49, 25, 8, 11, 9, 9],
+                [46, 46, 14, 11, 10, 10],
+                [64, 52, 11, 19, 12, 15],
+                [54, 90, 21, 17, 18, 15],
+                [101, 80, 27, 21, 21, 21],
+                [114, 114, 32, 27, 27, 27],
+                [128, 154, 34, 41, 29, 35],
+                [178, 178, 42, 51, 42, 42],
+                [222, 222, 59, 59, 51, 51],
+                [279, 279, 73, 73, 64, 64],
+                [348, 348, 92, 92, 81, 81],
+                [436, 436, 115, 115, 101, 101],
+                [238, 238, 67, 57, 59, 51],
+                [255, 219, 67, 58, 59, 51],
+                [211, 263, 56, 69, 49, 61]
+            ]
+        },
+        "custoBladeChampion": {
+            "name": "Kariyan",
+            "FactionId": "Custodes",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Epic",
+            "powerMultiplier": 85,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 3,
+                    "DamageProfile": "Power"
+                }
+            ],
+            "stats": {
+                "Health": 95,
+                "Damage": 21,
+                "FixedArmor": 24,
+                "ProgressionIndex": 9
+            },
+            "traits": ["Hero", "MartialKatah", "BeastSlayer", "RapidAssault", "Parry", "Resilient"],
+            "activeAbilities": ["MartialInspiration"],
+            "passiveAbilities": ["LegacyOfCombat"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "timestampIfHeroUnlocked": 1752364800000,
+                "timestampIfHeroNotUnlocked": 1755388800000
+            },
+            "releaseStatus": "1747929600000",
+            "unlockQuestIds": ["hero_custoBladeChampion_01"],
+            "upgrades": [
+                ["upgHpC015", "upgHpC004", "upgDmgC009", "upgDmgC011", "upgArmC013", "upgArmC005"],
+                ["upgHpC003", "upgHpC002", "upgDmgU012", "upgDmgU015C", "upgArmC001", "upgArmC006"],
+                ["upgHpU002", "upgHpU004C", "upgDmgC013", "upgDmgC010", "upgArmU009", "upgArmU013"],
+                ["upgHpU018C", "upgHpU017", "upgDmgU012", "upgDmgU010", "upgArmU001", "upgArmU004C"],
+                ["upgHpU002", "upgHpR017C", "upgDmgU018C", "upgDmgU011", "upgArmR005", "upgArmU013"],
+                ["upgHpR020C", "upgHpU006", "upgDmgR037", "upgDmgR010C", "upgArmU003C", "upgArmR015"],
+                ["upgHpR037", "upgHpR005", "upgDmgR13C", "upgDmgR002", "upgArmR001C", "upgArmR002C"],
+                ["upgHpE037C", "upgHpR004C", "upgDmgR005", "upgDmgE006C", "upgArmR037", "upgArmR013C"],
+                ["upgHpR005", "upgHpE001C", "upgDmgE037C", "upgDmgR015C", "upgArmE037C", "upgArmE013"],
+                ["upgHpE037C", "upgHpE017", "upgDmgE037C", "upgDmgE011", "upgArmE037C", "upgArmE003C"],
+                ["upgHpL117", "upgHpE002C", "upgDmgL037C", "upgDmgE006C", "upgArmE037C", "upgArmE011C"],
+                ["upgHpE037C", "upgHpL017C", "upgDmgE037C", "upgDmgL015C", "upgArmL203", "upgArmL003C"],
+                ["upgHpL037C", "upgHpL001C", "upgDmgL003", "upgDmgL005C", "upgArmL037C", "upgArmL011C"],
+                ["upgHpL137C", "upgHpL002C", "upgDmgL037C", "upgDmgL015C", "upgArmL037C", "upgArmL010C"],
+                ["upgHpL037C", "upgHpL009C", "upgDmgL137C", "upgDmgL008C", "upgArmL137C", "upgArmL011C"],
+                ["upgHpL137C", "upgHpL002C", "upgDmgL137C", "upgDmgL006C", "upgArmL137C", "upgArmL003C"],
+                ["upgHpL137C", "upgHpL213C", "upgDmgL137C", "upgDmgL213C", "upgArmL137C", "upgArmL213C"],
+                ["upgHpL137C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpM137C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 3, 3, 3, 3],
+                [15, 15, 2, 4, 4, 4],
+                [15, 22, 4, 4, 5, 5],
+                [28, 19, 6, 6, 4, 7],
+                [20, 39, 7, 5, 9, 6],
+                [49, 25, 7, 9, 9, 9],
+                [46, 46, 11, 9, 12, 12],
+                [64, 52, 10, 16, 12, 17],
+                [54, 90, 18, 14, 20, 16],
+                [101, 80, 22, 18, 23, 23],
+                [114, 114, 27, 23, 29, 29],
+                [128, 154, 29, 34, 32, 39],
+                [178, 178, 35, 43, 45, 45],
+                [222, 222, 49, 49, 56, 56],
+                [279, 279, 62, 62, 71, 71],
+                [348, 348, 77, 77, 88, 88],
+                [436, 436, 96, 96, 110, 110],
+                [238, 238, 57, 48, 64, 55],
+                [255, 219, 57, 48, 65, 55],
+                [211, 263, 47, 58, 53, 67]
+            ]
+        },
+        "custoTrajann": {
+            "name": "Trajann",
+            "FactionId": "Custodes",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Legendary",
+            "powerMultiplier": 94,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 3,
+                    "DamageProfile": "Piercing"
+                }
+            ],
+            "stats": {
+                "Health": 100,
+                "Damage": 11,
+                "FixedArmor": 25,
+                "ProgressionIndex": 12
+            },
+            "traits": ["Hero", "MartialKatah", "CrushingStrike", "Resilient"],
+            "activeAbilities": ["MomentShackle"],
+            "passiveAbilities": ["LegendaryCommander"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Block"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "timestampIfHeroUnlocked": 1779667200000,
+                "timestampIfHeroNotUnlocked": 1782604800000
+            },
+            "releaseStatus": "1747929600000",
+            "unlockQuestIds": ["hero_custoTrajann_01"],
+            "eventMetadata": {
+                "leg": {
+                    "finalEventEndDate": 1779667200000
+                }
+            },
+            "upgrades": [
+                ["upgHpC015", "upgHpC004", "upgDmgC009", "upgDmgC011", "upgArmC013", "upgArmC005"],
+                ["upgHpC003", "upgHpC002", "upgDmgU012", "upgDmgU015C", "upgArmC001", "upgArmC006"],
+                ["upgHpU002", "upgHpU004C", "upgDmgC001", "upgDmgC010", "upgArmU009", "upgArmU013"],
+                ["upgHpU018C", "upgHpU017", "upgDmgU012", "upgDmgU010", "upgArmU001", "upgArmU004C"],
+                ["upgHpU002", "upgHpR017C", "upgDmgU001C", "upgDmgU011", "upgArmR005", "upgArmU013"],
+                ["upgHpR020C", "upgHpU006", "upgDmgR037", "upgDmgR010C", "upgArmU003C", "upgArmR015"],
+                ["upgHpR037", "upgHpR005", "upgDmgR001C", "upgDmgR005", "upgArmR001C", "upgArmR002C"],
+                ["upgHpE037C", "upgHpR004C", "upgDmgR005", "upgDmgE006C", "upgArmR037", "upgArmR013C"],
+                ["upgHpR005", "upgHpE001C", "upgDmgE037C", "upgDmgR015C", "upgArmE037C", "upgArmE013"],
+                ["upgHpE037C", "upgHpE017", "upgDmgE037C", "upgDmgE011", "upgArmE037C", "upgArmE003C"],
+                ["upgHpL117", "upgHpE002C", "upgDmgL037C", "upgDmgE006C", "upgArmE037C", "upgArmE011C"],
+                ["upgHpE037C", "upgHpL017C", "upgDmgE037C", "upgDmgL015C", "upgArmL203", "upgArmL003C"],
+                ["upgHpL037C", "upgHpL001C", "upgDmgL001", "upgDmgL005C", "upgArmL037C", "upgArmL011C"],
+                ["upgHpL137C", "upgHpL002C", "upgDmgL037C", "upgDmgL015C", "upgArmL037C", "upgArmL010C"],
+                ["upgHpL037C", "upgHpL009C", "upgDmgL137C", "upgDmgL007C", "upgArmL137C", "upgArmL011C"],
+                ["upgHpL137C", "upgHpL002C", "upgDmgL137C", "upgDmgL006C", "upgArmL137C", "upgArmL003C"],
+                ["upgHpL137C", "upgHpL213C", "upgDmgL137C", "upgDmgL213C", "upgArmL137C", "upgArmL213C"],
+                ["upgHpL137C", "upgHpL213C", "upgDmgM214C", "upgDmgL213C", "upgArmM211C", "upgArmL213C"],
+                ["upgHpM137C", "upgHpL213C", "upgDmgM214C", "upgDmgL213C", "upgArmM213C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [13, 13, 2, 2, 3, 3],
+                [16, 16, 1, 1, 4, 4],
+                [15, 23, 3, 3, 5, 5],
+                [30, 20, 2, 2, 5, 7],
+                [21, 41, 4, 3, 10, 6],
+                [51, 26, 3, 5, 10, 10],
+                [49, 49, 6, 5, 12, 12],
+                [67, 54, 5, 8, 13, 17],
+                [57, 95, 9, 8, 21, 17],
+                [106, 84, 12, 9, 24, 24],
+                [120, 120, 14, 12, 30, 30],
+                [135, 162, 15, 18, 34, 40],
+                [187, 187, 19, 22, 47, 47],
+                [234, 234, 26, 26, 58, 58],
+                [293, 293, 32, 32, 74, 74],
+                [367, 367, 41, 41, 91, 91],
+                [459, 459, 50, 50, 115, 115],
+                [250, 250, 30, 25, 67, 58],
+                [269, 231, 30, 25, 67, 58],
+                [222, 278, 24, 31, 56, 69]
+            ]
+        },
+        "emperNoiseMarine": {
+            "name": "Shiron",
+            "FactionId": "EmperorsChildren",
+            "GrandAllianceId": "Chaos",
+            "BaseRarity": "Uncommon",
+            "powerMultiplier": 97,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 3,
+                    "DamageProfile": "Eviscerate"
+                },
+                {
+                    "hits": 6,
+                    "DamageProfile": "Eviscerate",
+                    "Range": 3
+                }
+            ],
+            "stats": {
+                "Health": 85,
+                "Damage": 6,
+                "FixedArmor": 20,
+                "ProgressionIndex": 3
+            },
+            "traits": ["Hero", "ThrillSeekers", "HeavyWeapon", "SuppressiveFire"],
+            "activeAbilities": ["ExcruciatingFrequencies"],
+            "passiveAbilities": ["TerrifyingCrescendo"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [2],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_emperNoiseMarine_01"],
+            "upgrades": [
+                ["upgHpC002", "upgHpC010", "upgDmgC009", "upgDmgC014", "upgArmC003", "upgArmC007"],
+                ["upgHpC014", "upgHpC002", "upgDmgU012", "upgDmgU016C", "upgArmC007", "upgArmC013"],
+                ["upgHpU014", "upgHpU004C", "upgDmgC008", "upgDmgC003", "upgArmU005", "upgArmU007"],
+                ["upgHpU004C", "upgHpU012", "upgDmgU012", "upgDmgU014", "upgArmU007", "upgArmU010C"],
+                ["upgHpU014", "upgHpR015C", "upgDmgU008C", "upgDmgU019", "upgArmR015", "upgArmU009"],
+                ["upgHpR012C", "upgHpU009", "upgDmgR039", "upgDmgR012C", "upgArmU010C", "upgArmR005"],
+                ["upgHpR039", "upgHpR008", "upgDmgR14C", "upgDmgR006", "upgArmR003C", "upgArmR004C"],
+                ["upgHpE039C", "upgHpR004C", "upgDmgR003", "upgDmgE009C", "upgArmR039", "upgArmR012C"],
+                ["upgHpR018", "upgHpE001C", "upgDmgE039C", "upgDmgR016C", "upgArmE039C", "upgArmE010"],
+                ["upgHpE039C", "upgHpE012", "upgDmgE039C", "upgDmgE004", "upgArmE039C", "upgArmE004C"],
+                ["upgHpL119", "upgHpE008C", "upgDmgL039C", "upgDmgE009C", "upgArmE039C", "upgArmE005C"],
+                ["upgHpE039C", "upgHpL009C", "upgDmgE039C", "upgDmgL016C", "upgArmL202", "upgArmL004C"],
+                ["upgHpL039C", "upgHpL001C", "upgDmgL202", "upgDmgL009C", "upgArmL039C", "upgArmL005C"],
+                ["upgHpL139C", "upgHpL012C", "upgDmgL039C", "upgDmgL016C", "upgArmL039C", "upgArmL006C"],
+                ["upgHpL039C", "upgHpL001C", "upgDmgL139C", "upgDmgL010C", "upgArmL139C", "upgArmL005C"],
+                ["upgHpL139C", "upgHpL017C", "upgDmgL139C", "upgDmgL006C", "upgArmL139C", "upgArmL004C"],
+                ["upgHpL139C", "upgHpL213C", "upgDmgL139C", "upgDmgL213C", "upgArmL139C", "upgArmL213C"],
+                ["upgHpL139C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpM139C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM212C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [11, 11, 1, 1, 3, 3],
+                [13, 13, 1, 1, 3, 3],
+                [14, 20, 1, 1, 4, 4],
+                [25, 17, 2, 2, 4, 5],
+                [17, 35, 1, 1, 8, 5],
+                [44, 22, 2, 3, 8, 8],
+                [42, 42, 3, 3, 9, 9],
+                [57, 45, 3, 4, 11, 14],
+                [48, 81, 5, 4, 17, 13],
+                [90, 72, 7, 5, 19, 19],
+                [102, 102, 8, 6, 24, 24],
+                [115, 138, 8, 10, 27, 33],
+                [159, 159, 10, 12, 37, 37],
+                [199, 199, 15, 15, 47, 47],
+                [249, 249, 17, 17, 59, 59],
+                [312, 312, 22, 22, 73, 73],
+                [390, 390, 28, 28, 92, 92],
+                [213, 213, 16, 13, 54, 46],
+                [228, 196, 16, 14, 54, 46],
+                [188, 236, 13, 17, 44, 56]
+            ]
+        },
+        "emperFlawlessBlade": {
+            "name": "Hascule",
+            "FactionId": "EmperorsChildren",
+            "GrandAllianceId": "Chaos",
+            "BaseRarity": "Rare",
+            "powerMultiplier": 108,
+            "Movement": 4,
+            "weapons": [
+                {
+                    "hits": 3,
+                    "DamageProfile": "Piercing"
+                }
+            ],
+            "stats": {
+                "Health": 95,
+                "Damage": 15,
+                "FixedArmor": 19,
+                "ProgressionIndex": 6
+            },
+            "traits": ["Hero", "ThrillSeekers", "Parry"],
+            "activeAbilities": ["DaemonicPatrons"],
+            "passiveAbilities": ["EcstaticSlaughter"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [2],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_emperFlawlessBlade_01"],
+            "upgrades": [
+                ["upgHpC015", "upgHpC010", "upgDmgC003", "upgDmgC014", "upgArmC003", "upgArmC012"],
+                ["upgHpC013", "upgHpC015", "upgDmgU014", "upgDmgU016C", "upgArmC012", "upgArmC007"],
+                ["upgHpU012", "upgHpU018C", "upgDmgC013", "upgDmgC003", "upgArmU005", "upgArmU002"],
+                ["upgHpU018C", "upgHpU012", "upgDmgU014", "upgDmgU014", "upgArmU002", "upgArmU010C"],
+                ["upgHpU012", "upgHpR015C", "upgDmgU018C", "upgDmgU019", "upgArmR006", "upgArmU007"],
+                ["upgHpR015C", "upgHpU009", "upgDmgR039", "upgDmgR012C", "upgArmU010C", "upgArmR015"],
+                ["upgHpR039", "upgHpR008", "upgDmgR13C", "upgDmgR005", "upgArmR003C", "upgArmR008C"],
+                ["upgHpE039C", "upgHpR013C", "upgDmgR003", "upgDmgE009C", "upgArmR039", "upgArmR004C"],
+                ["upgHpR018", "upgHpE007C", "upgDmgE039C", "upgDmgR016C", "upgArmE039C", "upgArmE013"],
+                ["upgHpE039C", "upgHpE017", "upgDmgE039C", "upgDmgE011", "upgArmE039C", "upgArmE004C"],
+                ["upgHpL119", "upgHpE008C", "upgDmgL039C", "upgDmgE009C", "upgArmE039C", "upgArmE012C"],
+                ["upgHpE039C", "upgHpL009C", "upgDmgE039C", "upgDmgL016C", "upgArmL202", "upgArmL004C"],
+                ["upgHpL039C", "upgHpL009C", "upgDmgL003", "upgDmgL009C", "upgArmL039C", "upgArmL008C"],
+                ["upgHpL139C", "upgHpL012C", "upgDmgL039C", "upgDmgL016C", "upgArmL039C", "upgArmL005C"],
+                ["upgHpL039C", "upgHpL009C", "upgDmgL139C", "upgDmgL008C", "upgArmL139C", "upgArmL008C"],
+                ["upgHpL139C", "upgHpL009C", "upgDmgL139C", "upgDmgL009C", "upgArmL139C", "upgArmL004C"],
+                ["upgHpL139C", "upgHpL212C", "upgDmgL139C", "upgDmgL212C", "upgArmL139C", "upgArmL212C"],
+                ["upgHpL139C", "upgHpL212C", "upgDmgM211C", "upgDmgL212C", "upgArmM212C", "upgArmL212C"],
+                ["upgHpM139C", "upgHpL212C", "upgDmgM211C", "upgDmgL212C", "upgArmM214C", "upgArmL212C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 2, 2, 3, 3],
+                [15, 15, 2, 3, 3, 3],
+                [15, 22, 3, 3, 3, 3],
+                [28, 19, 4, 4, 4, 6],
+                [20, 39, 5, 3, 7, 4],
+                [49, 25, 5, 7, 8, 8],
+                [46, 46, 8, 6, 9, 9],
+                [64, 52, 7, 12, 10, 13],
+                [54, 90, 12, 10, 16, 13],
+                [101, 80, 16, 13, 18, 18],
+                [114, 114, 20, 16, 23, 23],
+                [128, 154, 20, 25, 25, 31],
+                [178, 178, 25, 31, 36, 36],
+                [222, 222, 35, 35, 44, 44],
+                [279, 279, 44, 44, 56, 56],
+                [348, 348, 55, 55, 70, 70],
+                [436, 436, 69, 69, 87, 87],
+                [238, 238, 40, 34, 51, 43],
+                [255, 219, 40, 35, 51, 44],
+                [211, 263, 33, 42, 42, 53]
+            ]
+        },
+        "emperKakophonist": {
+            "name": "Adamatar",
+            "FactionId": "EmperorsChildren",
+            "GrandAllianceId": "Chaos",
+            "BaseRarity": "Rare",
+            "powerMultiplier": 120,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 3,
+                    "DamageProfile": "Eviscerate"
+                }
+            ],
+            "stats": {
+                "Health": 100,
+                "Damage": 17,
+                "FixedArmor": 23,
+                "ProgressionIndex": 6
+            },
+            "traits": ["Hero", "ThrillSeekers"],
+            "activeAbilities": ["DoomSiren"],
+            "passiveAbilities": ["ObsessiveAnnunciation"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [2],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_emperKakophonist_01"],
+            "upgrades": [
+                ["upgHpC002", "upgHpC010", "upgDmgC009", "upgDmgC014", "upgArmC003", "upgArmC007"],
+                ["upgHpC014", "upgHpC002", "upgDmgU012", "upgDmgU016C", "upgArmC007", "upgArmC013"],
+                ["upgHpU014", "upgHpU004C", "upgDmgC008", "upgDmgC003", "upgArmU005", "upgArmU007"],
+                ["upgHpU004C", "upgHpU012", "upgDmgU012", "upgDmgU014", "upgArmU007", "upgArmU010C"],
+                ["upgHpU014", "upgHpR015C", "upgDmgU008C", "upgDmgU019", "upgArmR015", "upgArmU009"],
+                ["upgHpR012C", "upgHpU009", "upgDmgR039", "upgDmgR012C", "upgArmU010C", "upgArmR005"],
+                ["upgHpR039", "upgHpR008", "upgDmgR14C", "upgDmgR006", "upgArmR003C", "upgArmR004C"],
+                ["upgHpE039C", "upgHpR004C", "upgDmgR003", "upgDmgE009C", "upgArmR039", "upgArmR012C"],
+                ["upgHpR018", "upgHpE001C", "upgDmgE039C", "upgDmgR016C", "upgArmE039C", "upgArmE010"],
+                ["upgHpE039C", "upgHpE012", "upgDmgE039C", "upgDmgE004", "upgArmE039C", "upgArmE004C"],
+                ["upgHpL119", "upgHpE008C", "upgDmgL039C", "upgDmgE009C", "upgArmE039C", "upgArmE005C"],
+                ["upgHpE039C", "upgHpL009C", "upgDmgE039C", "upgDmgL016C", "upgArmL202", "upgArmL004C"],
+                ["upgHpL039C", "upgHpL001C", "upgDmgL202", "upgDmgL009C", "upgArmL039C", "upgArmL005C"],
+                ["upgHpL139C", "upgHpL012C", "upgDmgL039C", "upgDmgL016C", "upgArmL039C", "upgArmL006C"],
+                ["upgHpL039C", "upgHpL001C", "upgDmgL139C", "upgDmgL010C", "upgArmL139C", "upgArmL005C"],
+                ["upgHpL139C", "upgHpL017C", "upgDmgL139C", "upgDmgL006C", "upgArmL139C", "upgArmL004C"],
+                ["upgHpL139C", "upgHpL213C", "upgDmgL139C", "upgDmgL213C", "upgArmL139C", "upgArmL213C"],
+                ["upgHpL139C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpM139C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM212C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [13, 13, 2, 2, 3, 3],
+                [16, 16, 2, 4, 4, 4],
+                [15, 23, 3, 3, 4, 4],
+                [30, 20, 5, 5, 5, 7],
+                [21, 41, 5, 4, 8, 6],
+                [51, 26, 6, 7, 9, 9],
+                [49, 49, 10, 7, 11, 11],
+                [67, 54, 8, 13, 12, 16],
+                [57, 95, 14, 11, 19, 16],
+                [106, 84, 18, 15, 22, 22],
+                [120, 120, 22, 18, 28, 28],
+                [135, 162, 23, 28, 30, 37],
+                [187, 187, 29, 35, 43, 43],
+                [234, 234, 40, 40, 54, 54],
+                [293, 293, 50, 50, 68, 68],
+                [367, 367, 62, 62, 84, 84],
+                [459, 459, 78, 78, 106, 106],
+                [250, 250, 46, 39, 61, 53],
+                [269, 231, 46, 39, 62, 53],
+                [222, 278, 38, 47, 51, 63]
+            ]
+        },
+        "emperExultant": {
+            "name": "Laviscus",
+            "FactionId": "EmperorsChildren",
+            "GrandAllianceId": "Chaos",
+            "BaseRarity": "Epic",
+            "powerMultiplier": 132,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 1,
+                    "DamageProfile": "Power"
+                }
+            ],
+            "stats": {
+                "Health": 90,
+                "Damage": 40,
+                "FixedArmor": 21,
+                "ProgressionIndex": 9
+            },
+            "traits": ["Hero", "ThrillSeekers", "CrushingStrike"],
+            "activeAbilities": ["EuphoricStrikes"],
+            "passiveAbilities": ["RefusalToBeOutdone"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Crit"],
+            "itemSlotsRelic": [2],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "timestampIfHeroUnlocked": 1767484800000,
+                "timestampIfHeroNotUnlocked": 1770508800000
+            },
+            "releaseStatus": "1767225600000",
+            "unlockQuestIds": ["hero_emperExultant_01"],
+            "upgrades": [
+                ["upgHpC015", "upgHpC010", "upgDmgC010", "upgDmgC014", "upgArmC003", "upgArmC007"],
+                ["upgHpC013", "upgHpC015", "upgDmgU010", "upgDmgU016C", "upgArmC007", "upgArmC006"],
+                ["upgHpU012", "upgHpU018C", "upgDmgC013", "upgDmgC003", "upgArmU005", "upgArmU007"],
+                ["upgHpU018C", "upgHpU012", "upgDmgU010", "upgDmgU014", "upgArmU007", "upgArmU010C"],
+                ["upgHpU012", "upgHpR015C", "upgDmgU018C", "upgDmgU019", "upgArmR015", "upgArmU013"],
+                ["upgHpR015C", "upgHpU009", "upgDmgR039", "upgDmgR012C", "upgArmU010C", "upgArmR010"],
+                ["upgHpR039", "upgHpR008", "upgDmgR13C", "upgDmgR002", "upgArmR003C", "upgArmR004C"],
+                ["upgHpE039C", "upgHpR013C", "upgDmgR003", "upgDmgE009C", "upgArmR039", "upgArmR013C"],
+                ["upgHpR005", "upgHpE007C", "upgDmgE039C", "upgDmgR016C", "upgArmE039C", "upgArmE009"],
+                ["upgHpE039C", "upgHpE003", "upgDmgE039C", "upgDmgE011", "upgArmE039C", "upgArmE004C"],
+                ["upgHpL119", "upgHpE008C", "upgDmgL039C", "upgDmgE009C", "upgArmE039C", "upgArmE005C"],
+                ["upgHpE039C", "upgHpL009C", "upgDmgE039C", "upgDmgL016C", "upgArmL203", "upgArmL004C"],
+                ["upgHpL039C", "upgHpL009C", "upgDmgL003", "upgDmgL009C", "upgArmL039C", "upgArmL005C"],
+                ["upgHpL139C", "upgHpL012C", "upgDmgL039C", "upgDmgL016C", "upgArmL039C", "upgArmL011C"],
+                ["upgHpL039C", "upgHpL009C", "upgDmgL139C", "upgDmgL008C", "upgArmL139C", "upgArmL005C"],
+                ["upgHpL139C", "upgHpL009C", "upgDmgL139C", "upgDmgL005C", "upgArmL139C", "upgArmL004C"],
+                ["upgHpL139C", "upgHpL213C", "upgDmgL139C", "upgDmgL213C", "upgArmL139C", "upgArmL213C"],
+                ["upgHpL139C", "upgHpL213C", "upgDmgM211C", "upgDmgL213C", "upgArmM213C", "upgArmL213C"],
+                ["upgHpM139C", "upgHpL213C", "upgDmgM211C", "upgDmgL213C", "upgArmM212C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 5, 5, 3, 3],
+                [14, 14, 5, 8, 3, 3],
+                [14, 21, 8, 8, 4, 4],
+                [26, 18, 10, 10, 4, 7],
+                [19, 37, 14, 10, 8, 5],
+                [47, 23, 13, 18, 8, 8],
+                [44, 44, 22, 17, 10, 10],
+                [60, 48, 18, 30, 11, 15],
+                [51, 86, 34, 27, 18, 14],
+                [96, 76, 43, 34, 20, 20],
+                [107, 107, 52, 43, 25, 25],
+                [122, 147, 54, 65, 29, 34],
+                [168, 168, 68, 82, 39, 39],
+                [211, 211, 94, 94, 49, 49],
+                [264, 264, 117, 117, 62, 62],
+                [330, 330, 147, 147, 77, 77],
+                [413, 413, 183, 183, 96, 96],
+                [225, 225, 108, 92, 57, 48],
+                [242, 208, 108, 92, 57, 48],
+                [200, 249, 89, 111, 47, 58]
+            ]
+        },
+        "emperLucius": {
+            "name": "Lucius",
+            "FactionId": "EmperorsChildren",
+            "GrandAllianceId": "Chaos",
+            "BaseRarity": "Legendary",
+            "powerMultiplier": 101,
+            "Movement": 4,
+            "weapons": [
+                {
+                    "hits": 6,
+                    "DamageProfile": "Power"
+                }
+            ],
+            "stats": {
+                "Health": 90,
+                "Damage": 13,
+                "FixedArmor": 20,
+                "ProgressionIndex": 12
+            },
+            "traits": ["Hero", "ThrillSeekers", "Parry"],
+            "activeAbilities": ["LashOfTorment"],
+            "passiveAbilities": ["ArmourOfShriekingSouls"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "timestampIfHeroUnlocked": 1785715200000,
+                "timestampIfHeroNotUnlocked": 1788652800000
+            },
+            "releaseStatus": "1754179200000",
+            "unlockQuestIds": ["hero_emperLucius_01"],
+            "eventMetadata": {
+                "leg": {
+                    "finalEventEndDate": 1785715200000
+                }
+            },
+            "upgrades": [
+                ["upgHpC015", "upgHpC010", "upgDmgC003", "upgDmgC014", "upgArmC013", "upgArmC006"],
+                ["upgHpC013", "upgHpC015", "upgDmgU014", "upgDmgU016C", "upgArmC007", "upgArmC007"],
+                ["upgHpU012", "upgHpU018C", "upgDmgC013", "upgDmgC003", "upgArmU009", "upgArmU007"],
+                ["upgHpU018C", "upgHpU012", "upgDmgU014", "upgDmgU014", "upgArmU007", "upgArmU003C"],
+                ["upgHpU012", "upgHpR015C", "upgDmgU018C", "upgDmgU019", "upgArmR015", "upgArmU007"],
+                ["upgHpR015C", "upgHpU009", "upgDmgR039", "upgDmgR012C", "upgArmU003C", "upgArmR015"],
+                ["upgHpR039", "upgHpR008", "upgDmgR13C", "upgDmgR005", "upgArmR004C", "upgArmR003C"],
+                ["upgHpE039C", "upgHpR013C", "upgDmgR003", "upgDmgE009C", "upgArmR039", "upgArmR004C"],
+                ["upgHpR019", "upgHpE007C", "upgDmgE039C", "upgDmgR016C", "upgArmE039C", "upgArmE013"],
+                ["upgHpE039C", "upgHpE017", "upgDmgE039C", "upgDmgE011", "upgArmE039C", "upgArmE004C"],
+                ["upgHpL119", "upgHpE008C", "upgDmgL039C", "upgDmgE009C", "upgArmE039C", "upgArmE005C"],
+                ["upgHpE039C", "upgHpL009C", "upgDmgE039C", "upgDmgL016C", "upgArmL203", "upgArmL004C"],
+                ["upgHpL039C", "upgHpL009C", "upgDmgL003", "upgDmgL009C", "upgArmL039C", "upgArmL005C"],
+                ["upgHpL139C", "upgHpL012C", "upgDmgL039C", "upgDmgL016C", "upgArmL039C", "upgArmL005C"],
+                ["upgHpL039C", "upgHpL009C", "upgDmgL139C", "upgDmgL008C", "upgArmL139C", "upgArmL005C"],
+                ["upgHpL139C", "upgHpL009C", "upgDmgL139C", "upgDmgL009C", "upgArmL139C", "upgArmL004C"],
+                ["upgHpL139C", "upgHpL213C", "upgDmgL139C", "upgDmgL213C", "upgArmL139C", "upgArmL213C"],
+                ["upgHpL139C", "upgHpL213C", "upgDmgM212C", "upgDmgL213C", "upgArmM212C", "upgArmL213C"],
+                ["upgHpM139C", "upgHpL213C", "upgDmgM212C", "upgDmgL213C", "upgArmM212C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 2, 2, 3, 3],
+                [14, 14, 1, 2, 3, 3],
+                [14, 21, 3, 3, 4, 4],
+                [26, 18, 3, 3, 4, 5],
+                [19, 37, 5, 3, 8, 5],
+                [47, 23, 4, 6, 8, 8],
+                [44, 44, 7, 6, 9, 9],
+                [60, 48, 6, 9, 11, 14],
+                [51, 86, 11, 9, 17, 13],
+                [96, 76, 14, 11, 19, 19],
+                [107, 107, 17, 14, 24, 24],
+                [122, 147, 18, 21, 27, 33],
+                [168, 168, 22, 26, 37, 37],
+                [211, 211, 31, 31, 47, 47],
+                [264, 264, 38, 38, 59, 59],
+                [330, 330, 48, 48, 73, 73],
+                [413, 413, 59, 59, 92, 92],
+                [225, 225, 35, 30, 54, 46],
+                [242, 208, 35, 30, 54, 46],
+                [200, 249, 29, 36, 44, 56]
+            ]
+        },
+        "votanBeserk": {
+            "name": "Havyr",
+            "FactionId": "LeaguesOfVotann",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Uncommon",
+            "powerMultiplier": 102,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 4,
+                    "DamageProfile": "Eviscerate"
+                }
+            ],
+            "stats": {
+                "Health": 90,
+                "Damage": 20,
+                "FixedArmor": 14,
+                "ProgressionIndex": 3
+            },
+            "traits": ["Hero", "PrioritisedEfficiency", "Resilient", "CrushingStrike"],
+            "activeAbilities": ["AugmentedAssault"],
+            "passiveAbilities": ["FuryFromTheDelve"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_votanBeserk_01"],
+            "upgrades": [
+                ["upgHpC015", "upgHpC008", "upgDmgC003", "upgDmgC015", "upgArmC005", "upgArmC006"],
+                ["upgHpC001", "upgHpC002", "upgDmgU014", "upgDmgU017C", "upgArmC006", "upgArmC012"],
+                ["upgHpU001", "upgHpU004C", "upgDmgC013", "upgDmgC003", "upgArmU006", "upgArmU013"],
+                ["upgHpU018C", "upgHpU012", "upgDmgU014", "upgDmgU014", "upgArmU013", "upgArmU004C"],
+                ["upgHpU001", "upgHpR015C", "upgDmgU018C", "upgDmgU004", "upgArmR010", "upgArmU002"],
+                ["upgHpR003C", "upgHpU007", "upgDmgR040", "upgDmgR012C", "upgArmU004C", "upgArmR006"],
+                ["upgHpR040", "upgHpR014", "upgDmgR13C", "upgDmgR003", "upgArmR002C", "upgArmR013C"],
+                ["upgHpE040C", "upgHpR004C", "upgDmgR006", "upgDmgE009C", "upgArmR040", "upgArmR008C"],
+                ["upgHpR019", "upgHpE001C", "upgDmgE040C", "upgDmgR017C", "upgArmE040C", "upgArmE010"],
+                ["upgHpE040C", "upgHpE015", "upgDmgE040C", "upgDmgE004", "upgArmE040C", "upgArmE003C"],
+                ["upgHpL099", "upgHpE014C", "upgDmgL040C", "upgDmgE009C", "upgArmE040C", "upgArmE011C"],
+                ["upgHpE040C", "upgHpL009C", "upgDmgE040C", "upgDmgL017C", "upgArmL203", "upgArmL003C"],
+                ["upgHpL040C", "upgHpL001C", "upgDmgL003", "upgDmgL009C", "upgArmL040C", "upgArmL011C"],
+                ["upgHpL140C", "upgHpL014C", "upgDmgL040C", "upgDmgL017C", "upgArmL040C", "upgArmL008C"],
+                ["upgHpL040C", "upgHpL009C", "upgDmgL140C", "upgDmgL008C", "upgArmL140C", "upgArmL011C"],
+                ["upgHpL140C", "upgHpL017C", "upgDmgL140C", "upgDmgL009C", "upgArmL140C", "upgArmL003C"],
+                ["upgHpL140C", "upgHpL213C", "upgDmgL140C", "upgDmgL213C", "upgArmL140C", "upgArmL213C"],
+                ["upgHpL140C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpM140C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM213C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 3, 3, 2, 2],
+                [14, 14, 2, 3, 2, 2],
+                [14, 21, 4, 4, 3, 3],
+                [26, 18, 5, 5, 2, 4],
+                [19, 37, 8, 5, 5, 4],
+                [47, 23, 6, 9, 6, 6],
+                [44, 44, 11, 8, 7, 7],
+                [60, 48, 9, 16, 7, 9],
+                [51, 86, 17, 13, 12, 9],
+                [96, 76, 21, 17, 13, 13],
+                [107, 107, 26, 22, 17, 17],
+                [122, 147, 27, 33, 19, 23],
+                [168, 168, 34, 40, 26, 26],
+                [211, 211, 47, 47, 33, 33],
+                [264, 264, 59, 59, 41, 41],
+                [330, 330, 73, 73, 51, 51],
+                [413, 413, 92, 92, 65, 65],
+                [225, 225, 54, 46, 37, 32],
+                [242, 208, 54, 46, 38, 32],
+                [200, 249, 44, 56, 31, 39]
+            ]
+        },
+        "votanIronmaster": {
+            "name": "Vynn",
+            "FactionId": "LeaguesOfVotann",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Rare",
+            "powerMultiplier": 126,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 3,
+                    "DamageProfile": "Power"
+                }
+            ],
+            "stats": {
+                "Health": 80,
+                "Damage": 25,
+                "FixedArmor": 16,
+                "ProgressionIndex": 6
+            },
+            "traits": ["Hero", "PrioritisedEfficiency", "Mechanic"],
+            "activeAbilities": ["GravitonRifle"],
+            "passiveAbilities": ["EcogSupport"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "1770249600000",
+            "unlockQuestIds": ["hero_votanIronmaster_01"],
+            "upgrades": [
+                ["upgHpC002", "upgHpC008", "upgDmgC010", "upgDmgC015", "upgArmC005", "upgArmC011"],
+                ["upgHpC014", "upgHpC015", "upgDmgU010", "upgDmgU017C", "upgArmC011", "upgArmC012"],
+                ["upgHpU014", "upgHpU018C", "upgDmgC007", "upgDmgC009", "upgArmU006", "upgArmU014"],
+                ["upgHpU004C", "upgHpU016", "upgDmgU010", "upgDmgU012", "upgArmU014", "upgArmU004C"],
+                ["upgHpU014", "upgHpR016C", "upgDmgU007C", "upgDmgU004", "upgArmR010", "upgArmU002"],
+                ["upgHpR012C", "upgHpU007", "upgDmgR040", "upgDmgR011C", "upgArmU004C", "upgArmR006"],
+                ["upgHpR040", "upgHpR014", "upgDmgR008C", "upgDmgR003", "upgArmR002C", "upgArmR014C"],
+                ["upgHpE040C", "upgHpR013C", "upgDmgR006", "upgDmgE008C", "upgArmR040", "upgArmR008C"],
+                ["upgHpR014", "upgHpE007C", "upgDmgE040C", "upgDmgR017C", "upgArmE040C", "upgArmE010"],
+                ["upgHpE040C", "upgHpE015", "upgDmgE040C", "upgDmgE004", "upgArmE040C", "upgArmE003C"],
+                ["upgHpL099", "upgHpE014C", "upgDmgL040C", "upgDmgE008C", "upgArmE040C", "upgArmE014C"],
+                ["upgHpE040C", "upgHpL011C", "upgDmgE040C", "upgDmgL017C", "upgArmL203", "upgArmL003C"],
+                ["upgHpL040C", "upgHpL009C", "upgDmgL204", "upgDmgL006C", "upgArmL040C", "upgArmL009C"],
+                ["upgHpL140C", "upgHpL014C", "upgDmgL040C", "upgDmgL017C", "upgArmL040C", "upgArmL008C"],
+                ["upgHpL040C", "upgHpL001C", "upgDmgL140C", "upgDmgL012C", "upgArmL140C", "upgArmL009C"],
+                ["upgHpL140C", "upgHpL017C", "upgDmgL140C", "upgDmgL005C", "upgArmL140C", "upgArmL003C"],
+                ["upgHpL140C", "upgHpL214C", "upgDmgL140C", "upgDmgL214C", "upgArmL140C", "upgArmL214C"],
+                ["upgHpL140C", "upgHpL214C", "upgDmgM214C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpM140C", "upgHpL214C", "upgDmgM214C", "upgDmgL214C", "upgArmM213C", "upgArmL214C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [10, 10, 3, 3, 2, 2],
+                [13, 13, 3, 5, 3, 3],
+                [12, 19, 5, 5, 3, 3],
+                [24, 16, 6, 6, 3, 4],
+                [16, 33, 10, 6, 6, 4],
+                [41, 21, 8, 11, 7, 7],
+                [39, 39, 14, 11, 7, 7],
+                [54, 43, 11, 19, 9, 11],
+                [46, 76, 21, 17, 13, 11],
+                [84, 68, 27, 21, 15, 15],
+                [96, 96, 32, 27, 20, 20],
+                [108, 130, 34, 41, 21, 25],
+                [150, 150, 42, 51, 30, 30],
+                [187, 187, 59, 59, 38, 38],
+                [234, 234, 73, 73, 47, 47],
+                [294, 294, 92, 92, 58, 58],
+                [367, 367, 115, 115, 74, 74],
+                [200, 200, 67, 57, 43, 36],
+                [215, 185, 67, 58, 43, 37],
+                [177, 222, 56, 69, 36, 44]
+            ]
+        },
+        "votanMemnyr": {
+            "name": "Ammuk",
+            "FactionId": "LeaguesOfVotann",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Rare",
+            "powerMultiplier": 171,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 1,
+                    "DamageProfile": "Physical"
+                }
+            ],
+            "stats": {
+                "Health": 90,
+                "Damage": 25,
+                "FixedArmor": 22,
+                "ProgressionIndex": 6
+            },
+            "traits": ["Hero", "PrioritisedEfficiency", "Mechanical"],
+            "activeAbilities": ["IronkinSteeljack"],
+            "passiveAbilities": ["PredictiveGuidance"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [2],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true
+            },
+            "releaseStatus": "released",
+            "unlockQuestIds": ["hero_votanMemnyr_01"],
+            "upgrades": [
+                ["upgHpC002", "upgHpC008", "upgDmgC010", "upgDmgC015", "upgArmC005", "upgArmC011"],
+                ["upgHpC014", "upgHpC015", "upgDmgU010", "upgDmgU017C", "upgArmC011", "upgArmC012"],
+                ["upgHpU014", "upgHpU018C", "upgDmgC007", "upgDmgC009", "upgArmU006", "upgArmU014"],
+                ["upgHpU004C", "upgHpU017", "upgDmgU010", "upgDmgU012", "upgArmU014", "upgArmU004C"],
+                ["upgHpU014", "upgHpR017C", "upgDmgU007C", "upgDmgU004", "upgArmR010", "upgArmU002"],
+                ["upgHpR012C", "upgHpU007", "upgDmgR040", "upgDmgR011C", "upgArmU004C", "upgArmR006"],
+                ["upgHpR040", "upgHpR014", "upgDmgR008C", "upgDmgR005", "upgArmR002C", "upgArmR014C"],
+                ["upgHpE040C", "upgHpR013C", "upgDmgR005", "upgDmgE008C", "upgArmR040", "upgArmR008C"],
+                ["upgHpR014", "upgHpE007C", "upgDmgE040C", "upgDmgR017C", "upgArmE040C", "upgArmE010"],
+                ["upgHpE040C", "upgHpE015", "upgDmgE040C", "upgDmgE004", "upgArmE040C", "upgArmE003C"],
+                ["upgHpL099", "upgHpE014C", "upgDmgL040C", "upgDmgE008C", "upgArmE040C", "upgArmE014C"],
+                ["upgHpE040C", "upgHpL017C", "upgDmgE040C", "upgDmgL017C", "upgArmL204", "upgArmL003C"],
+                ["upgHpL040C", "upgHpL009C", "upgDmgL204", "upgDmgL006C", "upgArmL040C", "upgArmL009C"],
+                ["upgHpL140C", "upgHpL014C", "upgDmgL040C", "upgDmgL017C", "upgArmL040C", "upgArmL008C"],
+                ["upgHpL040C", "upgHpL001C", "upgDmgL140C", "upgDmgL012C", "upgArmL140C", "upgArmL009C"],
+                ["upgHpL140C", "upgHpL013C", "upgDmgL140C", "upgDmgL005C", "upgArmL140C", "upgArmL003C"],
+                ["upgHpL140C", "upgHpL214C", "upgDmgL140C", "upgDmgL214C", "upgArmL140C", "upgArmL214C"],
+                ["upgHpL140C", "upgHpL214C", "upgDmgM214C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpM140C", "upgHpL214C", "upgDmgM214C", "upgDmgL214C", "upgArmM213C", "upgArmL214C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 3, 3, 3, 3],
+                [14, 14, 3, 5, 3, 3],
+                [14, 21, 5, 5, 5, 5],
+                [26, 18, 6, 6, 4, 6],
+                [19, 37, 10, 6, 8, 6],
+                [47, 23, 8, 11, 9, 9],
+                [44, 44, 14, 11, 10, 10],
+                [60, 48, 11, 19, 12, 15],
+                [51, 86, 21, 17, 18, 15],
+                [96, 76, 27, 21, 21, 21],
+                [107, 107, 32, 27, 27, 27],
+                [122, 147, 34, 41, 29, 35],
+                [168, 168, 42, 51, 42, 42],
+                [211, 211, 59, 59, 51, 51],
+                [264, 264, 73, 73, 64, 64],
+                [330, 330, 92, 92, 81, 81],
+                [413, 413, 115, 115, 101, 101],
+                [225, 225, 67, 57, 59, 51],
+                [242, 208, 67, 58, 59, 51],
+                [200, 249, 56, 69, 49, 61]
+            ]
+        },
+        "votanChampion": {
+            "name": "Kimm",
+            "FactionId": "LeaguesOfVotann",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Epic",
+            "powerMultiplier": 94,
+            "Movement": 2,
+            "weapons": [
+                {
+                    "hits": 2,
+                    "DamageProfile": "Eviscerate"
+                },
+                {
+                    "hits": 2,
+                    "DamageProfile": "Bolter",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 100,
+                "Damage": 32,
+                "FixedArmor": 28,
+                "ProgressionIndex": 9
+            },
+            "traits": ["Hero", "PrioritisedEfficiency", "RapidAssault", "Unstoppable"],
+            "activeAbilities": ["MassDriverAccelerator"],
+            "passiveAbilities": ["ModifiedExoarmour"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Block"],
+            "itemSlotsRelic": [1],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": false,
+                "canDropIfHeroNotUnlocked": false
+            },
+            "releaseStatus": "1788652800000",
+            "unlockQuestIds": ["hero_votanChampion_01"],
+            "upgrades": [
+                ["upgHpC015", "upgHpC002", "upgDmgC009", "upgDmgC015", "upgArmC005", "upgArmC012"],
+                ["upgHpC014", "upgHpC002", "upgDmgU012", "upgDmgU017C", "upgArmC012", "upgArmC013"],
+                ["upgHpU014", "upgHpU004C", "upgDmgC013", "upgDmgC010", "upgArmU006", "upgArmU002"],
+                ["upgHpU018C", "upgHpU017", "upgDmgU012", "upgDmgU010", "upgArmU002", "upgArmU004C"],
+                ["upgHpU014", "upgHpR017C", "upgDmgU018C", "upgDmgU004", "upgArmR006", "upgArmU009"],
+                ["upgHpR012C", "upgHpU007", "upgDmgR040", "upgDmgR010C", "upgArmU004C", "upgArmR005"],
+                ["upgHpR040", "upgHpR014", "upgDmgR13C", "upgDmgR002", "upgArmR002C", "upgArmR008C"],
+                ["upgHpE040C", "upgHpR004C", "upgDmgR003", "upgDmgE006C", "upgArmR040", "upgArmR012C"],
+                ["upgHpR019", "upgHpE001C", "upgDmgE040C", "upgDmgR017C", "upgArmE040C", "upgArmE010"],
+                ["upgHpE040C", "upgHpE015", "upgDmgE040C", "upgDmgE011", "upgArmE040C", "upgArmE003C"],
+                ["upgHpL099", "upgHpE014C", "upgDmgL040C", "upgDmgE006C", "upgArmE040C", "upgArmE012C"],
+                ["upgHpE040C", "upgHpL017C", "upgDmgE040C", "upgDmgL017C", "upgArmL203", "upgArmL003C"],
+                ["upgHpL040C", "upgHpL001C", "upgDmgL204", "upgDmgL005C", "upgArmL040C", "upgArmL008C"],
+                ["upgHpL140C", "upgHpL014C", "upgDmgL040C", "upgDmgL017C", "upgArmL040C", "upgArmL006C"],
+                ["upgHpL040C", "upgHpL009C", "upgDmgL140C", "upgDmgL008C", "upgArmL140C", "upgArmL008C"],
+                ["upgHpL140C", "upgHpL013C", "upgDmgL140C", "upgDmgL006C", "upgArmL140C", "upgArmL003C"],
+                ["upgHpL140C", "upgHpL214C", "upgDmgL140C", "upgDmgL214C", "upgArmL140C", "upgArmL214C"],
+                ["upgHpL140C", "upgHpL214C", "upgDmgM213C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpM140C", "upgHpL214C", "upgDmgM213C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [13, 13, 4, 4, 4, 4],
+                [16, 16, 4, 6, 4, 4],
+                [15, 23, 7, 7, 6, 6],
+                [30, 20, 8, 8, 5, 8],
+                [21, 41, 11, 7, 10, 7],
+                [51, 26, 11, 14, 11, 11],
+                [49, 49, 18, 13, 14, 14],
+                [67, 54, 15, 24, 14, 19],
+                [57, 95, 27, 22, 24, 19],
+                [106, 84, 34, 27, 27, 27],
+                [120, 120, 41, 35, 33, 33],
+                [135, 162, 44, 52, 38, 45],
+                [187, 187, 54, 65, 53, 53],
+                [234, 234, 75, 75, 65, 65],
+                [293, 293, 94, 94, 82, 82],
+                [367, 367, 117, 117, 103, 103],
+                [459, 459, 147, 147, 129, 129],
+                [250, 250, 86, 74, 75, 64],
+                [269, 231, 86, 74, 75, 65],
+                [222, 278, 71, 89, 62, 78]
+            ]
+        },
+        "votanUthar": {
+            "name": "Uthar",
+            "FactionId": "LeaguesOfVotann",
+            "GrandAllianceId": "Xenos",
+            "BaseRarity": "Legendary",
+            "powerMultiplier": 70,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 3,
+                    "DamageProfile": "Plasma"
+                },
+                {
+                    "hits": 4,
+                    "DamageProfile": "Energy",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 90,
+                "Damage": 19,
+                "FixedArmor": 23,
+                "ProgressionIndex": 12
+            },
+            "traits": ["Hero", "PrioritisedEfficiency", "Resilient"],
+            "activeAbilities": ["AncestralFortune"],
+            "passiveAbilities": ["GrimEfficiency"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": false,
+                "canDropIfHeroNotUnlocked": false
+            },
+            "releaseStatus": "1770249600000",
+            "unlockQuestIds": ["hero_votanUthar_01"],
+            "upgrades": [
+                ["upgHpC015", "upgHpC008", "upgDmgC012", "upgDmgC015", "upgArmC005", "upgArmC006"],
+                ["upgHpC016", "upgHpC002", "upgDmgU009", "upgDmgU017C", "upgArmC006", "upgArmC013"],
+                ["upgHpU016", "upgHpU004C", "upgDmgC013", "upgDmgC010", "upgArmU006", "upgArmU013"],
+                ["upgHpU018C", "upgHpU017", "upgDmgU009", "upgDmgU010", "upgArmU013", "upgArmU004C"],
+                ["upgHpU016", "upgHpR017C", "upgDmgU018C", "upgDmgU004", "upgArmR010", "upgArmU009"],
+                ["upgHpR016C", "upgHpU007", "upgDmgR040", "upgDmgR010C", "upgArmU004C", "upgArmR005"],
+                ["upgHpR040", "upgHpR014", "upgDmgR13C", "upgDmgR002", "upgArmR002C", "upgArmR013C"],
+                ["upgHpE040C", "upgHpR004C", "upgDmgR005", "upgDmgE006C", "upgArmR040", "upgArmR012C"],
+                ["upgHpR019", "upgHpE001C", "upgDmgE040C", "upgDmgR017C", "upgArmE040C", "upgArmE010"],
+                ["upgHpE040C", "upgHpE015", "upgDmgE040C", "upgDmgE011", "upgArmE040C", "upgArmE003C"],
+                ["upgHpL099", "upgHpE014C", "upgDmgL040C", "upgDmgE006C", "upgArmE040C", "upgArmE011C"],
+                ["upgHpE040C", "upgHpL017C", "upgDmgE040C", "upgDmgL017C", "upgArmL204", "upgArmL003C"],
+                ["upgHpL040C", "upgHpL001C", "upgDmgL003", "upgDmgL005C", "upgArmL040C", "upgArmL011C"],
+                ["upgHpL140C", "upgHpL014C", "upgDmgL040C", "upgDmgL017C", "upgArmL040C", "upgArmL006C"],
+                ["upgHpL040C", "upgHpL009C", "upgDmgL140C", "upgDmgL008C", "upgArmL140C", "upgArmL011C"],
+                ["upgHpL140C", "upgHpL011C", "upgDmgL140C", "upgDmgL012C", "upgArmL140C", "upgArmL003C"],
+                ["upgHpL140C", "upgHpL214C", "upgDmgL140C", "upgDmgL214C", "upgArmL140C", "upgArmL214C"],
+                ["upgHpL140C", "upgHpL214C", "upgDmgM213C", "upgDmgL214C", "upgArmM214C", "upgArmL214C"],
+                ["upgHpM140C", "upgHpL214C", "upgDmgM213C", "upgDmgL214C", "upgArmM213C", "upgArmL214C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 3, 3, 3, 3],
+                [14, 14, 2, 3, 4, 4],
+                [14, 21, 4, 4, 4, 4],
+                [26, 18, 5, 5, 5, 7],
+                [19, 37, 6, 4, 8, 6],
+                [47, 23, 6, 9, 9, 9],
+                [44, 44, 11, 8, 11, 11],
+                [60, 48, 9, 14, 12, 16],
+                [51, 86, 16, 13, 19, 16],
+                [96, 76, 20, 16, 22, 22],
+                [107, 107, 25, 20, 28, 28],
+                [122, 147, 26, 31, 30, 37],
+                [168, 168, 32, 39, 43, 43],
+                [211, 211, 45, 45, 54, 54],
+                [264, 264, 55, 55, 68, 68],
+                [330, 330, 70, 70, 84, 84],
+                [413, 413, 87, 87, 106, 106],
+                [225, 225, 51, 44, 61, 53],
+                [242, 208, 51, 44, 62, 53],
+                [200, 249, 42, 53, 51, 63]
+            ]
+        },
+        "astarCyrus": {
+            "name": "Cyrus",
+            "FactionId": "AdeptusAstartes",
+            "Subfaction": "BloodRavens",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Epic",
+            "powerMultiplier": 87,
+            "Movement": 3,
+            "weapons": [
+                {
+                    "hits": 3,
+                    "DamageProfile": "Bolter"
+                },
+                {
+                    "hits": 3,
+                    "DamageProfile": "Bolter",
+                    "Range": 3
+                }
+            ],
+            "stats": {
+                "Health": 80,
+                "Damage": 28,
+                "FixedArmor": 20,
+                "ProgressionIndex": 9
+            },
+            "traits": ["Hero", "Camouflage", "Infiltrate", "SuppressiveFire"],
+            "activeAbilities": ["StrikeFromTheShadows"],
+            "passiveAbilities": ["HaywireMine"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Crit"],
+            "itemSlotsRelic": [0],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "timestampIfHeroUnlocked": 1779580800000,
+                "timestampIfHeroNotUnlocked": 1782604800000
+            },
+            "releaseStatus": "1779379200000",
+            "unlockQuestIds": ["hero_astarCyrus_01"],
+            "upgrades": [
+                ["upgHpC015", "upgHpC004", "upgDmgC009", "upgDmgC011", "upgArmC002", "upgArmC006"],
+                ["upgHpC003", "upgHpC002", "upgDmgU012", "upgDmgU015C", "upgArmC006", "upgArmC001"],
+                ["upgHpU002", "upgHpU004C", "upgDmgC001", "upgDmgC004", "upgArmU005", "upgArmU013"],
+                ["upgHpU018C", "upgHpU017", "upgDmgU012", "upgDmgU003", "upgArmU013", "upgArmU010C"],
+                ["upgHpU002", "upgHpR017C", "upgDmgU001C", "upgDmgU011", "upgArmR010", "upgArmU001"],
+                ["upgHpR020C", "upgHpU006", "upgDmgR007", "upgDmgR012C", "upgArmU010C", "upgArmR015"],
+                ["upgHpR043", "upgHpR005", "upgDmgR001C", "upgDmgR005", "upgArmR003C", "upgArmR013C"],
+                ["upgHpE020C", "upgHpR004C", "upgDmgR002", "upgDmgE002C", "upgDmgR005", "upgArmR001C"],
+                ["upgHpR019", "upgHpE001C", "upgDmgE020C", "upgDmgR015C", "upgArmE020C", "upgArmE013"],
+                ["upgHpE020C", "upgHpE017", "upgDmgE020C", "upgDmgE001", "upgArmE020C", "upgArmE004C"],
+                ["upgHpL100", "upgHpE002C", "upgDmgL004C", "upgDmgE002C", "upgArmE020C", "upgArmE011C"],
+                ["upgHpE020C", "upgHpL017C", "upgDmgE020C", "upgDmgL015C", "upgArmL001", "upgArmL004C"],
+                ["upgHpL020C", "upgHpL001C", "upgDmgL001", "upgDmgL002C", "upgArmL020C", "upgArmL011C"],
+                ["upgHpL120C", "upgHpL002C", "upgDmgL004C", "upgDmgL015C", "upgArmL020C", "upgArmL010C"],
+                ["upgHpL020C", "upgHpL009C", "upgDmgL120C", "upgDmgL007C", "upgArmL120C", "upgArmL011C"],
+                ["upgHpL120C", "upgHpL002C", "upgDmgL120C", "upgDmgL006C", "upgArmL120C", "upgArmL004C"],
+                ["upgHpL120C", "upgHpL213C", "upgDmgL120C", "upgDmgL213C", "upgArmL120C", "upgArmL213C"],
+                ["upgHpL120C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM211C", "upgArmL213C"],
+                ["upgHpM143C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM213C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [10, 10, 4, 4, 3, 3],
+                [13, 13, 3, 5, 3, 3],
+                [12, 19, 6, 6, 4, 4],
+                [24, 16, 7, 7, 4, 5],
+                [16, 33, 10, 6, 8, 5],
+                [41, 21, 9, 13, 8, 8],
+                [39, 39, 15, 12, 9, 9],
+                [54, 43, 9, 15, 9, 25],
+                [46, 76, 24, 20, 17, 13],
+                [84, 68, 29, 24, 19, 19],
+                [96, 96, 37, 30, 24, 24],
+                [108, 130, 38, 45, 27, 33],
+                [150, 150, 48, 57, 37, 37],
+                [187, 187, 66, 66, 47, 47],
+                [234, 234, 82, 82, 59, 59],
+                [294, 294, 103, 103, 73, 73],
+                [367, 367, 128, 128, 92, 92],
+                [200, 200, 75, 65, 54, 46],
+                [215, 185, 75, 65, 54, 46],
+                [177, 222, 62, 78, 44, 56]
+            ]
+        },
+        "astarLysander": {
+            "name": "Lysander",
+            "FactionId": "AdeptusAstartes",
+            "Subfaction": "ImperialFists",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Legendary",
+            "powerMultiplier": 108,
+            "Movement": 2,
+            "weapons": [
+                {
+                    "hits": 1,
+                    "DamageProfile": "Power"
+                }
+            ],
+            "stats": {
+                "Health": 110,
+                "Damage": 50,
+                "FixedArmor": 28,
+                "ProgressionIndex": 12
+            },
+            "traits": ["Hero", "TeleportStrike", "TerminatorArmour", "Resilient", "CrushingStrike"],
+            "activeAbilities": ["TitanhammerSquad"],
+            "passiveAbilities": ["IconOfObstinacy"],
+            "itemSlots": ["I_Crit", "I_Block", "I_Booster_Block"],
+            "itemSlotsRelic": [2],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": false,
+                "canDropIfHeroNotUnlocked": false
+            },
+            "releaseStatus": "1787616000000",
+            "unlockQuestIds": ["hero_astarLysander_01"],
+            "upgrades": [
+                ["upgHpC015", "upgHpC004", "upgDmgC009", "upgDmgC011", "upgArmC002", "upgArmC006"],
+                ["upgHpC003", "upgHpC002", "upgDmgU012", "upgDmgU015C", "upgArmC006", "upgArmC001"],
+                ["upgHpU002", "upgHpU004C", "upgDmgC013", "upgDmgC010", "upgArmU005", "upgArmU013"],
+                ["upgHpU018C", "upgHpU014", "upgDmgU012", "upgDmgU010", "upgArmU013", "upgArmU010C"],
+                ["upgHpU002", "upgHpR012C", "upgDmgU018C", "upgDmgU011", "upgArmR010", "upgArmU001"],
+                ["upgHpR020C", "upgHpU006", "upgDmgR021", "upgDmgR010C", "upgArmU010C", "upgArmR015"],
+                ["upgHpR043", "upgHpR005", "upgDmgR13C", "upgDmgR005", "upgArmR003C", "upgArmR013C"],
+                ["upgHpE020C", "upgHpR004C", "upgDmgR006", "upgDmgE006C", "upgArmR005", "upgArmR001C"],
+                ["upgHpR019", "upgHpE001C", "upgDmgE021C", "upgDmgR015C", "upgArmE020C", "upgArmE013"],
+                ["upgHpE020C", "upgHpE003", "upgDmgE021C", "upgDmgE011", "upgArmE020C", "upgArmE004C"],
+                ["upgHpL100", "upgHpE002C", "upgDmgL021C", "upgDmgE006C", "upgArmE020C", "upgArmE011C"],
+                ["upgHpE020C", "upgHpL013C", "upgDmgE021C", "upgDmgL015C", "upgArmL001", "upgArmL004C"],
+                ["upgHpL020C", "upgHpL001C", "upgDmgL003", "upgDmgL005C", "upgArmL020C", "upgArmL011C"],
+                ["upgHpL120C", "upgHpL002C", "upgDmgL021C", "upgDmgL015C", "upgArmL020C", "upgArmL010C"],
+                ["upgHpL020C", "upgHpL009C", "upgDmgL121C", "upgDmgL008C", "upgArmL120C", "upgArmL011C"],
+                ["upgHpL120C", "upgHpL002C", "upgDmgL121C", "upgDmgL006C", "upgArmL120C", "upgArmL004C"],
+                ["upgHpL120C", "upgHpL213C", "upgDmgL121C", "upgDmgL213C", "upgArmL120C", "upgArmL213C"],
+                ["upgHpL120C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM211C", "upgArmL213C"],
+                ["upgHpM143C", "upgHpL213C", "upgDmgM213C", "upgDmgL213C", "upgArmM213C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [14, 14, 7, 7, 4, 4],
+                [17, 17, 6, 8, 4, 4],
+                [18, 26, 10, 10, 6, 6],
+                [32, 22, 13, 13, 5, 8],
+                [23, 45, 18, 12, 10, 7],
+                [57, 29, 17, 22, 11, 11],
+                [53, 53, 27, 21, 14, 14],
+                [74, 60, 23, 38, 14, 19],
+                [63, 104, 42, 34, 24, 19],
+                [117, 93, 53, 42, 27, 27],
+                [131, 131, 65, 54, 33, 33],
+                [150, 179, 68, 82, 38, 45],
+                [206, 206, 85, 102, 53, 53],
+                [257, 257, 117, 117, 65, 65],
+                [322, 322, 147, 147, 82, 82],
+                [404, 404, 183, 183, 103, 103],
+                [505, 505, 230, 230, 129, 129],
+                [275, 275, 134, 115, 75, 64],
+                [296, 254, 135, 115, 75, 65],
+                [244, 305, 111, 138, 62, 78]
+            ]
+        },
+        "astarEradicator": {
+            "name": "Nubari",
+            "FactionId": "AdeptusAstartes",
+            "Subfaction": "Salamanders",
+            "GrandAllianceId": "Imperial",
+            "BaseRarity": "Uncommon",
+            "powerMultiplier": 87,
+            "Movement": 2,
+            "weapons": [
+                {
+                    "hits": 2,
+                    "DamageProfile": "Melta"
+                },
+                {
+                    "hits": 2,
+                    "DamageProfile": "Melta",
+                    "Range": 2
+                }
+            ],
+            "stats": {
+                "Health": 90,
+                "Damage": 24,
+                "FixedArmor": 18,
+                "ProgressionIndex": 3
+            },
+            "traits": ["Hero", "MkXGravis", "HeavyWeapon"],
+            "activeAbilities": ["TotalObliteration"],
+            "passiveAbilities": ["CrucibleOfBattle"],
+            "itemSlots": ["I_Crit", "I_Defensive", "I_Booster_Crit"],
+            "itemSlotsRelic": [1],
+            "eligibilityRequirements": {
+                "canDropIfHeroUnlocked": true,
+                "canDropIfHeroNotUnlocked": true,
+                "timestampIfHeroUnlocked": 1790553600000,
+                "timestampIfHeroNotUnlocked": 1792540800000
+            },
+            "releaseStatus": "1788998400000",
+            "unlockQuestIds": ["hero_astarEradicator_01"],
+            "upgrades": [
+                ["upgHpC015", "upgHpC004", "upgDmgC009", "upgDmgC011", "upgArmC002", "upgArmC012"],
+                ["upgHpC017", "upgHpC015", "upgDmgU012", "upgDmgU015C", "upgArmC012", "upgArmC001"],
+                ["upgHpU017", "upgHpU018C", "upgDmgC007", "upgDmgC004", "upgArmU005", "upgArmU002"],
+                ["upgHpU018C", "upgHpU001", "upgDmgU012", "upgDmgU003", "upgArmU002", "upgArmU010C"],
+                ["upgHpU017", "upgHpR003C", "upgDmgU007C", "upgDmgU011", "upgArmR031", "upgArmU001"],
+                ["upgHpR017C", "upgHpU006", "upgDmgR007", "upgDmgR012C", "upgArmU010C", "upgArmR015"],
+                ["upgHpR021", "upgHpR005", "upgDmgR008C", "upgDmgR003", "upgArmR003C", "upgArmR008C"],
+                ["upgHpE021C", "upgHpR013C", "upgDmgR003", "upgDmgE002C", "upgArmR035", "upgArmR001C"],
+                ["upgHpR005", "upgHpE007C", "upgDmgE020C", "upgDmgR015C", "upgArmE035C", "upgArmE013"],
+                ["upgHpE021C", "upgHpE012", "upgDmgE020C", "upgDmgE003", "upgArmE035C", "upgArmE004C"],
+                ["upgHpL100", "upgHpE002C", "upgDmgL004C", "upgDmgE002C", "upgArmE035C", "upgArmE012C"],
+                ["upgHpE021C", "upgHpL017C", "upgDmgE020C", "upgDmgL015C", "upgArmL001", "upgArmL004C"],
+                ["upgHpL021C", "upgHpL009C", "upgDmgL204", "upgDmgL002C", "upgArmL020C", "upgArmL008C"],
+                ["upgHpL120C", "upgHpL002C", "upgDmgL004C", "upgDmgL015C", "upgArmL020C", "upgArmL010C"],
+                ["upgHpL021C", "upgHpL009C", "upgDmgL120C", "upgDmgL012C", "upgArmL120C", "upgArmL008C"],
+                ["upgHpL120C", "upgHpL017C", "upgDmgL120C", "upgDmgL006C", "upgArmL120C", "upgArmL004C"],
+                ["upgHpL120C", "upgHpL213C", "upgDmgL120C", "upgDmgL213C", "upgArmL120C", "upgArmL213C"],
+                ["upgHpL120C", "upgHpL213C", "upgDmgM214C", "upgDmgL213C", "upgArmM211C", "upgArmL213C"],
+                ["upgHpM143C", "upgHpL213C", "upgDmgM214C", "upgDmgL213C", "upgArmM214C", "upgArmL213C"],
+                ["upgHpECS", "upgHpCS", "upgDmgECS", "upgDmgCS", "upgArmECS", "upgArmCS"]
+            ],
+            "upgradesStatIncrease": [
+                [12, 12, 3, 3, 3, 3],
+                [14, 14, 3, 5, 2, 2],
+                [14, 21, 5, 5, 4, 4],
+                [26, 18, 6, 6, 3, 5],
+                [19, 37, 8, 6, 7, 4],
+                [47, 23, 8, 10, 7, 7],
+                [44, 44, 14, 10, 9, 9],
+                [60, 48, 11, 18, 9, 13],
+                [51, 86, 20, 16, 15, 12],
+                [96, 76, 26, 20, 17, 17],
+                [107, 107, 31, 26, 22, 22],
+                [122, 147, 33, 39, 24, 29],
+                [168, 168, 41, 49, 34, 34],
+                [211, 211, 56, 56, 42, 42],
+                [264, 264, 71, 71, 53, 53],
+                [330, 330, 88, 88, 66, 66],
+                [413, 413, 110, 110, 82, 82],
+                [225, 225, 64, 55, 48, 42],
+                [242, 208, 65, 55, 48, 42],
+                [200, 249, 53, 67, 40, 50]
+            ]
+        }
+    },
+    "heroProgressionSteps": [
+        {
+            "stars": 0,
+            "rarity": "Common",
+            "maxXpLevel": 8,
+            "maxRank": 3,
+            "unitStatMultiplierPct": 100,
+            "abilityStatMultiplierPct": 100,
+            "abilityPowerMultiplier": 2,
+            "costs": {
+                "shards": 40
+            },
+            "ascensionCosts": {
+                "hreShards": 25
+            }
+        },
+        {
+            "stars": 1,
+            "rarity": "Common",
+            "maxXpLevel": 8,
+            "maxRank": 3,
+            "unitStatMultiplierPct": 110,
+            "abilityStatMultiplierPct": 100,
+            "abilityPowerMultiplier": 2,
+            "costs": {
+                "shards": 10
+            },
+            "ascensionCosts": {
+                "hreShards": 25
+            }
+        },
+        {
+            "stars": 2,
+            "rarity": "Common",
+            "maxXpLevel": 8,
+            "maxRank": 3,
+            "unitStatMultiplierPct": 120,
+            "abilityStatMultiplierPct": 100,
+            "abilityPowerMultiplier": 2,
+            "costs": {
+                "shards": 15
+            },
+            "ascensionCosts": {
+                "hreShards": 25
+            }
+        },
+        {
+            "stars": 2,
+            "rarity": "Uncommon",
+            "maxXpLevel": 17,
+            "maxRank": 6,
+            "unitStatMultiplierPct": 120,
+            "abilityStatMultiplierPct": 120,
+            "abilityPowerMultiplier": 3,
+            "costs": {
+                "shards": 15,
+                "heroAscensionOrbUncommon": 10
+            },
+            "ascensionCosts": {
+                "hreShards": 25
+            }
+        },
+        {
+            "stars": 3,
+            "rarity": "Uncommon",
+            "maxXpLevel": 17,
+            "maxRank": 6,
+            "unitStatMultiplierPct": 130,
+            "abilityStatMultiplierPct": 120,
+            "abilityPowerMultiplier": 3,
+            "costs": {
+                "shards": 15
+            },
+            "ascensionCosts": {
+                "hreShards": 50
+            }
+        },
+        {
+            "stars": 4,
+            "rarity": "Uncommon",
+            "maxXpLevel": 17,
+            "maxRank": 6,
+            "unitStatMultiplierPct": 140,
+            "abilityStatMultiplierPct": 120,
+            "abilityPowerMultiplier": 3,
+            "costs": {
+                "shards": 15
+            },
+            "ascensionCosts": {
+                "hreShards": 60
+            }
+        },
+        {
+            "stars": 4,
+            "rarity": "Rare",
+            "maxXpLevel": 26,
+            "maxRank": 9,
+            "unitStatMultiplierPct": 140,
+            "abilityStatMultiplierPct": 140,
+            "abilityPowerMultiplier": 4,
+            "costs": {
+                "shards": 20,
+                "heroAscensionOrbRare": 10
+            },
+            "ascensionCosts": {
+                "hreShards": 70
+            }
+        },
+        {
+            "stars": 5,
+            "rarity": "Rare",
+            "maxXpLevel": 26,
+            "maxRank": 9,
+            "unitStatMultiplierPct": 150,
+            "abilityStatMultiplierPct": 140,
+            "abilityPowerMultiplier": 4,
+            "costs": {
+                "shards": 30
+            },
+            "ascensionCosts": {
+                "hreShards": 50
+            }
+        },
+        {
+            "stars": 6,
+            "rarity": "Rare",
+            "maxXpLevel": 26,
+            "maxRank": 9,
+            "unitStatMultiplierPct": 160,
+            "abilityStatMultiplierPct": 140,
+            "abilityPowerMultiplier": 4,
+            "costs": {
+                "shards": 40
+            },
+            "ascensionCosts": {
+                "hreShards": 60
+            }
+        },
+        {
+            "stars": 6,
+            "rarity": "Epic",
+            "maxXpLevel": 35,
+            "maxRank": 12,
+            "unitStatMultiplierPct": 160,
+            "abilityStatMultiplierPct": 160,
+            "abilityPowerMultiplier": 5,
+            "costs": {
+                "shards": 50,
+                "heroAscensionOrbEpic": 10
+            },
+            "ascensionCosts": {
+                "hreShards": 70
+            }
+        },
+        {
+            "stars": 7,
+            "rarity": "Epic",
+            "maxXpLevel": 35,
+            "maxRank": 12,
+            "unitStatMultiplierPct": 170,
+            "abilityStatMultiplierPct": 160,
+            "abilityPowerMultiplier": 5,
+            "costs": {
+                "shards": 65
+            },
+            "ascensionCosts": {
+                "hreShards": 50
+            }
+        },
+        {
+            "stars": 8,
+            "rarity": "Epic",
+            "maxXpLevel": 35,
+            "maxRank": 12,
+            "unitStatMultiplierPct": 180,
+            "abilityStatMultiplierPct": 160,
+            "abilityPowerMultiplier": 5,
+            "costs": {
+                "shards": 85
+            },
+            "ascensionCosts": {
+                "hreShards": 60
+            }
+        },
+        {
+            "stars": 8,
+            "rarity": "Legendary",
+            "maxXpLevel": 50,
+            "maxRank": 17,
+            "unitStatMultiplierPct": 180,
+            "abilityStatMultiplierPct": 180,
+            "abilityPowerMultiplier": 7,
+            "costs": {
+                "shards": 100,
+                "heroAscensionOrbLegendary": 10
+            },
+            "ascensionCosts": {
+                "hreShards": 100
+            }
+        },
+        {
+            "stars": 9,
+            "rarity": "Legendary",
+            "maxXpLevel": 50,
+            "maxRank": 17,
+            "unitStatMultiplierPct": 190,
+            "abilityStatMultiplierPct": 180,
+            "abilityPowerMultiplier": 7,
+            "costs": {
+                "shards": 150,
+                "heroAscensionOrbLegendary": 10
+            },
+            "ascensionCosts": {
+                "hreShards": 100
+            }
+        },
+        {
+            "stars": 10,
+            "rarity": "Legendary",
+            "maxXpLevel": 50,
+            "maxRank": 17,
+            "unitStatMultiplierPct": 200,
+            "abilityStatMultiplierPct": 180,
+            "abilityPowerMultiplier": 7,
+            "costs": {
+                "shards": 250,
+                "heroAscensionOrbLegendary": 15
+            },
+            "ascensionCosts": {
+                "hreShards": 200
+            }
+        },
+        {
+            "stars": 11,
+            "rarity": "Legendary",
+            "maxXpLevel": 50,
+            "maxRank": 17,
+            "unitStatMultiplierPct": 210,
+            "abilityStatMultiplierPct": 180,
+            "abilityPowerMultiplier": 7,
+            "costs": {
+                "shards": 500,
+                "heroAscensionOrbLegendary": 20
+            },
+            "ascensionCosts": {
+                "hreShards": 400
+            }
+        },
+        {
+            "stars": 11,
+            "rarity": "Mythic",
+            "maxXpLevel": 60,
+            "maxRank": 20,
+            "unitStatMultiplierPct": 210,
+            "abilityStatMultiplierPct": 200,
+            "abilityPowerMultiplier": 9,
+            "costs": {
+                "mythicShards": 20,
+                "heroAscensionOrbMythic": 10
+            }
+        },
+        {
+            "stars": 12,
+            "rarity": "Mythic",
+            "maxXpLevel": 60,
+            "maxRank": 20,
+            "unitStatMultiplierPct": 220,
+            "abilityStatMultiplierPct": 200,
+            "abilityPowerMultiplier": 9,
+            "costs": {
+                "mythicShards": 30,
+                "heroAscensionOrbMythic": 10
+            }
+        },
+        {
+            "stars": 13,
+            "rarity": "Mythic",
+            "maxXpLevel": 60,
+            "maxRank": 20,
+            "unitStatMultiplierPct": 230,
+            "abilityStatMultiplierPct": 200,
+            "abilityPowerMultiplier": 9,
+            "costs": {
+                "mythicShards": 50,
+                "heroAscensionOrbMythic": 15
+            }
+        },
+        {
+            "stars": 14,
+            "rarity": "Mythic",
+            "maxXpLevel": 60,
+            "maxRank": 20,
+            "unitStatMultiplierPct": 240,
+            "abilityStatMultiplierPct": 200,
+            "abilityPowerMultiplier": 9,
+            "costs": {
+                "mythicShards": 100,
+                "heroAscensionOrbMythic": 25
+            }
+        }
+    ],
+    "heroProgressionStepsPerUnit": {
+        "default": [
+            {
+                "stars": 0,
+                "rarity": "Common",
+                "maxXpLevel": 8,
+                "maxRank": 3,
+                "unitStatMultiplierPct": 100,
+                "abilityStatMultiplierPct": 100,
+                "abilityPowerMultiplier": 2,
+                "costs": {
+                    "shards": 40
+                },
+                "ascensionCosts": {
+                    "hreShards": 25
+                }
+            },
+            {
+                "stars": 1,
+                "rarity": "Common",
+                "maxXpLevel": 8,
+                "maxRank": 3,
+                "unitStatMultiplierPct": 110,
+                "abilityStatMultiplierPct": 100,
+                "abilityPowerMultiplier": 2,
+                "costs": {
+                    "shards": 10
+                },
+                "ascensionCosts": {
+                    "hreShards": 25
+                }
+            },
+            {
+                "stars": 2,
+                "rarity": "Common",
+                "maxXpLevel": 8,
+                "maxRank": 3,
+                "unitStatMultiplierPct": 120,
+                "abilityStatMultiplierPct": 100,
+                "abilityPowerMultiplier": 2,
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "hreShards": 25
+                }
+            },
+            {
+                "stars": 2,
+                "rarity": "Uncommon",
+                "maxXpLevel": 17,
+                "maxRank": 6,
+                "unitStatMultiplierPct": 120,
+                "abilityStatMultiplierPct": 120,
+                "abilityPowerMultiplier": 3,
+                "costs": {
+                    "shards": 15,
+                    "heroAscensionOrbUncommon": 10
+                },
+                "ascensionCosts": {
+                    "hreShards": 25
+                }
+            },
+            {
+                "stars": 3,
+                "rarity": "Uncommon",
+                "maxXpLevel": 17,
+                "maxRank": 6,
+                "unitStatMultiplierPct": 130,
+                "abilityStatMultiplierPct": 120,
+                "abilityPowerMultiplier": 3,
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "hreShards": 50
+                }
+            },
+            {
+                "stars": 4,
+                "rarity": "Uncommon",
+                "maxXpLevel": 17,
+                "maxRank": 6,
+                "unitStatMultiplierPct": 140,
+                "abilityStatMultiplierPct": 120,
+                "abilityPowerMultiplier": 3,
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "hreShards": 60
+                }
+            },
+            {
+                "stars": 4,
+                "rarity": "Rare",
+                "maxXpLevel": 26,
+                "maxRank": 9,
+                "unitStatMultiplierPct": 140,
+                "abilityStatMultiplierPct": 140,
+                "abilityPowerMultiplier": 4,
+                "costs": {
+                    "shards": 20,
+                    "heroAscensionOrbRare": 10
+                },
+                "ascensionCosts": {
+                    "hreShards": 70
+                }
+            },
+            {
+                "stars": 5,
+                "rarity": "Rare",
+                "maxXpLevel": 26,
+                "maxRank": 9,
+                "unitStatMultiplierPct": 150,
+                "abilityStatMultiplierPct": 140,
+                "abilityPowerMultiplier": 4,
+                "costs": {
+                    "shards": 30
+                },
+                "ascensionCosts": {
+                    "hreShards": 50
+                }
+            },
+            {
+                "stars": 6,
+                "rarity": "Rare",
+                "maxXpLevel": 26,
+                "maxRank": 9,
+                "unitStatMultiplierPct": 160,
+                "abilityStatMultiplierPct": 140,
+                "abilityPowerMultiplier": 4,
+                "costs": {
+                    "shards": 40
+                },
+                "ascensionCosts": {
+                    "hreShards": 60
+                }
+            },
+            {
+                "stars": 6,
+                "rarity": "Epic",
+                "maxXpLevel": 35,
+                "maxRank": 12,
+                "unitStatMultiplierPct": 160,
+                "abilityStatMultiplierPct": 160,
+                "abilityPowerMultiplier": 5,
+                "costs": {
+                    "shards": 50,
+                    "heroAscensionOrbEpic": 10
+                },
+                "ascensionCosts": {
+                    "hreShards": 70
+                }
+            },
+            {
+                "stars": 7,
+                "rarity": "Epic",
+                "maxXpLevel": 35,
+                "maxRank": 12,
+                "unitStatMultiplierPct": 170,
+                "abilityStatMultiplierPct": 160,
+                "abilityPowerMultiplier": 5,
+                "costs": {
+                    "shards": 65
+                },
+                "ascensionCosts": {
+                    "hreShards": 50
+                }
+            },
+            {
+                "stars": 8,
+                "rarity": "Epic",
+                "maxXpLevel": 35,
+                "maxRank": 12,
+                "unitStatMultiplierPct": 180,
+                "abilityStatMultiplierPct": 160,
+                "abilityPowerMultiplier": 5,
+                "costs": {
+                    "shards": 85
+                },
+                "ascensionCosts": {
+                    "hreShards": 60
+                }
+            },
+            {
+                "stars": 8,
+                "rarity": "Legendary",
+                "maxXpLevel": 50,
+                "maxRank": 17,
+                "unitStatMultiplierPct": 180,
+                "abilityStatMultiplierPct": 180,
+                "abilityPowerMultiplier": 7,
+                "costs": {
+                    "shards": 100,
+                    "heroAscensionOrbLegendary": 10
+                },
+                "ascensionCosts": {
+                    "hreShards": 100
+                }
+            },
+            {
+                "stars": 9,
+                "rarity": "Legendary",
+                "maxXpLevel": 50,
+                "maxRank": 17,
+                "unitStatMultiplierPct": 190,
+                "abilityStatMultiplierPct": 180,
+                "abilityPowerMultiplier": 7,
+                "costs": {
+                    "shards": 150,
+                    "heroAscensionOrbLegendary": 10
+                },
+                "ascensionCosts": {
+                    "hreShards": 100
+                }
+            },
+            {
+                "stars": 10,
+                "rarity": "Legendary",
+                "maxXpLevel": 50,
+                "maxRank": 17,
+                "unitStatMultiplierPct": 200,
+                "abilityStatMultiplierPct": 180,
+                "abilityPowerMultiplier": 7,
+                "costs": {
+                    "shards": 250,
+                    "heroAscensionOrbLegendary": 15
+                },
+                "ascensionCosts": {
+                    "hreShards": 200
+                }
+            },
+            {
+                "stars": 11,
+                "rarity": "Legendary",
+                "maxXpLevel": 50,
+                "maxRank": 17,
+                "unitStatMultiplierPct": 210,
+                "abilityStatMultiplierPct": 180,
+                "abilityPowerMultiplier": 7,
+                "costs": {
+                    "shards": 500,
+                    "heroAscensionOrbLegendary": 20
+                },
+                "ascensionCosts": {
+                    "hreShards": 400
+                }
+            },
+            {
+                "stars": 11,
+                "rarity": "Mythic",
+                "maxXpLevel": 60,
+                "maxRank": 20,
+                "unitStatMultiplierPct": 210,
+                "abilityStatMultiplierPct": 200,
+                "abilityPowerMultiplier": 9,
+                "costs": {
+                    "mythicShards": 20
+                }
+            },
+            {
+                "stars": 12,
+                "rarity": "Mythic",
+                "maxXpLevel": 60,
+                "maxRank": 20,
+                "unitStatMultiplierPct": 220,
+                "abilityStatMultiplierPct": 200,
+                "abilityPowerMultiplier": 9,
+                "costs": {
+                    "mythicShards": 30
+                }
+            },
+            {
+                "stars": 13,
+                "rarity": "Mythic",
+                "maxXpLevel": 60,
+                "maxRank": 20,
+                "unitStatMultiplierPct": 230,
+                "abilityStatMultiplierPct": 200,
+                "abilityPowerMultiplier": 9,
+                "costs": {
+                    "mythicShards": 50
+                }
+            },
+            {
+                "stars": 14,
+                "rarity": "Mythic",
+                "maxXpLevel": 60,
+                "maxRank": 20,
+                "unitStatMultiplierPct": 240,
+                "abilityStatMultiplierPct": 200,
+                "abilityPowerMultiplier": 9,
+                "costs": {
+                    "mythicShards": 100
+                }
+            }
+        ],
+        "eldarMauganRa": [
+            {
+                "stars": 0,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 40
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 1,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 2,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 2,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15,
+                    "heroAscensionOrbUncommon": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 3,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 4,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 4,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 20,
+                    "heroAscensionOrbRare": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 5,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 30
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 6,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 40
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 6,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 50,
+                    "heroAscensionOrbEpic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 7,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 65
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 8,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 85
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 8,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 100,
+                    "heroAscensionOrbLegendary": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 150
+                }
+            },
+            {
+                "stars": 9,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 150,
+                    "heroAscensionOrbLegendary": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 60
+                }
+            },
+            {
+                "stars": 10,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 250,
+                    "heroAscensionOrbLegendary": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 70
+                }
+            },
+            {
+                "stars": 11,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 500,
+                    "heroAscensionOrbLegendary": 20
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 80
+                }
+            },
+            {
+                "stars": 11,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 20,
+                    "heroAscensionOrbMythic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 250
+                }
+            },
+            {
+                "stars": 12,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 30,
+                    "heroAscensionOrbMythic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 150
+                }
+            },
+            {
+                "stars": 13,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 50,
+                    "heroAscensionOrbMythic": 15
+                }
+            },
+            {
+                "stars": 14,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 100,
+                    "heroAscensionOrbMythic": 25
+                }
+            }
+        ],
+        "eldarJainZar": [
+            {
+                "stars": 0,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 40
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 1,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 2,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 2,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15,
+                    "heroAscensionOrbUncommon": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 3,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 4,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 4,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 20,
+                    "heroAscensionOrbRare": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 5,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 30
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 6,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 40
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 6,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 50,
+                    "heroAscensionOrbEpic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 7,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 65
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 8,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 85
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 8,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 100,
+                    "heroAscensionOrbLegendary": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 150
+                }
+            },
+            {
+                "stars": 9,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 150,
+                    "heroAscensionOrbLegendary": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 60
+                }
+            },
+            {
+                "stars": 10,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 250,
+                    "heroAscensionOrbLegendary": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 70
+                }
+            },
+            {
+                "stars": 11,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 500,
+                    "heroAscensionOrbLegendary": 20
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 80
+                }
+            },
+            {
+                "stars": 11,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 20,
+                    "heroAscensionOrbMythic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 250
+                }
+            },
+            {
+                "stars": 12,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 30,
+                    "heroAscensionOrbMythic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 150
+                }
+            },
+            {
+                "stars": 13,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 50,
+                    "heroAscensionOrbMythic": 15
+                }
+            },
+            {
+                "stars": 14,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 100,
+                    "heroAscensionOrbMythic": 25
+                }
+            }
+        ],
+        "tauAunShi": [
+            {
+                "stars": 0,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 40
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 1,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 2,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 2,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15,
+                    "heroAscensionOrbUncommon": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 3,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 4,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 4,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 20,
+                    "heroAscensionOrbRare": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 5,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 30
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 6,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 40
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 6,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 50,
+                    "heroAscensionOrbEpic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 7,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 65
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 8,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 85
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 8,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 100,
+                    "heroAscensionOrbLegendary": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 150
+                }
+            },
+            {
+                "stars": 9,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 150,
+                    "heroAscensionOrbLegendary": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 60
+                }
+            },
+            {
+                "stars": 10,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 250,
+                    "heroAscensionOrbLegendary": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 70
+                }
+            },
+            {
+                "stars": 11,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 500,
+                    "heroAscensionOrbLegendary": 20
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 80
+                }
+            },
+            {
+                "stars": 11,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 20,
+                    "heroAscensionOrbMythic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 250
+                }
+            },
+            {
+                "stars": 12,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 30,
+                    "heroAscensionOrbMythic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 150
+                }
+            },
+            {
+                "stars": 13,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 50,
+                    "heroAscensionOrbMythic": 15
+                }
+            },
+            {
+                "stars": 14,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 100,
+                    "heroAscensionOrbMythic": 25
+                }
+            }
+        ],
+        "tauShadowsun": [
+            {
+                "stars": 0,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 40
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 1,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 2,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 2,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15,
+                    "heroAscensionOrbUncommon": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 3,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 4,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 4,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 20,
+                    "heroAscensionOrbRare": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 5,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 30
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 6,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 40
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 6,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 50,
+                    "heroAscensionOrbEpic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 7,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 65
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 8,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 85
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 8,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 100,
+                    "heroAscensionOrbLegendary": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 150
+                }
+            },
+            {
+                "stars": 9,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 150,
+                    "heroAscensionOrbLegendary": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 60
+                }
+            },
+            {
+                "stars": 10,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 250,
+                    "heroAscensionOrbLegendary": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 70
+                }
+            },
+            {
+                "stars": 11,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 500,
+                    "heroAscensionOrbLegendary": 20
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 80
+                }
+            },
+            {
+                "stars": 11,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 20,
+                    "heroAscensionOrbMythic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 250
+                }
+            },
+            {
+                "stars": 12,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 30,
+                    "heroAscensionOrbMythic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 150
+                }
+            },
+            {
+                "stars": 13,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 50,
+                    "heroAscensionOrbMythic": 15
+                }
+            },
+            {
+                "stars": 14,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 100,
+                    "heroAscensionOrbMythic": 25
+                }
+            }
+        ],
+        "spaceBlackmane": [
+            {
+                "stars": 0,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 40
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 1,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 2,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 2,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15,
+                    "heroAscensionOrbUncommon": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 3,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 4,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 4,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 20,
+                    "heroAscensionOrbRare": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 5,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 30
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 6,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 40
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 6,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 50,
+                    "heroAscensionOrbEpic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 7,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 65
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 8,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 85
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 8,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 100,
+                    "heroAscensionOrbLegendary": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 400
+                }
+            },
+            {
+                "stars": 9,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 150,
+                    "heroAscensionOrbLegendary": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 120
+                }
+            },
+            {
+                "stars": 10,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 250,
+                    "heroAscensionOrbLegendary": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 180
+                }
+            },
+            {
+                "stars": 11,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 500,
+                    "heroAscensionOrbLegendary": 20
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 200
+                }
+            },
+            {
+                "stars": 11,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 20,
+                    "heroAscensionOrbMythic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 250
+                }
+            },
+            {
+                "stars": 12,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 30,
+                    "heroAscensionOrbMythic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 150
+                }
+            },
+            {
+                "stars": 13,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 50,
+                    "heroAscensionOrbMythic": 15
+                }
+            },
+            {
+                "stars": 14,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 100,
+                    "heroAscensionOrbMythic": 25
+                }
+            }
+        ],
+        "admecDominus": [
+            {
+                "stars": 0,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 40
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 1,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 2,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 2,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15,
+                    "heroAscensionOrbUncommon": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 3,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 4,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 4,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 20,
+                    "heroAscensionOrbRare": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 5,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 30
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 6,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 40
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 6,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 50,
+                    "heroAscensionOrbEpic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 7,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 65
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 8,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 85
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 8,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 100,
+                    "heroAscensionOrbLegendary": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 400
+                }
+            },
+            {
+                "stars": 9,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 150,
+                    "heroAscensionOrbLegendary": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 120
+                }
+            },
+            {
+                "stars": 10,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 250,
+                    "heroAscensionOrbLegendary": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 180
+                }
+            },
+            {
+                "stars": 11,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 500,
+                    "heroAscensionOrbLegendary": 20
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 200
+                }
+            },
+            {
+                "stars": 11,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 20,
+                    "heroAscensionOrbMythic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 250
+                }
+            },
+            {
+                "stars": 12,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 30,
+                    "heroAscensionOrbMythic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 150
+                }
+            },
+            {
+                "stars": 13,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 50,
+                    "heroAscensionOrbMythic": 15
+                }
+            },
+            {
+                "stars": 14,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 100,
+                    "heroAscensionOrbMythic": 25
+                }
+            }
+        ],
+        "worldKharn": [
+            {
+                "stars": 0,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 40
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 1,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 2,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 2,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15,
+                    "heroAscensionOrbUncommon": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 3,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 4,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 4,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 20,
+                    "heroAscensionOrbRare": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 5,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 30
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 6,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 40
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 6,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 50,
+                    "heroAscensionOrbEpic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 7,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 65
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 8,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 85
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 8,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 100,
+                    "heroAscensionOrbLegendary": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 400
+                }
+            },
+            {
+                "stars": 9,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 150,
+                    "heroAscensionOrbLegendary": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 120
+                }
+            },
+            {
+                "stars": 10,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 250,
+                    "heroAscensionOrbLegendary": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 180
+                }
+            },
+            {
+                "stars": 11,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 500,
+                    "heroAscensionOrbLegendary": 20
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 200
+                }
+            },
+            {
+                "stars": 11,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 20,
+                    "heroAscensionOrbMythic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 250
+                }
+            },
+            {
+                "stars": 12,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 30,
+                    "heroAscensionOrbMythic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 150
+                }
+            },
+            {
+                "stars": 13,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 50,
+                    "heroAscensionOrbMythic": 15
+                }
+            },
+            {
+                "stars": 14,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 100,
+                    "heroAscensionOrbMythic": 25
+                }
+            }
+        ],
+        "bloodMephiston": [
+            {
+                "stars": 0,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 40
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 1,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 2,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 2,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15,
+                    "heroAscensionOrbUncommon": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 3,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 4,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 4,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 20,
+                    "heroAscensionOrbRare": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 5,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 30
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 6,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 40
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 6,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 50,
+                    "heroAscensionOrbEpic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 7,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 65
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 8,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 85
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 8,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 100,
+                    "heroAscensionOrbLegendary": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 400
+                }
+            },
+            {
+                "stars": 9,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 150,
+                    "heroAscensionOrbLegendary": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 120
+                }
+            },
+            {
+                "stars": 10,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 250,
+                    "heroAscensionOrbLegendary": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 180
+                }
+            },
+            {
+                "stars": 11,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 500,
+                    "heroAscensionOrbLegendary": 20
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 200
+                }
+            },
+            {
+                "stars": 11,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 20,
+                    "heroAscensionOrbMythic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 250
+                }
+            },
+            {
+                "stars": 12,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 30,
+                    "heroAscensionOrbMythic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 150
+                }
+            },
+            {
+                "stars": 13,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 50,
+                    "heroAscensionOrbMythic": 15
+                }
+            },
+            {
+                "stars": 14,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 100,
+                    "heroAscensionOrbMythic": 25
+                }
+            }
+        ],
+        "genesPatriarch": [
+            {
+                "stars": 0,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 40
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 1,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 2,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 2,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15,
+                    "heroAscensionOrbUncommon": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 3,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 4,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 4,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 20,
+                    "heroAscensionOrbRare": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 5,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 30
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 6,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 40
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 6,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 50,
+                    "heroAscensionOrbEpic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 7,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 65
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 8,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 85
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 8,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 100,
+                    "heroAscensionOrbLegendary": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 400
+                }
+            },
+            {
+                "stars": 9,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 150,
+                    "heroAscensionOrbLegendary": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 120
+                }
+            },
+            {
+                "stars": 10,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 250,
+                    "heroAscensionOrbLegendary": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 180
+                }
+            },
+            {
+                "stars": 11,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 500,
+                    "heroAscensionOrbLegendary": 20
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 200
+                }
+            },
+            {
+                "stars": 11,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 20,
+                    "heroAscensionOrbMythic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 250
+                }
+            },
+            {
+                "stars": 12,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 30,
+                    "heroAscensionOrbMythic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 150
+                }
+            },
+            {
+                "stars": 13,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 50,
+                    "heroAscensionOrbMythic": 15
+                }
+            },
+            {
+                "stars": 14,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 100,
+                    "heroAscensionOrbMythic": 25
+                }
+            }
+        ],
+        "bloodDante": [
+            {
+                "stars": 0,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 40
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 1,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 2,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 2,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15,
+                    "heroAscensionOrbUncommon": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 3,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 4,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 4,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 20,
+                    "heroAscensionOrbRare": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 5,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 30
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 6,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 40
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 6,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 50,
+                    "heroAscensionOrbEpic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 7,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 65
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 8,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 85
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 8,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 100,
+                    "heroAscensionOrbLegendary": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 400
+                }
+            },
+            {
+                "stars": 9,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 150,
+                    "heroAscensionOrbLegendary": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 120
+                }
+            },
+            {
+                "stars": 10,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 250,
+                    "heroAscensionOrbLegendary": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 180
+                }
+            },
+            {
+                "stars": 11,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 500,
+                    "heroAscensionOrbLegendary": 20
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 200
+                }
+            },
+            {
+                "stars": 11,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 20,
+                    "heroAscensionOrbMythic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 250
+                }
+            },
+            {
+                "stars": 12,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 30,
+                    "heroAscensionOrbMythic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 150
+                }
+            },
+            {
+                "stars": 13,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 50,
+                    "heroAscensionOrbMythic": 15
+                }
+            },
+            {
+                "stars": 14,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 100,
+                    "heroAscensionOrbMythic": 25
+                }
+            }
+        ],
+        "custoTrajann": [
+            {
+                "stars": 0,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 40
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 1,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 2,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 2,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15,
+                    "heroAscensionOrbUncommon": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 3,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 4,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 4,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 20,
+                    "heroAscensionOrbRare": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 5,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 30
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 6,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 40
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 6,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 50,
+                    "heroAscensionOrbEpic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 7,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 65
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 8,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 85
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 8,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 100,
+                    "heroAscensionOrbLegendary": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 400
+                }
+            },
+            {
+                "stars": 9,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 150,
+                    "heroAscensionOrbLegendary": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 120
+                }
+            },
+            {
+                "stars": 10,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 250,
+                    "heroAscensionOrbLegendary": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 180
+                }
+            },
+            {
+                "stars": 11,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 500,
+                    "heroAscensionOrbLegendary": 20
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 200
+                }
+            },
+            {
+                "stars": 11,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 20,
+                    "heroAscensionOrbMythic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 250
+                }
+            },
+            {
+                "stars": 12,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 30,
+                    "heroAscensionOrbMythic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 150
+                }
+            },
+            {
+                "stars": 13,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 50,
+                    "heroAscensionOrbMythic": 15
+                }
+            },
+            {
+                "stars": 14,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 100,
+                    "heroAscensionOrbMythic": 25
+                }
+            }
+        ],
+        "emperLucius": [
+            {
+                "stars": 0,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 40
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 1,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 2,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 2,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15,
+                    "heroAscensionOrbUncommon": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 3,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 4,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 4,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 20,
+                    "heroAscensionOrbRare": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 5,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 30
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 6,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 40
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 6,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 50,
+                    "heroAscensionOrbEpic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 7,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 65
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 8,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 85
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 8,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 100,
+                    "heroAscensionOrbLegendary": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 400
+                }
+            },
+            {
+                "stars": 9,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 150,
+                    "heroAscensionOrbLegendary": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 120
+                }
+            },
+            {
+                "stars": 10,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 250,
+                    "heroAscensionOrbLegendary": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 180
+                }
+            },
+            {
+                "stars": 11,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 500,
+                    "heroAscensionOrbLegendary": 20
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 200
+                }
+            },
+            {
+                "stars": 11,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 20,
+                    "heroAscensionOrbMythic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 250
+                }
+            },
+            {
+                "stars": 12,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 30,
+                    "heroAscensionOrbMythic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 150
+                }
+            },
+            {
+                "stars": 13,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 50,
+                    "heroAscensionOrbMythic": 15
+                }
+            },
+            {
+                "stars": 14,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 100,
+                    "heroAscensionOrbMythic": 25
+                }
+            }
+        ],
+        "tauFarsight": [
+            {
+                "stars": 0,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 40
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 1,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 2,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 2,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15,
+                    "heroAscensionOrbUncommon": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 3,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 4,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 4,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 20,
+                    "heroAscensionOrbRare": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 5,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 30
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 6,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 40
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 6,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 50,
+                    "heroAscensionOrbEpic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 7,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 65
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 8,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 85
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 8,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 100,
+                    "heroAscensionOrbLegendary": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 400
+                }
+            },
+            {
+                "stars": 9,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 150,
+                    "heroAscensionOrbLegendary": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 120
+                }
+            },
+            {
+                "stars": 10,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 250,
+                    "heroAscensionOrbLegendary": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 180
+                }
+            },
+            {
+                "stars": 11,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 500,
+                    "heroAscensionOrbLegendary": 20
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 200
+                }
+            },
+            {
+                "stars": 11,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 20,
+                    "heroAscensionOrbMythic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 250
+                }
+            },
+            {
+                "stars": 12,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 30,
+                    "heroAscensionOrbMythic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 150
+                }
+            },
+            {
+                "stars": 13,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 50,
+                    "heroAscensionOrbMythic": 15
+                }
+            },
+            {
+                "stars": 14,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 100,
+                    "heroAscensionOrbMythic": 25
+                }
+            }
+        ],
+        "votanUthar": [
+            {
+                "stars": 0,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 40
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 1,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 2,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 2,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15,
+                    "heroAscensionOrbUncommon": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 3,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 4,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 4,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 20,
+                    "heroAscensionOrbRare": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 5,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 30
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 6,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 40
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 6,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 50,
+                    "heroAscensionOrbEpic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 7,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 65
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 8,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 85
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 8,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 100,
+                    "heroAscensionOrbLegendary": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 400
+                }
+            },
+            {
+                "stars": 9,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 150,
+                    "heroAscensionOrbLegendary": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 120
+                }
+            },
+            {
+                "stars": 10,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 250,
+                    "heroAscensionOrbLegendary": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 180
+                }
+            },
+            {
+                "stars": 11,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 500,
+                    "heroAscensionOrbLegendary": 20
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 200
+                }
+            },
+            {
+                "stars": 11,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 20,
+                    "heroAscensionOrbMythic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 250
+                }
+            },
+            {
+                "stars": 12,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 30,
+                    "heroAscensionOrbMythic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 150
+                }
+            },
+            {
+                "stars": 13,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 50,
+                    "heroAscensionOrbMythic": 15
+                }
+            },
+            {
+                "stars": 14,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 100,
+                    "heroAscensionOrbMythic": 25
+                }
+            }
+        ],
+        "astarLysander": [
+            {
+                "stars": 0,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 40
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 1,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 2,
+                "rarity": "Common",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 2,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15,
+                    "heroAscensionOrbUncommon": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 3,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 4,
+                "rarity": "Uncommon",
+                "costs": {
+                    "shards": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 4,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 20,
+                    "heroAscensionOrbRare": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 5,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 30
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 6,
+                "rarity": "Rare",
+                "costs": {
+                    "shards": 40
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 6,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 50,
+                    "heroAscensionOrbEpic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 7,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 65
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 8,
+                "rarity": "Epic",
+                "costs": {
+                    "shards": 85
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 0
+                }
+            },
+            {
+                "stars": 8,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 100,
+                    "heroAscensionOrbLegendary": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 400
+                }
+            },
+            {
+                "stars": 9,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 150,
+                    "heroAscensionOrbLegendary": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 120
+                }
+            },
+            {
+                "stars": 10,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 250,
+                    "heroAscensionOrbLegendary": 15
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 180
+                }
+            },
+            {
+                "stars": 11,
+                "rarity": "Legendary",
+                "costs": {
+                    "shards": 500,
+                    "heroAscensionOrbLegendary": 20
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 200
+                }
+            },
+            {
+                "stars": 11,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 20,
+                    "heroAscensionOrbMythic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 250
+                }
+            },
+            {
+                "stars": 12,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 30,
+                    "heroAscensionOrbMythic": 10
+                },
+                "ascensionCosts": {
+                    "legendaryEventShards": 150
+                }
+            },
+            {
+                "stars": 13,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 50,
+                    "heroAscensionOrbMythic": 15
+                }
+            },
+            {
+                "stars": 14,
+                "rarity": "Mythic",
+                "costs": {
+                    "mythicShards": 100,
+                    "heroAscensionOrbMythic": 25
+                }
+            }
+        ]
+    },
+    "heroProgressionStepsMoW": [
+        {
+            "Step": 0,
+            "stars": 0,
+            "rarity": "Common",
+            "maxAbilityLevel": 8,
+            "abilityStatMultiplierPct": 100,
+            "abilityPowerMultiplier": 7,
+            "costs": {
+                "shards": 40
+            }
+        },
+        {
+            "Step": 1,
+            "stars": 1,
+            "rarity": "Common",
+            "maxAbilityLevel": 8,
+            "abilityStatMultiplierPct": 105,
+            "abilityPowerMultiplier": 8,
+            "costs": {
+                "shards": 10
+            }
+        },
+        {
+            "Step": 2,
+            "stars": 2,
+            "rarity": "Common",
+            "maxAbilityLevel": 8,
+            "abilityStatMultiplierPct": 110,
+            "abilityPowerMultiplier": 9,
+            "costs": {
+                "shards": 15
+            }
+        },
+        {
+            "Step": 3,
+            "stars": 2,
+            "rarity": "Uncommon",
+            "maxAbilityLevel": 17,
+            "abilityStatMultiplierPct": 115,
+            "abilityPowerMultiplier": 10,
+            "costs": {
+                "shards": 15,
+                "heroAscensionOrbUncommon": 10
+            }
+        },
+        {
+            "Step": 4,
+            "stars": 3,
+            "rarity": "Uncommon",
+            "maxAbilityLevel": 17,
+            "abilityStatMultiplierPct": 120,
+            "abilityPowerMultiplier": 11,
+            "costs": {
+                "shards": 15
+            }
+        },
+        {
+            "Step": 5,
+            "stars": 4,
+            "rarity": "Uncommon",
+            "maxAbilityLevel": 17,
+            "abilityStatMultiplierPct": 125,
+            "abilityPowerMultiplier": 12,
+            "costs": {
+                "shards": 15
+            }
+        },
+        {
+            "Step": 6,
+            "stars": 4,
+            "rarity": "Rare",
+            "maxAbilityLevel": 26,
+            "abilityStatMultiplierPct": 130,
+            "abilityPowerMultiplier": 13,
+            "costs": {
+                "shards": 20,
+                "heroAscensionOrbRare": 10
+            }
+        },
+        {
+            "Step": 7,
+            "stars": 5,
+            "rarity": "Rare",
+            "maxAbilityLevel": 26,
+            "abilityStatMultiplierPct": 135,
+            "abilityPowerMultiplier": 14,
+            "costs": {
+                "shards": 30
+            }
+        },
+        {
+            "Step": 8,
+            "stars": 6,
+            "rarity": "Rare",
+            "maxAbilityLevel": 26,
+            "abilityStatMultiplierPct": 140,
+            "abilityPowerMultiplier": 15,
+            "costs": {
+                "shards": 40
+            }
+        },
+        {
+            "Step": 9,
+            "stars": 6,
+            "rarity": "Epic",
+            "maxAbilityLevel": 35,
+            "abilityStatMultiplierPct": 145,
+            "abilityPowerMultiplier": 16,
+            "costs": {
+                "shards": 50,
+                "heroAscensionOrbEpic": 10
+            }
+        },
+        {
+            "Step": 10,
+            "stars": 7,
+            "rarity": "Epic",
+            "maxAbilityLevel": 35,
+            "abilityStatMultiplierPct": 150,
+            "abilityPowerMultiplier": 17,
+            "costs": {
+                "shards": 65
+            }
+        },
+        {
+            "Step": 11,
+            "stars": 8,
+            "rarity": "Epic",
+            "maxAbilityLevel": 35,
+            "abilityStatMultiplierPct": 155,
+            "abilityPowerMultiplier": 18,
+            "costs": {
+                "shards": 85
+            }
+        },
+        {
+            "Step": 12,
+            "stars": 8,
+            "rarity": "Legendary",
+            "maxAbilityLevel": 50,
+            "abilityStatMultiplierPct": 160,
+            "abilityPowerMultiplier": 19,
+            "costs": {
+                "shards": 100,
+                "heroAscensionOrbLegendary": 10
+            }
+        },
+        {
+            "Step": 13,
+            "stars": 9,
+            "rarity": "Legendary",
+            "maxAbilityLevel": 50,
+            "abilityStatMultiplierPct": 165,
+            "abilityPowerMultiplier": 21,
+            "costs": {
+                "shards": 150,
+                "heroAscensionOrbLegendary": 10
+            }
+        },
+        {
+            "Step": 14,
+            "stars": 10,
+            "rarity": "Legendary",
+            "maxAbilityLevel": 50,
+            "abilityStatMultiplierPct": 170,
+            "abilityPowerMultiplier": 23,
+            "costs": {
+                "shards": 250,
+                "heroAscensionOrbLegendary": 15
+            }
+        },
+        {
+            "Step": 15,
+            "stars": 11,
+            "rarity": "Legendary",
+            "maxAbilityLevel": 50,
+            "abilityStatMultiplierPct": 180,
+            "abilityPowerMultiplier": 25,
+            "costs": {
+                "shards": 500,
+                "heroAscensionOrbLegendary": 20
+            }
+        },
+        {
+            "Step": 16,
+            "stars": 11,
+            "rarity": "Mythic",
+            "maxAbilityLevel": 60,
+            "abilityStatMultiplierPct": 185,
+            "abilityPowerMultiplier": 26,
+            "mythicAbilityStatMultiplierPct": 100,
+            "mythicAbilityPower": 75000,
+            "costs": {
+                "mythicShards": 20,
+                "heroAscensionOrbMythic": 10
+            }
+        },
+        {
+            "Step": 17,
+            "stars": 12,
+            "rarity": "Mythic",
+            "maxAbilityLevel": 60,
+            "abilityStatMultiplierPct": 190,
+            "abilityPowerMultiplier": 27,
+            "mythicAbilityStatMultiplierPct": 130,
+            "mythicAbilityPower": 100000,
+            "costs": {
+                "mythicShards": 30,
+                "heroAscensionOrbMythic": 10
+            }
+        },
+        {
+            "Step": 18,
+            "stars": 13,
+            "rarity": "Mythic",
+            "maxAbilityLevel": 60,
+            "abilityStatMultiplierPct": 195,
+            "abilityPowerMultiplier": 28,
+            "mythicAbilityStatMultiplierPct": 160,
+            "mythicAbilityPower": 125000,
+            "costs": {
+                "mythicShards": 50,
+                "heroAscensionOrbMythic": 15
+            }
+        },
+        {
+            "Step": 19,
+            "stars": 14,
+            "rarity": "Mythic",
+            "maxAbilityLevel": 60,
+            "abilityStatMultiplierPct": 200,
+            "abilityPowerMultiplier": 29,
+            "mythicAbilityStatMultiplierPct": 200,
+            "mythicAbilityPower": 150000,
+            "costs": {
+                "mythicShards": 100,
+                "heroAscensionOrbMythic": 25
+            }
+        }
+    ],
+    "damageProfileModifiers": {
+        "Physical": 35,
+        "Projectile": 56,
+        "Las": 54,
+        "Bolter": 63,
+        "Flame": 90,
+        "Particle": 82,
+        "Acid": 115,
+        "Power": 88,
+        "Plasma": 119,
+        "Melta": 130,
+        "HeavyRound": 107,
+        "Gauss": 113,
+        "Psychic": 191,
+        "DirectDamage": 159,
+        "Energy": 76,
+        "Chain": 63,
+        "Blast": 61,
+        "Piercing": 136,
+        "Bio": 76,
+        "Pulse": 63,
+        "Toxic": 156,
+        "Eviscerate": 101
+    },
+    "abilityPowerCurve": {
+        "active": [
+            3, 4, 6, 7, 9, 12, 15, 19, 22, 27, 31, 36, 41, 47, 53, 60, 67, 74, 81, 89, 101, 118, 159, 206, 260, 320,
+            387, 460, 540, 627, 721, 821, 929, 1043, 1165, 1293, 1429, 1571, 1721, 1944, 2281, 2665, 3116, 3658, 4761,
+            6017, 7428, 8996, 10721, 12605, 12898, 13264, 13634, 14137, 14649, 15171, 15703, 16380, 17073, 17781, 18650,
+            19541, 20454, 21389, 22345
+        ],
+        "passive": [
+            2, 3, 4, 5, 7, 9, 11, 14, 16, 19, 23, 26, 30, 34, 39, 43, 48, 54, 59, 65, 73, 86, 116, 150, 189, 233, 281,
+            335, 393, 456, 524, 597, 676, 759, 847, 941, 1039, 1143, 1252, 1413, 1659, 1938, 2266, 2660, 3463, 4376,
+            5402, 6542, 7797, 9167, 9380, 9646, 9916, 10282, 10654, 11034, 11420, 11913, 12417, 12932, 13564, 14212,
+            14876, 15555, 16251
+        ],
+        "relic": [42000, 45500, 49000, 52500, 56000, 59500, 63000, 66500, 70000, 73500]
+    },
+    "abilityPowerModifiers": {
+        "ComingSoonActive": {
+            "baseMultiplier": 100
+        },
+        "ComingSoonPassive": {
+            "baseMultiplier": 100
+        },
+        "GauntletsOfUltramar": {
+            "baseMultiplier": 80
+        },
+        "RitesOfBattle": {
+            "baseMultiplier": 100
+        },
+        "PsychicFortress": {
+            "baseMultiplier": 80
+        },
+        "CombatRestoratives": {
+            "baseMultiplier": 75
+        },
+        "Narthecium": {
+            "baseMultiplier": 80
+        },
+        "DeathFromAbove": {
+            "baseMultiplier": 140
+        },
+        "ShockAssault": {
+            "baseMultiplier": 85
+        },
+        "MortisRound": {
+            "baseMultiplier": 105
+        },
+        "CamoCloak": {
+            "baseMultiplier": 95
+        },
+        "AdaptiveStrategy": {
+            "baseMultiplier": 85
+        },
+        "RelentlessMarch": {
+            "baseMultiplier": 115
+        },
+        "MultiThreatEliminator": {
+            "baseMultiplier": 90
+        },
+        "InescapableDeath": {
+            "baseMultiplier": 105
+        },
+        "ScarabHive": {
+            "baseMultiplier": 165
+        },
+        "FabricatorClawArray": {
+            "baseMultiplier": 60
+        },
+        "HarbingerOfDestruction": {
+            "baseMultiplier": 85
+        },
+        "LivingLightning": {
+            "baseMultiplier": 90
+        },
+        "ResurrectionOrb": {
+            "baseMultiplier": 135
+        },
+        "MyWillBeDoneOverlord": {
+            "baseMultiplier": 135
+        },
+        "StormOfFlensingBlades": {
+            "baseMultiplier": 70
+        },
+        "ReanimationProtocols": {
+            "baseMultiplier": 110
+        },
+        "TunnelingHorror": {
+            "baseMultiplier": 60
+        },
+        "WhipcoilBody": {
+            "baseMultiplier": 60
+        },
+        "ArmoriumCherub": {
+            "baseMultiplier": 90
+        },
+        "FireOfAbsolution": {
+            "baseMultiplier": 160
+        },
+        "PrecisionShot": {
+            "baseMultiplier": 60
+        },
+        "ScarabSummon": {
+            "baseMultiplier": 180
+        },
+        "StormOfWrath": {
+            "baseMultiplier": 120
+        },
+        "MartialApotheosis": {
+            "baseMultiplier": 140
+        },
+        "Chronometron": {
+            "baseMultiplier": 100
+        },
+        "TimesplinterMantle": {
+            "baseMultiplier": 100
+        },
+        "ReanimationBeam": {
+            "baseMultiplier": 100
+        },
+        "NanoscarabRepairProtocols": {
+            "baseMultiplier": 100
+        },
+        "GuardianConstruct": {
+            "baseMultiplier": 100
+        },
+        "RitesOfRestoration": {
+            "baseMultiplier": 180
+        },
+        "SanctorumMissile": {
+            "baseMultiplier": 120
+        },
+        "BrazierOfHolyFire": {
+            "baseMultiplier": 90
+        },
+        "SkyStrike": {
+            "baseMultiplier": 110
+        },
+        "MultiMelta": {
+            "baseMultiplier": 100
+        },
+        "PsychicMaelstrom": {
+            "baseMultiplier": 80
+        },
+        "SendInTheNextWave": {
+            "baseMultiplier": 145
+        },
+        "FragBomb": {
+            "baseMultiplier": 110
+        },
+        "BasiliskBarrage": {
+            "baseMultiplier": 115
+        },
+        "SupremeCommander": {
+            "baseMultiplier": 165
+        },
+        "ValkyrieStrike": {
+            "baseMultiplier": 70
+        },
+        "BringerOfDespair": {
+            "baseMultiplier": 85
+        },
+        "FrenziedFiring": {
+            "baseMultiplier": 140
+        },
+        "Incursion": {
+            "baseMultiplier": 150
+        },
+        "HeraldOfTheApocalypse": {
+            "baseMultiplier": 90
+        },
+        "Drachnyen": {
+            "baseMultiplier": 100
+        },
+        "PlagueWind": {
+            "baseMultiplier": 120
+        },
+        "FlailSwing": {
+            "baseMultiplier": 80
+        },
+        "RevitalizingMalignancy": {
+            "baseMultiplier": 70
+        },
+        "FoulInfusion": {
+            "baseMultiplier": 85
+        },
+        "Poxwalkers": {
+            "baseMultiplier": 145
+        },
+        "MedicusMinistorum": {
+            "baseMultiplier": 80
+        },
+        "RighteousRepugnance": {
+            "baseMultiplier": 115
+        },
+        "CondemnorStake": {
+            "baseMultiplier": 90
+        },
+        "GeminaeSuperia": {
+            "baseMultiplier": 155
+        },
+        "Lifewards": {
+            "baseMultiplier": 1
+        },
+        "Nightshroud": {
+            "baseMultiplier": 100
+        },
+        "SummaryExecution": {
+            "baseMultiplier": 70
+        },
+        "AvalancheOfMuscle": {
+            "baseMultiplier": 80
+        },
+        "Spotter": {
+            "baseMultiplier": 70
+        },
+        "SpotterReworked": {
+            "baseMultiplier": 70
+        },
+        "SwornProtector": {
+            "baseMultiplier": 145
+        },
+        "SwornProtector_Protect": {
+            "baseMultiplier": 1
+        },
+        "ListenUpMaggots": {
+            "baseMultiplier": 1
+        },
+        "CallInReinforcements": {
+            "baseMultiplier": 130
+        },
+        "Shrapnel": {
+            "baseMultiplier": 110
+        },
+        "HatefulAssault": {
+            "baseMultiplier": 115
+        },
+        "FleshmetalGuns": {
+            "baseMultiplier": 90
+        },
+        "Possession": {
+            "baseMultiplier": 150
+        },
+        "HeadClaimer": {
+            "baseMultiplier": 150
+        },
+        "FirstAmongTraitors": {
+            "baseMultiplier": 100
+        },
+        "UnstoppableFerocity": {
+            "baseMultiplier": 150
+        },
+        "DestroyerHive": {
+            "baseMultiplier": 85
+        },
+        "HazeOfCorruption": {
+            "baseMultiplier": 95
+        },
+        "TaintedNarthecium": {
+            "baseMultiplier": 80
+        },
+        "ExplosiveMaladies": {
+            "baseMultiplier": 100
+        },
+        "CursedPlagueBell": {
+            "baseMultiplier": 120
+        },
+        "CursedOfTheWalkingPox": {
+            "baseMultiplier": 105
+        },
+        "Burrowers": {
+            "baseMultiplier": 110
+        },
+        "AdrenalGlands": {
+            "baseMultiplier": 70
+        },
+        "HungeringSwarm": {
+            "baseMultiplier": 115
+        },
+        "HailOfLivingAmmunition": {
+            "baseMultiplier": 110
+        },
+        "SpawnTermagants": {
+            "baseMultiplier": 200
+        },
+        "SpawnTermagants2": {
+            "baseMultiplier": 200
+        },
+        "SpawnTermagants3": {
+            "baseMultiplier": 200
+        },
+        "Catalyst": {
+            "baseMultiplier": 100
+        },
+        "BroodProgenitor": {
+            "baseMultiplier": 100
+        },
+        "MassiveScythingTalons": {
+            "baseMultiplier": 160
+        },
+        "SynapticBacklash": {
+            "baseMultiplier": 50
+        },
+        "SynapticImperative": {
+            "baseMultiplier": 120
+        },
+        "BioBarrage": {
+            "baseMultiplier": 100
+        },
+        "LethalMiasma": {
+            "baseMultiplier": 100
+        },
+        "GuildBossRunAway": {
+            "baseMultiplier": 0
+        },
+        "CrusadeOfWrath": {
+            "baseMultiplier": 75
+        },
+        "HolyDuel": {
+            "baseMultiplier": 85
+        },
+        "UnbreakableDuty": {
+            "baseMultiplier": 120
+        },
+        "ThunderousAssault": {
+            "baseMultiplier": 100
+        },
+        "FragstormGrenadeLauncher": {
+            "baseMultiplier": 115
+        },
+        "IncendiaryShells": {
+            "baseMultiplier": 50
+        },
+        "DestroyTheWitch": {
+            "baseMultiplier": 95
+        },
+        "MartialSuperiority": {
+            "baseMultiplier": 115
+        },
+        "AstartesBanner": {
+            "baseMultiplier": 110
+        },
+        "ChampionOfTheFeast": {
+            "baseMultiplier": 110
+        },
+        "Boltstorm": {
+            "baseMultiplier": 100
+        },
+        "HeavyBoltPistol": {
+            "baseMultiplier": 65
+        },
+        "Waaagh": {
+            "baseMultiplier": 130
+        },
+        "GrotTank": {
+            "baseMultiplier": 130
+        },
+        "RammingSpeed": {
+            "baseMultiplier": 100
+        },
+        "DakkaDakkaDakka": {
+            "baseMultiplier": 100
+        },
+        "GetEmRuntz": {
+            "baseMultiplier": 165
+        },
+        "UnstoppableMomentumReworked": {
+            "baseMultiplier": 100
+        },
+        "Stikkbomb": {
+            "baseMultiplier": 115
+        },
+        "StormboyzStrike": {
+            "baseMultiplier": 65
+        },
+        "LightImUp": {
+            "baseMultiplier": 100
+        },
+        "KustomForceField": {
+            "baseMultiplier": 85
+        },
+        "KustomForceFieldReworked": {
+            "baseMultiplier": 85
+        },
+        "KanOpener": {
+            "baseMultiplier": 100
+        },
+        "PowerTrip": {
+            "baseMultiplier": 100
+        },
+        "SquigHound": {
+            "baseMultiplier": 90
+        },
+        "SmashaEad": {
+            "baseMultiplier": 85
+        },
+        "PileIn": {
+            "baseMultiplier": 80
+        },
+        "ItsGonnaBlow": {
+            "baseMultiplier": 20
+        },
+        "OiWatchIt": {
+            "baseMultiplier": 0
+        },
+        "Ramshackle": {
+            "baseMultiplier": 50
+        },
+        "FullThrottle": {
+            "baseMultiplier": 0
+        },
+        "Volatile": {
+            "baseMultiplier": 80
+        },
+        "Explosive": {
+            "baseMultiplier": 100
+        },
+        "Detonation": {
+            "baseMultiplier": 80
+        },
+        "RunsAway": {
+            "baseMultiplier": 0
+        },
+        "RunsAround": {
+            "baseMultiplier": 0
+        },
+        "DevoutPush": {
+            "baseMultiplier": 55
+        },
+        "Pyreblaster": {
+            "baseMultiplier": 125
+        },
+        "CallRipperSwarms": {
+            "baseMultiplier": 200
+        },
+        "CallRipperSwarms2": {
+            "baseMultiplier": 200
+        },
+        "CallRipperSwarms3": {
+            "baseMultiplier": 200
+        },
+        "StranglethornCannon": {
+            "baseMultiplier": 105
+        },
+        "PrehensilePincerTail": {
+            "baseMultiplier": 130
+        },
+        "SoulHunger": {
+            "baseMultiplier": 120
+        },
+        "AdaptiveToxins": {
+            "baseMultiplier": 115
+        },
+        "DrawFire": {
+            "baseMultiplier": 100
+        },
+        "CrazedFocus": {
+            "baseMultiplier": 100
+        },
+        "FireAndReposition": {
+            "baseMultiplier": 105
+        },
+        "WireweaveNet": {
+            "baseMultiplier": 110
+        },
+        "Loki_SwoopingHawk": {
+            "baseMultiplier": 110
+        },
+        "PathOfCommand": {
+            "baseMultiplier": 140
+        },
+        "Executioner": {
+            "baseMultiplier": 95
+        },
+        "Doom": {
+            "baseMultiplier": 80
+        },
+        "HarvesterOfSouls": {
+            "baseMultiplier": 135
+        },
+        "InescapableAccuracy": {
+            "baseMultiplier": 75
+        },
+        "SilentDeath": {
+            "baseMultiplier": 120
+        },
+        "TerrorsLament": {
+            "baseMultiplier": 80
+        },
+        "EmpyricAmbush": {
+            "baseMultiplier": 100
+        },
+        "WhisperingWeb": {
+            "baseMultiplier": 100
+        },
+        "ScythingTalons": {
+            "baseMultiplier": 65
+        },
+        "ReinforcedHiveNode": {
+            "baseMultiplier": 85
+        },
+        "BreathOfSilence": {
+            "baseMultiplier": 200
+        },
+        "AnnihilatorBeam": {
+            "baseMultiplier": 200
+        },
+        "MyWillBeDone": {
+            "baseMultiplier": 185
+        },
+        "ScytheOfDust": {
+            "baseMultiplier": 145
+        },
+        "StaffOfStars": {
+            "baseMultiplier": 155
+        },
+        "TargetingProtocols": {
+            "baseMultiplier": 100
+        },
+        "ObeisanceGenerators": {
+            "baseMultiplier": 130
+        },
+        "NoctilithBeacons": {
+            "baseMultiplier": 80
+        },
+        "PhaeronOfTheBlades": {
+            "baseMultiplier": 80
+        },
+        "PhaeronOfTheStars": {
+            "baseMultiplier": 110
+        },
+        "IntegratedCircuits": {
+            "baseMultiplier": 0
+        },
+        "SeekerMissileFrequencyLock": {
+            "baseMultiplier": 160
+        },
+        "MV71SniperDroneSquad": {
+            "baseMultiplier": 160
+        },
+        "SaviorProtocols": {
+            "baseMultiplier": 120
+        },
+        "EarlyWarningOverride": {
+            "baseMultiplier": 105
+        },
+        "CyclicIonBlaster": {
+            "baseMultiplier": 92
+        },
+        "FightingRetreat": {
+            "baseMultiplier": 130
+        },
+        "StructuralAnalyser": {
+            "baseMultiplier": 152
+        },
+        "InspiredToGreatness": {
+            "baseMultiplier": 185
+        },
+        "SereneUnifier": {
+            "baseMultiplier": 120
+        },
+        "ExemplarOfTheKauyon": {
+            "baseMultiplier": 120
+        },
+        "DefenderOfTheGreaterGood": {
+            "baseMultiplier": 108
+        },
+        "Fragstorm": {
+            "baseMultiplier": 130
+        },
+        "RapidFire": {
+            "baseMultiplier": 80
+        },
+        "PowerUp_Armor": {
+            "baseMultiplier": 80
+        },
+        "PowerUp_Damage": {
+            "baseMultiplier": 80
+        },
+        "PowerUp_Health": {
+            "baseMultiplier": 80
+        },
+        "PowerUp_Hits": {
+            "baseMultiplier": 80
+        },
+        "PowerUp_ReactivateAbility": {
+            "baseMultiplier": 80
+        },
+        "PowerUp_Healing": {
+            "baseMultiplier": 80
+        },
+        "PowerUp_MeleeHits": {
+            "baseMultiplier": 80
+        },
+        "PowerUp_Reinforcement": {
+            "baseMultiplier": 80
+        },
+        "PowerUp_ReinforcementShield": {
+            "baseMultiplier": 80
+        },
+        "PowerUp_Resurrect": {
+            "baseMultiplier": 80
+        },
+        "PowerUp_Bomb": {
+            "baseMultiplier": 80
+        },
+        "PowerUp_HeroSpawn_VexilusPraetor": {
+            "baseMultiplier": 80
+        },
+        "PowerUp_HeroSpawn_BladeChampion": {
+            "baseMultiplier": 80
+        },
+        "PowerUp_HeroSpawn_Uthar": {
+            "baseMultiplier": 80
+        },
+        "PowerUp_HeroSpawn:Uthar": {
+            "baseMultiplier": 80
+        },
+        "PowerUp_SummonSpawn_ultraSmnInceptor": {
+            "baseMultiplier": 80
+        },
+        "PowerUp_SummonSpawn_ultraSmnHeavyIntercessor": {
+            "baseMultiplier": 80
+        },
+        "PowerUp_SummonSpawn_templSmnAggressor": {
+            "baseMultiplier": 80
+        },
+        "PowerUp_SummonSpawn_bloodSmnIntercessor": {
+            "baseMultiplier": 80
+        },
+        "PowerUp_SummonSpawn_darkaSmnHellblaster": {
+            "baseMultiplier": 80
+        },
+        "PowerUp_SummonSpawn_darkaSmnTerminator": {
+            "baseMultiplier": 80
+        },
+        "PowerUp_SummonSpawn_necroSmnWarrior": {
+            "baseMultiplier": 80
+        },
+        "PowerUp_SummonSpawn_necroSmnFlayedOne": {
+            "baseMultiplier": 80
+        },
+        "PowerUp_SummonSpawn_necroSmnDeathmark": {
+            "baseMultiplier": 80
+        },
+        "PowerUp_SummonSpawn_necroSmnDestroyer": {
+            "baseMultiplier": 80
+        },
+        "PowerUp_SummonSpawn_necroSmnSwarm": {
+            "baseMultiplier": 80
+        },
+        "Player_SummonSpawn:astraSmnGuardsman": {
+            "baseMultiplier": 80
+        },
+        "EnvCapturePointShield": {
+            "baseMultiplier": 80
+        },
+        "HellfireShells": {
+            "baseMultiplier": 110
+        },
+        "FiringPosition": {
+            "baseMultiplier": 105
+        },
+        "NeedsMoreDakka": {
+            "baseMultiplier": 200
+        },
+        "DaGreatWaaagh": {
+            "baseMultiplier": 200
+        },
+        "EreWeGo": {
+            "baseMultiplier": 200
+        },
+        "ProperKilly": {
+            "baseMultiplier": 200
+        },
+        "ProphetOfGorkAndMork": {
+            "baseMultiplier": 200
+        },
+        "DaBossIsWatchin": {
+            "baseMultiplier": 200
+        },
+        "UnbridledCarnageReworked": {
+            "baseMultiplier": 150
+        },
+        "BigBadaBoomReworked": {
+            "baseMultiplier": 100
+        },
+        "Split": {
+            "baseMultiplier": 300
+        },
+        "FlamesOfMutation": {
+            "baseMultiplier": 100
+        },
+        "TimeFlux": {
+            "baseMultiplier": 90
+        },
+        "AllIsDust": {
+            "baseMultiplier": 100
+        },
+        "HellfyreMissileRack": {
+            "baseMultiplier": 100
+        },
+        "SlashingDive": {
+            "baseMultiplier": 100
+        },
+        "MasterOfTheTutelaries": {
+            "baseMultiplier": 145
+        },
+        "InfernalPacts": {
+            "baseMultiplier": 100
+        },
+        "SorcerousFacade": {
+            "baseMultiplier": 140
+        },
+        "RealityUnbound": {
+            "baseMultiplier": 110
+        },
+        "AttemptedPossession": {
+            "baseMultiplier": 100
+        },
+        "ArcaneShield": {
+            "baseMultiplier": 75
+        },
+        "Doombolt": {
+            "baseMultiplier": 100
+        },
+        "PsychicStalk": {
+            "baseMultiplier": 80
+        },
+        "HeavyWarpFlamer": {
+            "baseMultiplier": 100
+        },
+        "PropheticSentinel": {
+            "baseMultiplier": 100
+        },
+        "TzeentchsFirestorm": {
+            "baseMultiplier": 100
+        },
+        "TreasonOfTzeentch": {
+            "baseMultiplier": 100
+        },
+        "BladeOfMagnus": {
+            "baseMultiplier": 100
+        },
+        "GazeOfMagnus": {
+            "baseMultiplier": 100
+        },
+        "PsychicDominion": {
+            "baseMultiplier": 100
+        },
+        "ImpossibleForm": {
+            "baseMultiplier": 100
+        },
+        "IllusionsOfTzeentch": {
+            "baseMultiplier": 100
+        },
+        "ScreamerInvocation": {
+            "baseMultiplier": 100
+        },
+        "GreatFrostAxe": {
+            "baseMultiplier": 130
+        },
+        "SavageKiller": {
+            "baseMultiplier": 110
+        },
+        "GrapnelLauncher": {
+            "baseMultiplier": 125
+        },
+        "HuntersBeyondDeath": {
+            "baseMultiplier": 105
+        },
+        "Foehammer": {
+            "baseMultiplier": 100
+        },
+        "AnvilShield": {
+            "baseMultiplier": 100
+        },
+        "WarHowl": {
+            "baseMultiplier": 100
+        },
+        "SagaOfTheWarriorBorn": {
+            "baseMultiplier": 100
+        },
+        "Stormcaller": {
+            "baseMultiplier": 100
+        },
+        "LordOfTempests": {
+            "baseMultiplier": 100
+        },
+        "MortarionsPlagueWind": {
+            "baseMultiplier": 200
+        },
+        "TheLantern": {
+            "baseMultiplier": 200
+        },
+        "ReapingScythe": {
+            "baseMultiplier": 200
+        },
+        "ArchContaminator": {
+            "baseMultiplier": 200
+        },
+        "HostOfPlagues": {
+            "baseMultiplier": 200
+        },
+        "RevoltinglyResilient": {
+            "baseMultiplier": 200
+        },
+        "TheWrathfulDead": {
+            "baseMultiplier": 150
+        },
+        "DarkTalonStrike": {
+            "baseMultiplier": 100
+        },
+        "LionHelm": {
+            "baseMultiplier": 80
+        },
+        "Supercharge": {
+            "baseMultiplier": 95
+        },
+        "GrimRetribution": {
+            "baseMultiplier": 85
+        },
+        "ExemplarOfHate": {
+            "baseMultiplier": 100
+        },
+        "FearedInterrogator": {
+            "baseMultiplier": 85
+        },
+        "PlasmaCannon": {
+            "baseMultiplier": 110
+        },
+        "Deathwing": {
+            "baseMultiplier": 100
+        },
+        "DeathwingKnight": {
+            "baseMultiplier": 100
+        },
+        "SternguardFocus": {
+            "baseMultiplier": 100
+        },
+        "SpecialIssueCombiMelta": {
+            "baseMultiplier": 100
+        },
+        "PlasmaGrenade": {
+            "baseMultiplier": 115
+        },
+        "BattleFocus": {
+            "baseMultiplier": 90
+        },
+        "Reveal": {
+            "baseMultiplier": 80
+        },
+        "Conceal": {
+            "baseMultiplier": 100
+        },
+        "KissOfDeath": {
+            "baseMultiplier": 120
+        },
+        "HarlequinsPanoply": {
+            "baseMultiplier": 90
+        },
+        "CrushingClaws": {
+            "baseMultiplier": 100
+        },
+        "GuardianOrganism": {
+            "baseMultiplier": 110
+        },
+        "AlphaWarrior": {
+            "baseMultiplier": 110
+        },
+        "SynapticLinchpin": {
+            "baseMultiplier": 110
+        },
+        "SynapticInsight": {
+            "baseMultiplier": 100
+        },
+        "SpiritLeech": {
+            "baseMultiplier": 100
+        },
+        "Neuroparasite": {
+            "baseMultiplier": 152
+        },
+        "DeathScream": {
+            "baseMultiplier": 100
+        },
+        "UnparalleledFerocity": {
+            "baseMultiplier": 100
+        },
+        "LivingBatteringRam": {
+            "baseMultiplier": 100
+        },
+        "AdrenalSurge": {
+            "baseMultiplier": 100
+        },
+        "BlisteringAssault": {
+            "baseMultiplier": 100
+        },
+        "HyperAggression": {
+            "baseMultiplier": 100
+        },
+        "VulnerableToMelee": {
+            "baseMultiplier": 100
+        },
+        "VulnerableToFlameAndBlast": {
+            "baseMultiplier": 100
+        },
+        "FeederTendrils": {
+            "baseMultiplier": 100
+        },
+        "FearOfTheUnseen": {
+            "baseMultiplier": 125
+        },
+        "ItItches": {
+            "baseMultiplier": 150
+        },
+        "BarbedOvipositor": {
+            "baseMultiplier": 125
+        },
+        "DefendTheDivineWork": {
+            "baseMultiplier": 110
+        },
+        "GalvanicField": {
+            "baseMultiplier": 150
+        },
+        "RadBombardment": {
+            "baseMultiplier": 125
+        },
+        "MasterAnnihilator": {
+            "baseMultiplier": 125
+        },
+        "DoctrinaImperatives": {
+            "baseMultiplier": 140
+        },
+        "ControlEdict": {
+            "baseMultiplier": 144
+        },
+        "RadSaturation": {
+            "baseMultiplier": 80
+        },
+        "CordClaw": {
+            "baseMultiplier": 100
+        },
+        "OptimizedGait": {
+            "baseMultiplier": 180
+        },
+        "SentinelDirectives": {
+            "baseMultiplier": 125
+        },
+        "HeavyGravCannon": {
+            "baseMultiplier": 100
+        },
+        "PoundThemToDust": {
+            "baseMultiplier": 100
+        },
+        "GunnersKillOnSight": {
+            "baseMultiplier": 100
+        },
+        "ArmouredMight": {
+            "baseMultiplier": 100
+        },
+        "WeakerRearArmour": {
+            "baseMultiplier": 100
+        },
+        "AblativePlating": {
+            "baseMultiplier": 100
+        },
+        "Reinforcements": {
+            "baseMultiplier": 100
+        },
+        "FieldsOfFire": {
+            "baseMultiplier": 100
+        },
+        "BloodyFury": {
+            "baseMultiplier": 80
+        },
+        "WrathfulDevotion": {
+            "baseMultiplier": 110
+        },
+        "JakhalStimms": {
+            "baseMultiplier": 125
+        },
+        "Skullsmasher": {
+            "baseMultiplier": 160
+        },
+        "KillMaimBurn": {
+            "baseMultiplier": 100
+        },
+        "TheBetrayer": {
+            "baseMultiplier": 100
+        },
+        "MurderousSwing": {
+            "baseMultiplier": 125
+        },
+        "TrophyTaker": {
+            "baseMultiplier": 90
+        },
+        "OverwhelmingWrath": {
+            "baseMultiplier": 100
+        },
+        "BeaconOfRage": {
+            "baseMultiplier": 100
+        },
+        "EchoesFromTheWarp": {
+            "baseMultiplier": 100
+        },
+        "WarConstruct": {
+            "baseMultiplier": 100
+        },
+        "Wraithcannon": {
+            "baseMultiplier": 150
+        },
+        "TheWailingDoomSweeps": {
+            "baseMultiplier": 100
+        },
+        "TheWailingDoomStrikes": {
+            "baseMultiplier": 100
+        },
+        "TheWrathOfKhaineUnleashed": {
+            "baseMultiplier": 100
+        },
+        "TheWrathOfKhaineUnleashedReworked": {
+            "baseMultiplier": 100
+        },
+        "MoltenForm": {
+            "baseMultiplier": 100
+        },
+        "TheBloodyHanded": {
+            "baseMultiplier": 100
+        },
+        "BloodRunsAngerRisesWarCalls": {
+            "baseMultiplier": 100
+        },
+        "BloodRunsAngerRisesWarCallsReworked": {
+            "baseMultiplier": 100
+        },
+        "TheWildHost": {
+            "baseMultiplier": 100
+        },
+        "Phantasm": {
+            "baseMultiplier": 100
+        },
+        "MalleusRocketLauncher": {
+            "baseMultiplier": 100
+        },
+        "ForwardSpotter": {
+            "baseMultiplier": 100
+        },
+        "HadesAutocannons": {
+            "baseMultiplier": 100
+        },
+        "DaemonicOrdnance": {
+            "baseMultiplier": 100
+        },
+        "BioMinefield": {
+            "baseMultiplier": 100
+        },
+        "SporeMineLauncher": {
+            "baseMultiplier": 100
+        },
+        "BossAdjutant": {
+            "baseMultiplier": 100
+        },
+        "FloatingDeath": {
+            "baseMultiplier": 100
+        },
+        "TheQuickening": {
+            "baseMultiplier": 100
+        },
+        "FuryOfTheAncients": {
+            "baseMultiplier": 100
+        },
+        "HammerOfWrath": {
+            "baseMultiplier": 100
+        },
+        "AggressiveOnslaught": {
+            "baseMultiplier": 140
+        },
+        "BlackRage": {
+            "baseMultiplier": 100
+        },
+        "VisionsOfHeresy": {
+            "baseMultiplier": 100
+        },
+        "RedThirst": {
+            "baseMultiplier": 100
+        },
+        "BloodChalice": {
+            "baseMultiplier": 100
+        },
+        "SanguinaryPriest": {
+            "baseMultiplier": 120
+        },
+        "LightOfSanguinius": {
+            "baseMultiplier": 100
+        },
+        "LordOfTheHost": {
+            "baseMultiplier": 100
+        },
+        "SavageEchoes": {
+            "baseMultiplier": 100
+        },
+        "RedRampage": {
+            "baseMultiplier": 100
+        },
+        "DutyEternal": {
+            "baseMultiplier": 100
+        },
+        "MacroPlasmaIncinerator": {
+            "baseMultiplier": 100
+        },
+        "AncientFury": {
+            "baseMultiplier": 100
+        },
+        "TacticalPrecision": {
+            "baseMultiplier": 100
+        },
+        "FuelledByFury": {
+            "baseMultiplier": 125
+        },
+        "HeavyRailRifle": {
+            "baseMultiplier": 100
+        },
+        "TwinSmartMissileSystem": {
+            "baseMultiplier": 100
+        },
+        "MindControl": {
+            "baseMultiplier": 100
+        },
+        "SpiritualLeader": {
+            "baseMultiplier": 100
+        },
+        "MightFromBelow": {
+            "baseMultiplier": 100
+        },
+        "CosmicHorror": {
+            "baseMultiplier": 100
+        },
+        "Hypermorph": {
+            "baseMultiplier": 100
+        },
+        "AberrantHypermorph": {
+            "baseMultiplier": 130
+        },
+        "TwistedScience": {
+            "baseMultiplier": 100
+        },
+        "CultDemagogue": {
+            "baseMultiplier": 100
+        },
+        "DecoysAndMisdirection": {
+            "baseMultiplier": 100
+        },
+        "HeroicFusillade": {
+            "baseMultiplier": 100
+        },
+        "HypersensoryAbilities": {
+            "baseMultiplier": 100
+        },
+        "EntropyCannons": {
+            "baseMultiplier": 100
+        },
+        "PlagueburstMortar": {
+            "baseMultiplier": 100
+        },
+        "VengeanceForTheOmnissiah": {
+            "baseMultiplier": 100
+        },
+        "OmnissiahsBlessing": {
+            "baseMultiplier": 100
+        },
+        "VoltagheistField": {
+            "baseMultiplier": 100
+        },
+        "ElectroShock": {
+            "baseMultiplier": 100
+        },
+        "ExplosivePresents": {
+            "baseMultiplier": 100
+        },
+        "DaRevolushun": {
+            "baseMultiplier": 100
+        },
+        "Bounce": {
+            "baseMultiplier": 100
+        },
+        "PriorityReclamation": {
+            "baseMultiplier": 100
+        },
+        "RadZoneCorps": {
+            "baseMultiplier": 100
+        },
+        "InvocationOfMachineVengeance": {
+            "baseMultiplier": 100
+        },
+        "ArcScourge": {
+            "baseMultiplier": 100
+        },
+        "SolarAtomizer": {
+            "baseMultiplier": 100
+        },
+        "SelfRepairMechanism": {
+            "baseMultiplier": 100
+        },
+        "SelfRepairMechanismReworked": {
+            "baseMultiplier": 100
+        },
+        "ShroudPsalm": {
+            "baseMultiplier": 100
+        },
+        "PreCalibratedPurgeSolution": {
+            "baseMultiplier": 100
+        },
+        "EnvSquigSmash": {
+            "baseMultiplier": 100
+        },
+        "BlightGrenades": {
+            "baseMultiplier": 100
+        },
+        "CloudOfFlies": {
+            "baseMultiplier": 100
+        },
+        "VexillaMagnifica": {
+            "baseMultiplier": 100
+        },
+        "StandVigil": {
+            "baseMultiplier": 100
+        },
+        "MomentShackle": {
+            "baseMultiplier": 100
+        },
+        "LegendaryCommander": {
+            "baseMultiplier": 105
+        },
+        "EnhancementLifeSteal": {
+            "baseMultiplier": 100
+        },
+        "EnhancementHitBoost": {
+            "baseMultiplier": 100
+        },
+        "EnhancementCritBoost": {
+            "baseMultiplier": 100
+        },
+        "EnhancementDamageBoost": {
+            "baseMultiplier": 100
+        },
+        "EnhancementSummonHarlequin": {
+            "baseMultiplier": 100
+        },
+        "EnhancementSummonHavoc": {
+            "baseMultiplier": 100
+        },
+        "EnhancementSummonWarrior": {
+            "baseMultiplier": 100
+        },
+        "EnhancementRegeneration": {
+            "baseMultiplier": 100
+        },
+        "EnhancementAddTrait:MkXGravis": {
+            "baseMultiplier": 100
+        },
+        "EnhancementAddTrait:RapidAssault": {
+            "baseMultiplier": 100
+        },
+        "EnhancementAddTrait:Resilient": {
+            "baseMultiplier": 100
+        },
+        "EnhancementAddTrait:Infiltrate": {
+            "baseMultiplier": 100
+        },
+        "EnhancementSummon:Harlequin": {
+            "baseMultiplier": 100
+        },
+        "EnhancementSummon:Havoc": {
+            "baseMultiplier": 100
+        },
+        "EnhancementSummon:DeathPlagueMarine": {
+            "baseMultiplier": 100
+        },
+        "EnhancementSummon:Warrior": {
+            "baseMultiplier": 100
+        },
+        "EnhancementSummon:Electropriest": {
+            "baseMultiplier": 100
+        },
+        "EnhancementSummon:Eliminator": {
+            "baseMultiplier": 100
+        },
+        "EnhancementSummon:Inceptor": {
+            "baseMultiplier": 100
+        },
+        "EnhancementPierceBoost": {
+            "baseMultiplier": 100
+        },
+        "ForwardObservers": {
+            "baseMultiplier": 100
+        },
+        "WallOfMirrors": {
+            "baseMultiplier": 100
+        },
+        "EnvFactionSummons:AdeptusMechanicus": {
+            "baseMultiplier": 100
+        },
+        "EnvFactionSummons:Aeldari": {
+            "baseMultiplier": 100
+        },
+        "EnvFactionSummons:AstraMilitarum": {
+            "baseMultiplier": 100
+        },
+        "EnvFactionSummons:BlackLegion": {
+            "baseMultiplier": 100
+        },
+        "EnvFactionSummons:BlackTemplars": {
+            "baseMultiplier": 100
+        },
+        "EnvFactionSummons:Custodes": {
+            "baseMultiplier": 100
+        },
+        "EnvFactionSummons:DarkAngels": {
+            "baseMultiplier": 100
+        },
+        "EnvFactionSummons:DeathGuard": {
+            "baseMultiplier": 100
+        },
+        "EnvFactionSummons:EmperorsChildren": {
+            "baseMultiplier": 100
+        },
+        "EnvFactionSummons:Genestealers": {
+            "baseMultiplier": 100
+        },
+        "EnvFactionSummons:LeaguesOfVotann": {
+            "baseMultiplier": 100
+        },
+        "EnvFactionSummons:Necrons": {
+            "baseMultiplier": 100
+        },
+        "EnvFactionSummons:Sisterhood": {
+            "baseMultiplier": 100
+        },
+        "EnvFactionSummons:SpaceWolves": {
+            "baseMultiplier": 100
+        },
+        "EnvFactionSummons:ThousandSons": {
+            "baseMultiplier": 100
+        },
+        "EnvFactionSummons:Tyranids": {
+            "baseMultiplier": 100
+        },
+        "EnvFactionSummons:Ultramarines": {
+            "baseMultiplier": 100
+        },
+        "EnvFactionSummons:WorldEaters": {
+            "baseMultiplier": 100
+        },
+        "EnvFactionSummons:ArmageddonAstra": {
+            "baseMultiplier": 100
+        },
+        "EnvFactionSummons:ArmageddonBA": {
+            "baseMultiplier": 100
+        },
+        "EnvFactionSummons:ArmageddonBT": {
+            "baseMultiplier": 100
+        },
+        "EnvFactionSummons:ArmageddonOrks": {
+            "baseMultiplier": 100
+        },
+        "EnvFactionSummons:ArmageddonSW": {
+            "baseMultiplier": 100
+        },
+        "EnvFactionSummons:ArmageddonUM": {
+            "baseMultiplier": 100
+        },
+        "EnvFactionSummons:ArmageddonWE": {
+            "baseMultiplier": 100
+        },
+        "ThriceBlessedConflagration": {
+            "baseMultiplier": 100
+        },
+        "DevastatingRefrain": {
+            "baseMultiplier": 100
+        },
+        "CalibaniteGreatsword": {
+            "baseMultiplier": 110
+        },
+        "EnmityForTheUnworthy": {
+            "baseMultiplier": 100
+        },
+        "TalonsOfTheEmperor": {
+            "baseMultiplier": 100
+        },
+        "DaughterOfTheAbyss": {
+            "baseMultiplier": 100
+        },
+        "MartialInspiration": {
+            "baseMultiplier": 100
+        },
+        "LegacyOfCombat": {
+            "baseMultiplier": 105
+        },
+        "EnvAllyAndEnemyNpcs:WarpSurge": {
+            "baseMultiplier": 100
+        },
+        "EnvStatBoost:WarpSurge": {
+            "baseMultiplier": 100
+        },
+        "EnvStatBoost:FactionBoost_SpaceWolves": {
+            "baseMultiplier": 100
+        },
+        "EnvStatBoost:FactionBoost_AdeptusMechanicus": {
+            "baseMultiplier": 100
+        },
+        "EnvStatBoost:FactionBoost_DarkAngels": {
+            "baseMultiplier": 100
+        },
+        "EnvStatBoost:FactionBoost_BloodAngels": {
+            "baseMultiplier": 100
+        },
+        "EnvStatBoost:FactionBoost_Orks": {
+            "baseMultiplier": 100
+        },
+        "EnvStatBoost:TraitBoost_Flying": {
+            "baseMultiplier": 100
+        },
+        "EnvStatBoost:TraitBoost_Psyker": {
+            "baseMultiplier": 100
+        },
+        "EnvStatBoost:TraitBoost_RapidAssault": {
+            "baseMultiplier": 100
+        },
+        "EnvStatBoost:TraitBoost_TerminatorArmour": {
+            "baseMultiplier": 100
+        },
+        "EnvStrategicBuff:Killzone": {
+            "baseMultiplier": 100
+        },
+        "EnvStrategicBuff:PowerMatrix": {
+            "baseMultiplier": 100
+        },
+        "LashOfTorment": {
+            "baseMultiplier": 100
+        },
+        "ArmourOfShriekingSouls": {
+            "baseMultiplier": 100
+        },
+        "ExcruciatingFrequencies": {
+            "baseMultiplier": 100
+        },
+        "TerrifyingCrescendo": {
+            "baseMultiplier": 100
+        },
+        "EuphoricStrikes": {
+            "baseMultiplier": 100
+        },
+        "RefusalToBeOutdone": {
+            "baseMultiplier": 200
+        },
+        "DoomSiren": {
+            "baseMultiplier": 100
+        },
+        "ObsessiveAnnunciation": {
+            "baseMultiplier": 100
+        },
+        "DaemonicPatrons": {
+            "baseMultiplier": 100
+        },
+        "EcstaticSlaughter": {
+            "baseMultiplier": 100
+        },
+        "NovaBoost": {
+            "baseMultiplier": 100
+        },
+        "NovaCharge": {
+            "baseMultiplier": 100
+        },
+        "NovaShield": {
+            "baseMultiplier": 100
+        },
+        "MultiTracker": {
+            "baseMultiplier": 100
+        },
+        "TargetLock": {
+            "baseMultiplier": 100
+        },
+        "ATemptingTrap": {
+            "baseMultiplier": 100
+        },
+        "PinpointCounterOffensive": {
+            "baseMultiplier": 100
+        },
+        "MischiefMakers": {
+            "baseMultiplier": 100
+        },
+        "EmbodiedProphecy": {
+            "baseMultiplier": 100
+        },
+        "HuntersInstincts": {
+            "baseMultiplier": 100
+        },
+        "testRelicAbility": {
+            "baseMultiplier": 100
+        },
+        "KardiocoreGalvanus": {
+            "baseMultiplier": 100
+        },
+        "PhoenixGem": {
+            "baseMultiplier": 100
+        },
+        "RelicOfLostCadia": {
+            "baseMultiplier": 100
+        },
+        "BookOfFate": {
+            "baseMultiplier": 100
+        },
+        "TalismanOfRage": {
+            "baseMultiplier": 100
+        },
+        "NetherRealmCasket": {
+            "baseMultiplier": 100
+        },
+        "IntoxicatingElixir": {
+            "baseMultiplier": 100
+        },
+        "AmuletOfTheVoidwyrm": {
+            "baseMultiplier": 100
+        },
+        "OrbsOfDecay": {
+            "baseMultiplier": 100
+        },
+        "RelicPowerFist": {
+            "baseMultiplier": 100
+        },
+        "RelicBoltPistol": {
+            "baseMultiplier": 100
+        },
+        "SupaCyborkBody": {
+            "baseMultiplier": 100
+        },
+        "MawClawsOfThyrax": {
+            "baseMultiplier": 100
+        },
+        "DaemonfleshPlate": {
+            "baseMultiplier": 100
+        },
+        "SabreOfSacrifice": {
+            "baseMultiplier": 100
+        },
+        "Vitarus": {
+            "baseMultiplier": 100
+        },
+        "TheArdentBlade": {
+            "baseMultiplier": 100
+        },
+        "Dw02AdvancedBurstCannon": {
+            "baseMultiplier": 100
+        },
+        "TalonOfHorus": {
+            "baseMultiplier": 100
+        },
+        "Maugetar": {
+            "baseMultiplier": 100
+        },
+        "ParagonSpear": {
+            "baseMultiplier": 100
+        },
+        "NornCrown": {
+            "baseMultiplier": 100
+        },
+        "DawnBlade": {
+            "baseMultiplier": 100
+        },
+        "WyrdmakersHelm": {
+            "baseMultiplier": 100
+        },
+        "BladeOfTheAncestors": {
+            "baseMultiplier": 100
+        },
+        "VolummsMasterArtifice": {
+            "baseMultiplier": 100
+        },
+        "MonsterSlayerOfCaliban": {
+            "baseMultiplier": 100
+        },
+        "Lakrimae": {
+            "baseMultiplier": 100
+        },
+        "HeadwoppasKillchoppa": {
+            "baseMultiplier": 100
+        },
+        "ChaliceOfBaal": {
+            "baseMultiplier": 100
+        },
+        "PhasalSubjugator": {
+            "baseMultiplier": 100
+        },
+        "Helspear": {
+            "baseMultiplier": 100
+        },
+        "BlightedLand": {
+            "baseMultiplier": 100
+        },
+        "ContemptuousDisregard": {
+            "baseMultiplier": 100
+        },
+        "WisdomOfTheAncients": {
+            "baseMultiplier": 100
+        },
+        "ShieldOfFaith": {
+            "baseMultiplier": 100
+        },
+        "OnMyPosition": {
+            "baseMultiplier": 100
+        },
+        "MoreGitzOverEre": {
+            "baseMultiplier": 100
+        },
+        "ElectrochaffBackups": {
+            "baseMultiplier": 100
+        },
+        "HyperCorrosiveAcid": {
+            "baseMultiplier": 100
+        },
+        "CabalOfSorcerers": {
+            "baseMultiplier": 100
+        },
+        "MastersOfManoeuvre": {
+            "baseMultiplier": 100
+        },
+        "SquigLaunchas": {
+            "baseMultiplier": 100
+        },
+        "SquigMine": {
+            "baseMultiplier": 100
+        },
+        "VigilanceEternal": {
+            "baseMultiplier": 100
+        },
+        "UnwaveringSentinel": {
+            "baseMultiplier": 105
+        },
+        "LeadingTheCharge": {
+            "baseMultiplier": 100
+        },
+        "ToughToKill": {
+            "baseMultiplier": 100
+        },
+        "FragLance": {
+            "baseMultiplier": 100
+        },
+        "BossEndFightUndefeated": {
+            "baseMultiplier": 100
+        },
+        "ExemplarOfTheMontka": {
+            "baseMultiplier": 105
+        },
+        "WayOfTheShortBlade": {
+            "baseMultiplier": 100
+        },
+        "AetherStride": {
+            "baseMultiplier": 100
+        },
+        "InfernalCannon": {
+            "baseMultiplier": 100
+        },
+        "HunterOfSouls": {
+            "baseMultiplier": 100
+        },
+        "RitesOfMorkai": {
+            "baseMultiplier": 100
+        },
+        "HealingBalms": {
+            "baseMultiplier": 100
+        },
+        "AncestralFortune": {
+            "baseMultiplier": 100
+        },
+        "GrimEfficiency": {
+            "baseMultiplier": 100
+        },
+        "GravitonRifle": {
+            "baseMultiplier": 100
+        },
+        "EcogSupport": {
+            "baseMultiplier": 100
+        },
+        "RepairEnthusiast": {
+            "baseMultiplier": 100
+        },
+        "IronkinSteeljack": {
+            "baseMultiplier": 150
+        },
+        "PredictiveGuidance": {
+            "baseMultiplier": 150
+        },
+        "PurgeResponse": {
+            "baseMultiplier": 100
+        },
+        "AugmentedAssault": {
+            "baseMultiplier": 100
+        },
+        "FuryFromTheDelve": {
+            "baseMultiplier": 100
+        },
+        "MassDriverAccelerator": {
+            "baseMultiplier": 100
+        },
+        "ModifiedExoarmour": {
+            "baseMultiplier": 100
+        },
+        "StrikeFromTheShadows": {
+            "baseMultiplier": 100
+        },
+        "HaywireMine": {
+            "baseMultiplier": 100
+        },
+        "HaywireMineSteppable": {
+            "baseMultiplier": 100
+        },
+        "TitanhammerSquad": {
+            "baseMultiplier": 100
+        },
+        "IconOfObstinacy": {
+            "baseMultiplier": 100
+        },
+        "TotalObliteration": {
+            "baseMultiplier": 100
+        },
+        "CrucibleOfBattle": {
+            "baseMultiplier": 100
+        },
+        "DeathOnTheWind": {
+            "baseMultiplier": 100
+        },
+        "Hailstrike": {
+            "baseMultiplier": 100
+        },
+        "InstrumentsOfVengeance": {
+            "baseMultiplier": 100
+        },
+        "MartialExemplar": {
+            "baseMultiplier": 100
+        },
+        "TheLionsWrath": {
+            "baseMultiplier": 100
+        },
+        "PrimarchOfTheFirstLegion": {
+            "baseMultiplier": 100
+        },
+        "Fealty": {
+            "baseMultiplier": 100
+        },
+        "TheEmperorsShield": {
+            "baseMultiplier": 100
+        },
+        "NoHidingFromTheWatchers": {
+            "baseMultiplier": 100
+        },
+        "WatchedOver": {
+            "baseMultiplier": 100
+        },
+        "RedemptionOfTheRisen": {
+            "baseMultiplier": 100
+        },
+        "HuntTheFallen": {
+            "baseMultiplier": 100
+        }
+    },
+    "traitPowerModifiers": {
+        "Flying": 108,
+        "HeavyWeapon": 106,
+        "Overwatch": 115,
+        "Infiltrate": 110,
+        "Healer": 105,
+        "Psyker": 125,
+        "LivingMetal": 110,
+        "Explodes": 101,
+        "Terrifying": 115,
+        "Mechanical": 95,
+        "ActOfFaith": 103,
+        "Summon": 100,
+        "Resilient": 118,
+        "SuppressiveFire": 104,
+        "IndirectFire": 106,
+        "DeathToTheFalseEmperor": 101,
+        "Swarm": 105,
+        "MkXGravis": 128,
+        "FinalJustice": 105,
+        "InstinctiveBehaviour": 70,
+        "Emplacement": 108,
+        "BattleFatigue": 80,
+        "TwoManTeam": 104,
+        "BigTarget": 102,
+        "Daemon": 102,
+        "TeleportStrike": 105,
+        "Synapse": 102,
+        "ShadowInTheWarp": 102,
+        "Boss": 100,
+        "Immune": 106,
+        "ContagionsOfNurgle": 106,
+        "PutridExplosion": 102,
+        "Dakka": 125,
+        "Mechanic": 103,
+        "Mounted": 102,
+        "BeastSnagga": 106,
+        "BeastSlayer": 106,
+        "Parry": 103,
+        "Diminutive": 105,
+        "Vehicle": 101,
+        "Impervious": 300,
+        "Steppable": 10,
+        "Object": 50,
+        "NonAttacking": 30,
+        "Hero": 100,
+        "CloseCombatWeakness": 85,
+        "Camouflage": 105,
+        "TerminatorArmour": 105,
+        "Invincible": 100,
+        "BossAdjutant": 125,
+        "Unstoppable": 102,
+        "WeaverOfFate": 105,
+        "CounterCharge": 100,
+        "CrushingStrike": 100,
+        "RapidAssault": 100,
+        "BlessingsOfKhorne": 108,
+        "GetStuckIn": 115,
+        "MachineOfWar": 100,
+        "Ambush": 130,
+        "Decoy": 50,
+        "MartialKatah": 110,
+        "ThrillSeekers": 103,
+        "LetTheGalaxyBurn": 101,
+        "PrioritisedEfficiency": 110,
+        "RangedSpecialist": 105,
+        "PermaDeath": 100
+    }
+}

--- a/src/fsd/4-entities/unit/character-power/data/character-power-upgrades.json
+++ b/src/fsd/4-entities/unit/character-power/data/character-power-upgrades.json
@@ -1,0 +1,7258 @@
+{
+    "upgHpC001": {
+        "name": "Field Ration",
+        "rarity": "Common",
+        "statType": "hp",
+        "gold": 10
+    },
+    "upgHpC002": {
+        "name": "Minor Bionic Enhancement",
+        "rarity": "Common",
+        "statType": "hp",
+        "gold": 10
+    },
+    "upgHpC003": {
+        "name": "Lesser Reliquary of Protection",
+        "rarity": "Common",
+        "statType": "hp",
+        "gold": 10
+    },
+    "upgHpC004": {
+        "name": "The Iron Phoenix",
+        "rarity": "Common",
+        "statType": "hp",
+        "gold": 10
+    },
+    "upgHpC005": {
+        "name": "The Silver Aquila",
+        "rarity": "Common",
+        "statType": "hp",
+        "gold": 10
+    },
+    "upgHpC006": {
+        "name": "Standard-Issue Tourniquet",
+        "rarity": "Common",
+        "statType": "hp",
+        "gold": 10
+    },
+    "upgHpC007": {
+        "name": "Healing Ointment",
+        "rarity": "Common",
+        "statType": "hp",
+        "gold": 10
+    },
+    "upgHpC008": {
+        "name": "Thick Skin",
+        "rarity": "Common",
+        "statType": "hp",
+        "gold": 10
+    },
+    "upgHpC009": {
+        "name": "Nano Swarm",
+        "rarity": "Common",
+        "statType": "hp",
+        "gold": 10
+    },
+    "upgHpC010": {
+        "name": "Mutation: Warped Muscles",
+        "rarity": "Common",
+        "statType": "hp",
+        "gold": 10
+    },
+    "upgHpC013": {
+        "name": "Chip Damage",
+        "rarity": "Common",
+        "statType": "hp",
+        "gold": 10
+    },
+    "upgHpC014": {
+        "name": "Wires",
+        "rarity": "Common",
+        "statType": "hp",
+        "gold": 10
+    },
+    "upgHpC015": {
+        "name": "Ropes and Chains",
+        "rarity": "Common",
+        "statType": "hp",
+        "gold": 10
+    },
+    "upgHpC016": {
+        "name": "Scrolls",
+        "rarity": "Common",
+        "statType": "hp",
+        "gold": 10
+    },
+    "upgHpC017": {
+        "name": "Mission Assignment",
+        "rarity": "Common",
+        "statType": "hp",
+        "gold": 10
+    },
+    "upgHpU001": {
+        "name": "Enriched Rations",
+        "rarity": "Uncommon",
+        "statType": "hp",
+        "gold": 25
+    },
+    "upgHpU002": {
+        "name": "Reliquary of Protection",
+        "rarity": "Uncommon",
+        "statType": "hp",
+        "gold": 25
+    },
+    "upgHpU003": {
+        "name": "The Silver Scope",
+        "rarity": "Uncommon",
+        "statType": "hp",
+        "gold": 25
+    },
+    "upgHpU004C": {
+        "name": "Bionic Enhancement",
+        "rarity": "Uncommon",
+        "statType": "hp",
+        "gold": 25,
+        "crafting": [
+            {
+                "id": "upgHpC002",
+                "amount": 6
+            }
+        ]
+    },
+    "upgHpU005C": {
+        "name": "First Aid Kit",
+        "rarity": "Uncommon",
+        "statType": "hp",
+        "gold": 25,
+        "crafting": [
+            {
+                "id": "upgHpC007",
+                "amount": 6
+            }
+        ]
+    },
+    "upgHpU006": {
+        "name": "The Gold Phoenix",
+        "rarity": "Uncommon",
+        "statType": "hp",
+        "gold": 25
+    },
+    "upgHpU007": {
+        "name": "Purifier",
+        "rarity": "Uncommon",
+        "statType": "hp",
+        "gold": 25
+    },
+    "upgHpU008": {
+        "name": "The Silver Eagle with Swords",
+        "rarity": "Uncommon",
+        "statType": "hp",
+        "gold": 25
+    },
+    "upgHpU009": {
+        "name": "Mutation: Warped Lungs",
+        "rarity": "Uncommon",
+        "statType": "hp",
+        "gold": 25
+    },
+    "upgHpU010C": {
+        "name": "Regenerating Nano Swarm",
+        "rarity": "Uncommon",
+        "statType": "hp",
+        "gold": 25,
+        "crafting": [
+            {
+                "id": "upgHpC009",
+                "amount": 6
+            }
+        ]
+    },
+    "upgHpU012": {
+        "name": "Helmet Trophy",
+        "rarity": "Uncommon",
+        "statType": "hp",
+        "gold": 25
+    },
+    "upgHpU013": {
+        "name": "Artificial Vertebrae",
+        "rarity": "Uncommon",
+        "statType": "hp",
+        "gold": 25
+    },
+    "upgHpU014": {
+        "name": "Reinforced Cables",
+        "rarity": "Uncommon",
+        "statType": "hp",
+        "gold": 25
+    },
+    "upgHpU015": {
+        "name": "Satchel",
+        "rarity": "Uncommon",
+        "statType": "hp",
+        "gold": 25
+    },
+    "upgHpU016": {
+        "name": "Writings",
+        "rarity": "Uncommon",
+        "statType": "hp",
+        "gold": 25
+    },
+    "upgHpU017": {
+        "name": "Mission Objective",
+        "rarity": "Uncommon",
+        "statType": "hp",
+        "gold": 25
+    },
+    "upgHpU018C": {
+        "name": "Holster and Pockets",
+        "rarity": "Uncommon",
+        "statType": "hp",
+        "gold": 25,
+        "crafting": [
+            {
+                "id": "upgHpC015",
+                "amount": 3
+            },
+            {
+                "id": "upgHpC006",
+                "amount": 3
+            }
+        ]
+    },
+    "upgHpR001": {
+        "name": "Repair Tool",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75
+    },
+    "upgHpR002": {
+        "name": "Metal Decorative Skull",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75
+    },
+    "upgHpR003C": {
+        "name": "Box of Rations",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75,
+        "crafting": [
+            {
+                "id": "upgHpU001",
+                "amount": 5
+            },
+            {
+                "id": "upgHpC001",
+                "amount": 6
+            }
+        ]
+    },
+    "upgHpR004C": {
+        "name": "Refined Bionics",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75,
+        "crafting": [
+            {
+                "id": "upgArmU008",
+                "amount": 5
+            },
+            {
+                "id": "upgDmgC010",
+                "amount": 6
+            }
+        ]
+    },
+    "upgHpR005": {
+        "name": "The Phoenix Ascendant",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75
+    },
+    "upgHpR006C": {
+        "name": "Medical Supply Crate",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75,
+        "crafting": [
+            {
+                "id": "upgDmgU014",
+                "amount": 5
+            },
+            {
+                "id": "upgHpC006",
+                "amount": 6
+            }
+        ]
+    },
+    "upgHpR007": {
+        "name": "Zeidos Ribbon",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75
+    },
+    "upgHpR008": {
+        "name": "Mutation: Warped Heart",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75
+    },
+    "upgHpR009C": {
+        "name": "Otherworldly Nano Swarm",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75,
+        "crafting": [
+            {
+                "id": "upgArmU006",
+                "amount": 5
+            },
+            {
+                "id": "upgHpC009",
+                "amount": 6
+            }
+        ]
+    },
+    "upgHpR010": {
+        "name": "Bad Moon Teef",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75
+    },
+    "upgHpR011": {
+        "name": "Reconstitution Protocols",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75
+    },
+    "upgHpR012C": {
+        "name": "Electromantic Cable Bundle",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75,
+        "crafting": [
+            {
+                "id": "upgHpU014",
+                "amount": 5
+            },
+            {
+                "id": "upgHpC014",
+                "amount": 6
+            }
+        ]
+    },
+    "upgHpR013C": {
+        "name": "Utilitarian Belt",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75,
+        "crafting": [
+            {
+                "id": "upgHpU007",
+                "amount": 5
+            },
+            {
+                "id": "upgHpU018C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpR014": {
+        "name": "Ancient Runes",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75
+    },
+    "upgHpR015C": {
+        "name": "Grand Skull Trophy",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75,
+        "crafting": [
+            {
+                "id": "upgHpU012",
+                "amount": 5
+            },
+            {
+                "id": "upgArmC003",
+                "amount": 4
+            },
+            {
+                "id": "upgHpC013",
+                "amount": 2
+            }
+        ]
+    },
+    "upgHpR016C": {
+        "name": "Grandiloquent Litanical",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75,
+        "crafting": [
+            {
+                "id": "upgHpU016",
+                "amount": 5
+            },
+            {
+                "id": "upgHpC016",
+                "amount": 4
+            },
+            {
+                "id": "upgDmgC013",
+                "amount": 2
+            }
+        ]
+    },
+    "upgHpR017C": {
+        "name": "Battle Plan",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75,
+        "crafting": [
+            {
+                "id": "upgHpU017",
+                "amount": 5
+            },
+            {
+                "id": "upgHpC017",
+                "amount": 6
+            }
+        ]
+    },
+    "upgHpR018": {
+        "name": "Kill Count",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75
+    },
+    "upgHpR019": {
+        "name": "Battle Scar",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75
+    },
+    "upgHpR020C": {
+        "name": "Sanctified Reliquary of Protection",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75,
+        "crafting": [
+            {
+                "id": "upgHpU002",
+                "amount": 5
+            },
+            {
+                "id": "upgHpC003",
+                "amount": 6
+            }
+        ]
+    },
+    "upgHpR043": {
+        "name": "Service Studs",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75
+    },
+    "upgHpR021": {
+        "name": "Righteous Candle",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75
+    },
+    "upgHpR022": {
+        "name": "Rose of Martyrs",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75
+    },
+    "upgHpR023": {
+        "name": "Eye of Horus",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75
+    },
+    "upgHpR024": {
+        "name": "Plague Bell",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75
+    },
+    "upgHpR027": {
+        "name": "Stimm Injector",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75
+    },
+    "upgHpR028": {
+        "name": "Waystone",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75
+    },
+    "upgHpR029": {
+        "name": "Tainted Text",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75
+    },
+    "upgHpR031": {
+        "name": "Wolf Tail Talisman",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75
+    },
+    "upgHpR032": {
+        "name": "Key of Ignorance",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75
+    },
+    "upgHpR033": {
+        "name": "Adrenal Glands",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75
+    },
+    "upgHpR035": {
+        "name": "Bloodstone Tear",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75
+    },
+    "upgHpR036": {
+        "name": "Wyrm-form Sigil",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75
+    },
+    "upgHpR037": {
+        "name": "Flawless Terran Gem",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75
+    },
+    "upgHpR038": {
+        "name": "Brazen Jaws",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75
+    },
+    "upgHpR039": {
+        "name": "Outrageous Padding",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75
+    },
+    "upgHpR040": {
+        "name": "Kindred Weavefield Crest",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75
+    },
+    "upgHpE001C": {
+        "name": "Advanced Bionics",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgDmgR006",
+                "amount": 6
+            },
+            {
+                "id": "upgHpU004C",
+                "amount": 1
+            },
+            {
+                "id": "upgHpU014",
+                "amount": 6
+            }
+        ]
+    },
+    "upgHpE002C": {
+        "name": "Greater Reliquary of Protection",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR005",
+                "amount": 6
+            },
+            {
+                "id": "upgHpU007",
+                "amount": 6
+            },
+            {
+                "id": "upgArmC001",
+                "amount": 6
+            }
+        ]
+    },
+    "upgHpE003": {
+        "name": "Terminator Honours",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215
+    },
+    "upgHpE004C": {
+        "name": "Necrodermis Nano Scarab Swarm",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR009C",
+                "amount": 1
+            },
+            {
+                "id": "upgHpR014",
+                "amount": 4
+            },
+            {
+                "id": "upgArmC005",
+                "amount": 4
+            }
+        ]
+    },
+    "upgHpE005C": {
+        "name": "Nob Teef",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR010",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE006C": {
+        "name": "Exquisite Medical Supplies",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR006C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgR003",
+                "amount": 4
+            },
+            {
+                "id": "upgHpC007",
+                "amount": 4
+            }
+        ]
+    },
+    "upgHpE007C": {
+        "name": "Grand Helmet Trophy",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR015C",
+                "amount": 1
+            },
+            {
+                "id": "upgHpR018",
+                "amount": 4
+            },
+            {
+                "id": "upgDmgC014",
+                "amount": 4
+            }
+        ]
+    },
+    "upgHpE008C": {
+        "name": "Mutation: Regenerative Blood",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR008",
+                "amount": 6
+            },
+            {
+                "id": "upgHpU009",
+                "amount": 6
+            },
+            {
+                "id": "upgHpC010",
+                "amount": 6
+            }
+        ]
+    },
+    "upgHpE009C": {
+        "name": "Resurrection Protocols",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR011",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE011C": {
+        "name": "Royal Phylactery",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR011",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE012": {
+        "name": "Golden Ornamental Skull",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215
+    },
+    "upgHpE013C": {
+        "name": "Exospine",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR012C",
+                "amount": 1
+            },
+            {
+                "id": "upgArmR015",
+                "amount": 4
+            },
+            {
+                "id": "upgArmC011",
+                "amount": 4
+            }
+        ]
+    },
+    "upgHpE014C": {
+        "name": "Ominous Xenos Glyphs",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR014",
+                "amount": 6
+            },
+            {
+                "id": "upgHpU016",
+                "amount": 6
+            },
+            {
+                "id": "upgDmgC008",
+                "amount": 6
+            }
+        ]
+    },
+    "upgHpE015": {
+        "name": "Weathering",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215
+    },
+    "upgHpE017": {
+        "name": "Secret Agenda",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215
+    },
+    "upgHpE020C": {
+        "name": "Honour Markings",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR043",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE021C": {
+        "name": "Lights of Purgation",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR021",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE022C": {
+        "name": "Roses of Sacrifice",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR022",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE025C": {
+        "name": "Epaulettes",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR007",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE023C": {
+        "name": "Warp Touched Eye of Horus",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR023",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE024C": {
+        "name": "Death Bell",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR024",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE027C": {
+        "name": "Advanced Stimm Injector",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR027",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE028C": {
+        "name": "Spirit Stone",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR028",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE029C": {
+        "name": "Malefic Scroll",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR029",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE031C": {
+        "name": "Runic Talisman",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR031",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE032C": {
+        "name": "Key of Knowledge",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR032",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE033C": {
+        "name": "Adaptive Adrenal Glands",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR033",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE034C": {
+        "name": "Servo-Arc Claw",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR001",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE035C": {
+        "name": "Bloodstone Pendant",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR035",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE036C": {
+        "name": "Wyrm-form Icon",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR036",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE037C": {
+        "name": "Flawless Gem Embellishment",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR037",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE038C": {
+        "name": "Blessed Brazen Jaws",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR038",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE039C": {
+        "name": "Outrageous Adornment",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR039",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE040C": {
+        "name": "Champion Weavefield Crest",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR040",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE120C": {
+        "name": "Symbol of the Ultramarines",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR005",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR007",
+                "amount": 9
+            },
+            {
+                "id": "upgArmR005",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE121C": {
+        "name": "Symbol of the Black Templars",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR021",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR021",
+                "amount": 9
+            },
+            {
+                "id": "upgArmR021",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE122C": {
+        "name": "Symbol of the Adepta Sororitas",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR022",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR022",
+                "amount": 9
+            },
+            {
+                "id": "upgArmR022",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE123C": {
+        "name": "Symbol of the Black Legion",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR023",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR023",
+                "amount": 9
+            },
+            {
+                "id": "upgArmR023",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE124C": {
+        "name": "Symbol of the Death Guard",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR024",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR024",
+                "amount": 9
+            },
+            {
+                "id": "upgArmR009",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE125C": {
+        "name": "Symbol of the Astra Militarum",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR007",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR025",
+                "amount": 9
+            },
+            {
+                "id": "upgArmR025",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE126C": {
+        "name": "Symbol of the Orks",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR010",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR026",
+                "amount": 9
+            },
+            {
+                "id": "upgArmR026",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE127C": {
+        "name": "Symbol of the T'au Empire",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR027",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR027",
+                "amount": 9
+            },
+            {
+                "id": "upgArmR027",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE128C": {
+        "name": "Symbol of the Aeldari",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR028",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR028",
+                "amount": 9
+            },
+            {
+                "id": "upgArmR028",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE129C": {
+        "name": "Symbol of the Thousand Sons",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR029",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR029",
+                "amount": 9
+            },
+            {
+                "id": "upgArmR029",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE130C": {
+        "name": "Symbol of the Necrons",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR011",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR009",
+                "amount": 9
+            },
+            {
+                "id": "upgArmR030",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE131C": {
+        "name": "Symbol of the Space Wolves",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR031",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR031",
+                "amount": 9
+            },
+            {
+                "id": "upgArmR031",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE132C": {
+        "name": "Symbol of the Dark Angels",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR032",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR032",
+                "amount": 9
+            },
+            {
+                "id": "upgArmR032",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE133C": {
+        "name": "Symbol of the Tyranids",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR033",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR033",
+                "amount": 9
+            },
+            {
+                "id": "upgArmR033",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE134C": {
+        "name": "Symbol of the Adeptus Mechanicus",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR001",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR034",
+                "amount": 9
+            },
+            {
+                "id": "upgArmR034",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE135C": {
+        "name": "Symbol of the Blood Angels",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR035",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR035",
+                "amount": 9
+            },
+            {
+                "id": "upgArmR035",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE136C": {
+        "name": "Symbol of the Genestealer Cults",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR036",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR036",
+                "amount": 9
+            },
+            {
+                "id": "upgArmR036",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE137C": {
+        "name": "Symbol of the Adeptus Custodes",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR037",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR037",
+                "amount": 9
+            },
+            {
+                "id": "upgArmR037",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE138C": {
+        "name": "Symbol of the World Eaters",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR038",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR038",
+                "amount": 9
+            },
+            {
+                "id": "upgArmR038",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE139C": {
+        "name": "Symbol of the Emperor's Children",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR039",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR039",
+                "amount": 9
+            },
+            {
+                "id": "upgArmR039",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE140C": {
+        "name": "Symbol of the Leagues of Votann",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR040",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR040",
+                "amount": 9
+            },
+            {
+                "id": "upgArmR040",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpE143C": {
+        "name": "Symbol of the Adeptus Astartes",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR043",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR007",
+                "amount": 9
+            },
+            {
+                "id": "upgArmR005",
+                "amount": 9
+            }
+        ]
+    },
+    "upgHpL001C": {
+        "name": "Optimal Bionic Enhancement",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpE001C",
+                "amount": 1
+            },
+            {
+                "id": "upgHpR004C",
+                "amount": 2
+            },
+            {
+                "id": "upgDmgU012",
+                "amount": 2
+            }
+        ]
+    },
+    "upgHpL002C": {
+        "name": "Legendary Reliquary of Protection",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpE002C",
+                "amount": 1
+            },
+            {
+                "id": "upgHpR016C",
+                "amount": 2
+            },
+            {
+                "id": "upgArmU001",
+                "amount": 2
+            }
+        ]
+    },
+    "upgHpL005C": {
+        "name": "Ancient Nano Scarab Swarm",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpE004C",
+                "amount": 2
+            },
+            {
+                "id": "upgHpC009",
+                "amount": 5
+            }
+        ]
+    },
+    "upgHpL006C": {
+        "name": "Shiny Boss Teef",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpE005C",
+                "amount": 2
+            },
+            {
+                "id": "upgHpE014C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpL007C": {
+        "name": "Protocol of the Eternal Guardian",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpE009C",
+                "amount": 2
+            },
+            {
+                "id": "upgHpE014C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpL008C": {
+        "name": "Phylacterine Hive",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL010",
+                "amount": 9
+            },
+            {
+                "id": "upgHpR009C",
+                "amount": 1
+            },
+            {
+                "id": "upgArmE008",
+                "amount": 6
+            }
+        ]
+    },
+    "upgHpL009C": {
+        "name": "Grandiose Skull Ornament",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpE012",
+                "amount": 5
+            },
+            {
+                "id": "upgArmR012C",
+                "amount": 1
+            },
+            {
+                "id": "upgHpR015C",
+                "amount": 2
+            }
+        ]
+    },
+    "upgHpL010": {
+        "name": "Engrammatic Entangler",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650
+    },
+    "upgHpL011C": {
+        "name": "Tome of Arcane Knowledge",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgE010",
+                "amount": 5
+            },
+            {
+                "id": "upgHpR016C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgR14C",
+                "amount": 2
+            }
+        ]
+    },
+    "upgHpL012C": {
+        "name": "Mutation: Otherworldly Power",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpE008C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgR016C",
+                "amount": 2
+            },
+            {
+                "id": "upgHpU009",
+                "amount": 2
+            }
+        ]
+    },
+    "upgHpL013C": {
+        "name": "Advanced Exospine",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpE013C",
+                "amount": 1
+            },
+            {
+                "id": "upgHpR006C",
+                "amount": 2
+            },
+            {
+                "id": "upgArmU014",
+                "amount": 2
+            }
+        ]
+    },
+    "upgHpL014C": {
+        "name": "Portentous Xenos Glyphs",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpE014C",
+                "amount": 1
+            },
+            {
+                "id": "upgHpR017C",
+                "amount": 2
+            },
+            {
+                "id": "upgArmU006",
+                "amount": 2
+            }
+        ]
+    },
+    "upgHpL017C": {
+        "name": "Grand Strategy",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpE017",
+                "amount": 5
+            },
+            {
+                "id": "upgHpR017C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgR001C",
+                "amount": 2
+            }
+        ]
+    },
+    "upgHpL020C": {
+        "name": "Honorifics of Command",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpE020C",
+                "amount": 2
+            },
+            {
+                "id": "upgHpE002C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpL021C": {
+        "name": "Candelabrum of Burning Wrath",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpE021C",
+                "amount": 2
+            },
+            {
+                "id": "upgHpE002C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpL022C": {
+        "name": "Roses of the Divine",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpE022C",
+                "amount": 2
+            },
+            {
+                "id": "upgHpE002C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpL025C": {
+        "name": "Epaulettes of Renown",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpE025C",
+                "amount": 2
+            },
+            {
+                "id": "upgHpE002C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpL023C": {
+        "name": "Infernal Eye of Horus",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpE023C",
+                "amount": 2
+            },
+            {
+                "id": "upgHpE008C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpL024C": {
+        "name": "Bell of Despair",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpE024C",
+                "amount": 2
+            },
+            {
+                "id": "upgHpE008C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpL027C": {
+        "name": "Auto-Reactive Stimm Injector",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpE027C",
+                "amount": 2
+            },
+            {
+                "id": "upgHpE014C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpL028C": {
+        "name": "Resplendent Spirit Stone",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpE028C",
+                "amount": 2
+            },
+            {
+                "id": "upgHpE014C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpL029C": {
+        "name": "Athenaean Scroll",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpE029C",
+                "amount": 2
+            },
+            {
+                "id": "upgHpE008C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpL031C": {
+        "name": "Talisman of Storms",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpE031C",
+                "amount": 2
+            },
+            {
+                "id": "upgHpE002C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpL032C": {
+        "name": "Key of Achrabael",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpE032C",
+                "amount": 2
+            },
+            {
+                "id": "upgHpE002C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpL033C": {
+        "name": "Hyper-Adaptive Adrenal Glands",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpE033C",
+                "amount": 2
+            },
+            {
+                "id": "upgHpE008C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpL034C": {
+        "name": "Mechadendrite Hive",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpE034C",
+                "amount": 2
+            },
+            {
+                "id": "upgHpE002C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpL035C": {
+        "name": "Bloodstone Icon",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpE035C",
+                "amount": 2
+            },
+            {
+                "id": "upgHpE002C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpL036C": {
+        "name": "Wyrm-form Banner",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpE036C",
+                "amount": 2
+            },
+            {
+                "id": "upgHpE014C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpL037C": {
+        "name": "Flawless Gem Adornment",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpE037C",
+                "amount": 2
+            },
+            {
+                "id": "upgHpE002C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpL038C": {
+        "name": "Exalted Brazen Jaws",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpE038C",
+                "amount": 2
+            },
+            {
+                "id": "upgHpE008C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpL039C": {
+        "name": "Outrageous Grimace",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpE039C",
+                "amount": 2
+            },
+            {
+                "id": "upgHpE008C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpL040C": {
+        "name": "Ancestor Ward Crest",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpE040C",
+                "amount": 2
+            },
+            {
+                "id": "upgHpE014C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpL100": {
+        "name": "Codex Astartes Page",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650
+    },
+    "upgHpL101": {
+        "name": "Bones of the Paragons",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650
+    },
+    "upgHpL102": {
+        "name": "Holy Chaplet",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650
+    },
+    "upgHpL103": {
+        "name": "Boon of the Dark Gods",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650
+    },
+    "upgHpL104": {
+        "name": "Boon of Nurgle",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650
+    },
+    "upgHpL105": {
+        "name": "Honourifica Imperialis",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650
+    },
+    "upgHpL106": {
+        "name": "Kustom Gubbinz",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650
+    },
+    "upgHpL107": {
+        "name": "Engram Neurochip",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650
+    },
+    "upgHpL108": {
+        "name": "Runes of Fate",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650
+    },
+    "upgHpL109": {
+        "name": "Boon of Tzeentch",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650
+    },
+    "upgHpL111": {
+        "name": "Mjod",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650
+    },
+    "upgHpL112": {
+        "name": "Stone Guardian Fragment",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650
+    },
+    "upgHpL113": {
+        "name": "Synaptic Augmentation",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650
+    },
+    "upgHpL114": {
+        "name": "Blessed Cogitator",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650
+    },
+    "upgHpL115": {
+        "name": "Blood Vial",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650
+    },
+    "upgHpL116": {
+        "name": "Gifts of the Star Children",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650
+    },
+    "upgHpL117": {
+        "name": "Arcane Genetic Alchemy",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650
+    },
+    "upgHpL118": {
+        "name": "Boon of Khorne",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650
+    },
+    "upgHpL119": {
+        "name": "Boon of Slaanesh",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650
+    },
+    "upgHpL099": {
+        "name": "Cyberstimm Infusion",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650
+    },
+    "upgHpL120C": {
+        "name": "Codex Astartes",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL100",
+                "amount": 9
+            },
+            {
+                "id": "upgHpR017C",
+                "amount": 1
+            },
+            {
+                "id": "upgHpE003",
+                "amount": 6
+            }
+        ]
+    },
+    "upgHpL121C": {
+        "name": "Tannhauser's Bones",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL101",
+                "amount": 9
+            },
+            {
+                "id": "upgHpR020C",
+                "amount": 1
+            },
+            {
+                "id": "upgArmE009",
+                "amount": 6
+            }
+        ]
+    },
+    "upgHpL122C": {
+        "name": "Simulacrum Sanctorum",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL102",
+                "amount": 9
+            },
+            {
+                "id": "upgHpR020C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgE003",
+                "amount": 6
+            }
+        ]
+    },
+    "upgHpL123C": {
+        "name": "Mark of Chaos Undivided",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL103",
+                "amount": 9
+            },
+            {
+                "id": "upgHpR015C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgE010",
+                "amount": 6
+            }
+        ]
+    },
+    "upgHpL124C": {
+        "name": "Mark of Nurgle",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL104",
+                "amount": 9
+            },
+            {
+                "id": "upgHpR015C",
+                "amount": 1
+            },
+            {
+                "id": "upgHpE015",
+                "amount": 6
+            }
+        ]
+    },
+    "upgHpL125C": {
+        "name": "Sash of Honors",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL105",
+                "amount": 9
+            },
+            {
+                "id": "upgHpR013C",
+                "amount": 1
+            },
+            {
+                "id": "upgHpE012",
+                "amount": 6
+            }
+        ]
+    },
+    "upgHpL126C": {
+        "name": "Cybork Body Parts",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL106",
+                "amount": 9
+            },
+            {
+                "id": "upgHpR004C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgE004",
+                "amount": 6
+            }
+        ]
+    },
+    "upgHpL127C": {
+        "name": "Ta'lissera Bond",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL107",
+                "amount": 9
+            },
+            {
+                "id": "upgHpR006C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgE011",
+                "amount": 6
+            }
+        ]
+    },
+    "upgHpL128C": {
+        "name": "Scriptures of Fate",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL108",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR14C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgE010",
+                "amount": 6
+            }
+        ]
+    },
+    "upgHpL129C": {
+        "name": "Mark of Tzeentch",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL109",
+                "amount": 9
+            },
+            {
+                "id": "upgHpR017C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgE010",
+                "amount": 6
+            }
+        ]
+    },
+    "upgHpL131C": {
+        "name": "Personal Saga",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL111",
+                "amount": 9
+            },
+            {
+                "id": "upgHpR015C",
+                "amount": 1
+            },
+            {
+                "id": "upgHpE003",
+                "amount": 6
+            }
+        ]
+    },
+    "upgHpL132C": {
+        "name": "Perfidious Relic of the Unforgiven",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL112",
+                "amount": 9
+            },
+            {
+                "id": "upgArmR012C",
+                "amount": 1
+            },
+            {
+                "id": "upgHpE017",
+                "amount": 6
+            }
+        ]
+    },
+    "upgHpL133C": {
+        "name": "Hypermetabolic Acceleration",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL113",
+                "amount": 9
+            },
+            {
+                "id": "upgHpR006C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgE003",
+                "amount": 6
+            }
+        ]
+    },
+    "upgHpL134C": {
+        "name": "Sanctus Canister",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL114",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR012C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgE003",
+                "amount": 6
+            }
+        ]
+    },
+    "upgHpL135C": {
+        "name": "Icon of the Angel",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL115",
+                "amount": 9
+            },
+            {
+                "id": "upgHpR020C",
+                "amount": 1
+            },
+            {
+                "id": "upgHpE012",
+                "amount": 6
+            }
+        ]
+    },
+    "upgHpL136C": {
+        "name": "Biomorph Adaption",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL116",
+                "amount": 9
+            },
+            {
+                "id": "upgHpR006C",
+                "amount": 1
+            },
+            {
+                "id": "upgArmE013",
+                "amount": 6
+            }
+        ]
+    },
+    "upgHpL137C": {
+        "name": "Defensor Refractor Generator",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL117",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR010C",
+                "amount": 1
+            },
+            {
+                "id": "upgArmE008",
+                "amount": 6
+            }
+        ]
+    },
+    "upgHpL138C": {
+        "name": "Mark of Khorne",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL118",
+                "amount": 9
+            },
+            {
+                "id": "upgHpR015C",
+                "amount": 1
+            },
+            {
+                "id": "upgHpE012",
+                "amount": 6
+            }
+        ]
+    },
+    "upgHpL139C": {
+        "name": "Mark of Slaanesh",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL119",
+                "amount": 9
+            },
+            {
+                "id": "upgHpR015C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgE010",
+                "amount": 6
+            }
+        ]
+    },
+    "upgHpL140C": {
+        "name": "Forgewrought Maintainers Kit",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL099",
+                "amount": 9
+            },
+            {
+                "id": "upgHpR013C",
+                "amount": 1
+            },
+            {
+                "id": "upgArmE010",
+                "amount": 6
+            }
+        ]
+    },
+    "upgHpL211C": {
+        "name": "Monstrous Constitution",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgL003",
+                "amount": 8
+            },
+            {
+                "id": "upgArmL203",
+                "amount": 8
+            },
+            {
+                "id": "upgHpE015",
+                "amount": 8
+            }
+        ]
+    },
+    "upgHpL212C": {
+        "name": "Preternatural Constitution",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgL202",
+                "amount": 8
+            },
+            {
+                "id": "upgArmL202",
+                "amount": 8
+            },
+            {
+                "id": "upgHpE017",
+                "amount": 8
+            }
+        ]
+    },
+    "upgHpL213C": {
+        "name": "Superaugmented Constitution",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgL001",
+                "amount": 8
+            },
+            {
+                "id": "upgArmL001",
+                "amount": 8
+            },
+            {
+                "id": "upgHpE003",
+                "amount": 8
+            }
+        ]
+    },
+    "upgHpL214C": {
+        "name": "Technocrafted Constitution",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgL204",
+                "amount": 8
+            },
+            {
+                "id": "upgArmL204",
+                "amount": 8
+            },
+            {
+                "id": "upgHpE012",
+                "amount": 8
+            }
+        ]
+    },
+    "upgHpM001": {
+        "name": "Imperial Aquila",
+        "rarity": "Mythic",
+        "statType": "hp",
+        "gold": 2000
+    },
+    "upgHpM002": {
+        "name": "Mutant Form",
+        "rarity": "Mythic",
+        "statType": "hp",
+        "gold": 2000
+    },
+    "upgHpM003": {
+        "name": "Ancient Inscription",
+        "rarity": "Mythic",
+        "statType": "hp",
+        "gold": 2000
+    },
+    "upgHpM004": {
+        "name": "Venerable Battle Mark",
+        "rarity": "Mythic",
+        "statType": "hp",
+        "gold": 2000
+    },
+    "upgHpM120C": {
+        "name": "Grand Symbol of the Ultramarines",
+        "rarity": "Mythic",
+        "statType": "hp",
+        "gold": 2000,
+        "crafting": [
+            {
+                "id": "upgHpM001",
+                "amount": 6
+            },
+            {
+                "id": "upgHpL100",
+                "amount": 8
+            },
+            {
+                "id": "upgHpE120C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpM121C": {
+        "name": "Grand Symbol of the Black Templars",
+        "rarity": "Mythic",
+        "statType": "hp",
+        "gold": 2000,
+        "crafting": [
+            {
+                "id": "upgHpM001",
+                "amount": 6
+            },
+            {
+                "id": "upgHpL101",
+                "amount": 8
+            },
+            {
+                "id": "upgHpE121C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpM122C": {
+        "name": "Grand Symbol of the Adepta Sororitas",
+        "rarity": "Mythic",
+        "statType": "hp",
+        "gold": 2000,
+        "crafting": [
+            {
+                "id": "upgHpM001",
+                "amount": 6
+            },
+            {
+                "id": "upgHpL102",
+                "amount": 8
+            },
+            {
+                "id": "upgHpE122C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpM123C": {
+        "name": "Grand Symbol of the Black Legion",
+        "rarity": "Mythic",
+        "statType": "hp",
+        "gold": 2000,
+        "crafting": [
+            {
+                "id": "upgHpM002",
+                "amount": 6
+            },
+            {
+                "id": "upgHpL103",
+                "amount": 8
+            },
+            {
+                "id": "upgHpE123C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpM124C": {
+        "name": "Grand Symbol of the Death Guard",
+        "rarity": "Mythic",
+        "statType": "hp",
+        "gold": 2000,
+        "crafting": [
+            {
+                "id": "upgHpM004",
+                "amount": 6
+            },
+            {
+                "id": "upgHpL104",
+                "amount": 8
+            },
+            {
+                "id": "upgHpE124C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpM125C": {
+        "name": "Grand Symbol of the Astra Militarum",
+        "rarity": "Mythic",
+        "statType": "hp",
+        "gold": 2000,
+        "crafting": [
+            {
+                "id": "upgHpM004",
+                "amount": 6
+            },
+            {
+                "id": "upgHpL105",
+                "amount": 8
+            },
+            {
+                "id": "upgHpE125C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpM126C": {
+        "name": "Grand Symbol of the Orks",
+        "rarity": "Mythic",
+        "statType": "hp",
+        "gold": 2000,
+        "crafting": [
+            {
+                "id": "upgHpM004",
+                "amount": 6
+            },
+            {
+                "id": "upgHpL106",
+                "amount": 8
+            },
+            {
+                "id": "upgHpE126C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpM127C": {
+        "name": "Grand Symbol of the T'au Empire",
+        "rarity": "Mythic",
+        "statType": "hp",
+        "gold": 2000,
+        "crafting": [
+            {
+                "id": "upgHpM004",
+                "amount": 6
+            },
+            {
+                "id": "upgHpL107",
+                "amount": 8
+            },
+            {
+                "id": "upgHpE127C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpM128C": {
+        "name": "Grand Symbol of the Aeldari",
+        "rarity": "Mythic",
+        "statType": "hp",
+        "gold": 2000,
+        "crafting": [
+            {
+                "id": "upgHpM003",
+                "amount": 6
+            },
+            {
+                "id": "upgHpL108",
+                "amount": 8
+            },
+            {
+                "id": "upgHpE128C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpM129C": {
+        "name": "Grand Symbol of the Thousand Sons",
+        "rarity": "Mythic",
+        "statType": "hp",
+        "gold": 2000,
+        "crafting": [
+            {
+                "id": "upgHpM003",
+                "amount": 6
+            },
+            {
+                "id": "upgHpL109",
+                "amount": 8
+            },
+            {
+                "id": "upgHpE129C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpM130C": {
+        "name": "Grand Symbol of the Necrons",
+        "rarity": "Mythic",
+        "statType": "hp",
+        "gold": 2000,
+        "crafting": [
+            {
+                "id": "upgHpM003",
+                "amount": 6
+            },
+            {
+                "id": "upgHpL010",
+                "amount": 8
+            },
+            {
+                "id": "upgHpE130C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpM131C": {
+        "name": "Grand Symbol of the Space Wolves",
+        "rarity": "Mythic",
+        "statType": "hp",
+        "gold": 2000,
+        "crafting": [
+            {
+                "id": "upgHpM004",
+                "amount": 6
+            },
+            {
+                "id": "upgHpL111",
+                "amount": 8
+            },
+            {
+                "id": "upgHpE131C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpM132C": {
+        "name": "Grand Symbol of the Dark Angels",
+        "rarity": "Mythic",
+        "statType": "hp",
+        "gold": 2000,
+        "crafting": [
+            {
+                "id": "upgHpM001",
+                "amount": 6
+            },
+            {
+                "id": "upgHpL112",
+                "amount": 8
+            },
+            {
+                "id": "upgHpE132C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpM133C": {
+        "name": "Grand Symbol of the Tyranids",
+        "rarity": "Mythic",
+        "statType": "hp",
+        "gold": 2000,
+        "crafting": [
+            {
+                "id": "upgHpM002",
+                "amount": 6
+            },
+            {
+                "id": "upgHpL113",
+                "amount": 8
+            },
+            {
+                "id": "upgHpE133C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpM134C": {
+        "name": "Grand Symbol of the Adeptus Mechanicus",
+        "rarity": "Mythic",
+        "statType": "hp",
+        "gold": 2000,
+        "crafting": [
+            {
+                "id": "upgHpM003",
+                "amount": 6
+            },
+            {
+                "id": "upgHpL114",
+                "amount": 8
+            },
+            {
+                "id": "upgHpE134C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpM135C": {
+        "name": "Grand Symbol of the Blood Angels",
+        "rarity": "Mythic",
+        "statType": "hp",
+        "gold": 2000,
+        "crafting": [
+            {
+                "id": "upgHpM001",
+                "amount": 6
+            },
+            {
+                "id": "upgHpL115",
+                "amount": 8
+            },
+            {
+                "id": "upgHpE135C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpM136C": {
+        "name": "Grand Symbol of the Genestealer Cults",
+        "rarity": "Mythic",
+        "statType": "hp",
+        "gold": 2000,
+        "crafting": [
+            {
+                "id": "upgHpM002",
+                "amount": 6
+            },
+            {
+                "id": "upgHpL116",
+                "amount": 8
+            },
+            {
+                "id": "upgHpE136C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpM137C": {
+        "name": "Grand Symbol of the Adeptus Custodes",
+        "rarity": "Mythic",
+        "statType": "hp",
+        "gold": 2000,
+        "crafting": [
+            {
+                "id": "upgHpM001",
+                "amount": 6
+            },
+            {
+                "id": "upgHpL117",
+                "amount": 8
+            },
+            {
+                "id": "upgHpE137C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpM138C": {
+        "name": "Grand Symbol of the World Eaters",
+        "rarity": "Mythic",
+        "statType": "hp",
+        "gold": 2000,
+        "crafting": [
+            {
+                "id": "upgHpM002",
+                "amount": 6
+            },
+            {
+                "id": "upgHpL118",
+                "amount": 8
+            },
+            {
+                "id": "upgHpE138C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpM139C": {
+        "name": "Grand Symbol of the Emperor's Children",
+        "rarity": "Mythic",
+        "statType": "hp",
+        "gold": 2000,
+        "crafting": [
+            {
+                "id": "upgHpM002",
+                "amount": 6
+            },
+            {
+                "id": "upgHpL119",
+                "amount": 8
+            },
+            {
+                "id": "upgHpE139C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpM140C": {
+        "name": "Grand Symbol of the Leagues of Votann",
+        "rarity": "Mythic",
+        "statType": "hp",
+        "gold": 2000,
+        "crafting": [
+            {
+                "id": "upgHpM003",
+                "amount": 6
+            },
+            {
+                "id": "upgHpL099",
+                "amount": 8
+            },
+            {
+                "id": "upgHpE140C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpM143C": {
+        "name": "Grand Symbol of the Adeptus Astartes",
+        "rarity": "Mythic",
+        "statType": "hp",
+        "gold": 2000,
+        "crafting": [
+            {
+                "id": "upgHpM001",
+                "amount": 6
+            },
+            {
+                "id": "upgHpL100",
+                "amount": 8
+            },
+            {
+                "id": "upgHpE143C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgDmgC001": {
+        "name": "Round of Ammo",
+        "rarity": "Common",
+        "statType": "dmg",
+        "gold": 10
+    },
+    "upgDmgC002": {
+        "name": "Frag Grenade",
+        "rarity": "Common",
+        "statType": "dmg",
+        "gold": 10
+    },
+    "upgDmgC003": {
+        "name": "Canister of Chemicals",
+        "rarity": "Common",
+        "statType": "dmg",
+        "gold": 10
+    },
+    "upgDmgC004": {
+        "name": "Can of Promethium",
+        "rarity": "Common",
+        "statType": "dmg",
+        "gold": 10
+    },
+    "upgDmgC005": {
+        "name": "Ballistics Data",
+        "rarity": "Common",
+        "statType": "dmg",
+        "gold": 10
+    },
+    "upgDmgC006": {
+        "name": "Lesser Reliquary of Vengeance",
+        "rarity": "Common",
+        "statType": "dmg",
+        "gold": 10
+    },
+    "upgDmgC007": {
+        "name": "Single Power Pack",
+        "rarity": "Common",
+        "statType": "dmg",
+        "gold": 10
+    },
+    "upgDmgC008": {
+        "name": "Otherworldly Energy",
+        "rarity": "Common",
+        "statType": "dmg",
+        "gold": 10
+    },
+    "upgDmgC009": {
+        "name": "Basic Auxiliary Core",
+        "rarity": "Common",
+        "statType": "dmg",
+        "gold": 10
+    },
+    "upgDmgC010": {
+        "name": "Auspex",
+        "rarity": "Common",
+        "statType": "dmg",
+        "gold": 10
+    },
+    "upgDmgC011": {
+        "name": "Weapon Anointment Oils",
+        "rarity": "Common",
+        "statType": "dmg",
+        "gold": 10
+    },
+    "upgDmgC012": {
+        "name": "Weapon parts",
+        "rarity": "Common",
+        "statType": "dmg",
+        "gold": 10
+    },
+    "upgDmgC013": {
+        "name": "Vox-Caster",
+        "rarity": "Common",
+        "statType": "dmg",
+        "gold": 10
+    },
+    "upgDmgC014": {
+        "name": "Nasty Spikes",
+        "rarity": "Common",
+        "statType": "dmg",
+        "gold": 10
+    },
+    "upgDmgC015": {
+        "name": "Targeting Link",
+        "rarity": "Common",
+        "statType": "dmg",
+        "gold": 10
+    },
+    "upgDmgU001C": {
+        "name": "Magazine",
+        "rarity": "Uncommon",
+        "statType": "dmg",
+        "gold": 25,
+        "crafting": [
+            {
+                "id": "upgDmgC001",
+                "amount": 6
+            }
+        ]
+    },
+    "upgDmgU002C": {
+        "name": "Belt of Frag Grenades",
+        "rarity": "Uncommon",
+        "statType": "dmg",
+        "gold": 25,
+        "crafting": [
+            {
+                "id": "upgDmgC002",
+                "amount": 6
+            }
+        ]
+    },
+    "upgDmgU003": {
+        "name": "Barrel of Promethium",
+        "rarity": "Uncommon",
+        "statType": "dmg",
+        "gold": 25
+    },
+    "upgDmgU004": {
+        "name": "Attack Vector Data-slate",
+        "rarity": "Uncommon",
+        "statType": "dmg",
+        "gold": 25
+    },
+    "upgDmgU005": {
+        "name": "Chapter Reliquary",
+        "rarity": "Uncommon",
+        "statType": "dmg",
+        "gold": 25
+    },
+    "upgDmgU006": {
+        "name": "Marksman's Honour",
+        "rarity": "Uncommon",
+        "statType": "dmg",
+        "gold": 25
+    },
+    "upgDmgU007C": {
+        "name": "Power Pack Bundle",
+        "rarity": "Uncommon",
+        "statType": "dmg",
+        "gold": 25,
+        "crafting": [
+            {
+                "id": "upgDmgC007",
+                "amount": 6
+            }
+        ]
+    },
+    "upgDmgU008C": {
+        "name": "Otherworldly Energy Reservoir",
+        "rarity": "Uncommon",
+        "statType": "dmg",
+        "gold": 25,
+        "crafting": [
+            {
+                "id": "upgDmgC008",
+                "amount": 6
+            }
+        ]
+    },
+    "upgDmgU009": {
+        "name": "Plasma Cell",
+        "rarity": "Uncommon",
+        "statType": "dmg",
+        "gold": 25
+    },
+    "upgDmgU010": {
+        "name": "Fine Micro-Generator",
+        "rarity": "Uncommon",
+        "statType": "dmg",
+        "gold": 25
+    },
+    "upgDmgU011": {
+        "name": "Divinator Class Auspex",
+        "rarity": "Uncommon",
+        "statType": "dmg",
+        "gold": 25
+    },
+    "upgDmgU012": {
+        "name": "Locator Beacon",
+        "rarity": "Uncommon",
+        "statType": "dmg",
+        "gold": 25
+    },
+    "upgDmgU013C": {
+        "name": "Fine Auxiliary Core",
+        "rarity": "Uncommon",
+        "statType": "dmg",
+        "gold": 25,
+        "crafting": [
+            {
+                "id": "upgDmgC009",
+                "amount": 6
+            }
+        ]
+    },
+    "upgDmgU014": {
+        "name": "Combat Stimms",
+        "rarity": "Uncommon",
+        "statType": "dmg",
+        "gold": 25
+    },
+    "upgDmgU015C": {
+        "name": "Blessed Weapon Oils",
+        "rarity": "Uncommon",
+        "statType": "dmg",
+        "gold": 25,
+        "crafting": [
+            {
+                "id": "upgDmgC011",
+                "amount": 4
+            },
+            {
+                "id": "upgDmgC003",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgU016C": {
+        "name": "Razor-sharp Spikes",
+        "rarity": "Uncommon",
+        "statType": "dmg",
+        "gold": 25,
+        "crafting": [
+            {
+                "id": "upgDmgC014",
+                "amount": 4
+            },
+            {
+                "id": "upgDmgC012",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgU017C": {
+        "name": "Targeting Matrix",
+        "rarity": "Uncommon",
+        "statType": "dmg",
+        "gold": 25,
+        "crafting": [
+            {
+                "id": "upgDmgC015",
+                "amount": 4
+            },
+            {
+                "id": "upgDmgC005",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgU018C": {
+        "name": "Adamantium Blades",
+        "rarity": "Uncommon",
+        "statType": "dmg",
+        "gold": 25,
+        "crafting": [
+            {
+                "id": "upgDmgC012",
+                "amount": 4
+            },
+            {
+                "id": "upgHpC013",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgU019": {
+        "name": "Slicing Claws",
+        "rarity": "Uncommon",
+        "statType": "dmg",
+        "gold": 25
+    },
+    "upgDmgR001C": {
+        "name": "Box of Ammo",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75,
+        "crafting": [
+            {
+                "id": "upgArmU002",
+                "amount": 5
+            },
+            {
+                "id": "upgDmgC001",
+                "amount": 6
+            }
+        ]
+    },
+    "upgDmgR002": {
+        "name": "Krak Grenade",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75
+    },
+    "upgDmgR003": {
+        "name": "Tank of Promethium",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75
+    },
+    "upgDmgR004C": {
+        "name": "Plasma Cell Bundle",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75,
+        "crafting": [
+            {
+                "id": "upgDmgU009",
+                "amount": 5
+            },
+            {
+                "id": "upgDmgC003",
+                "amount": 6
+            }
+        ]
+    },
+    "upgDmgR005": {
+        "name": "Classified Data-slate",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75
+    },
+    "upgDmgR006": {
+        "name": "Bionic Eye",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75
+    },
+    "upgDmgR007": {
+        "name": "Bladesman's Honour",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75
+    },
+    "upgDmgR008C": {
+        "name": "High-capacity Power Pack",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75,
+        "crafting": [
+            {
+                "id": "upgDmgU009",
+                "amount": 5
+            },
+            {
+                "id": "upgDmgC007",
+                "amount": 6
+            }
+        ]
+    },
+    "upgDmgR009": {
+        "name": "Viridian Energy Tesseract",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75
+    },
+    "upgDmgR010C": {
+        "name": "Powerful Micro-Generator",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75,
+        "crafting": [
+            {
+                "id": "upgDmgU010",
+                "amount": 5
+            },
+            {
+                "id": "upgArmC012",
+                "amount": 4
+            },
+            {
+                "id": "upgDmgC007",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgR011C": {
+        "name": "Powerful Auxiliary Core",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75,
+        "crafting": [
+            {
+                "id": "upgDmgU010",
+                "amount": 2
+            },
+            {
+                "id": "upgDmgC009",
+                "amount": 6
+            },
+            {
+                "id": "upgHpU014",
+                "amount": 3
+            }
+        ]
+    },
+    "upgDmgR012C": {
+        "name": "Advanced Combat Stimms",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75,
+        "crafting": [
+            {
+                "id": "upgDmgU014",
+                "amount": 5
+            },
+            {
+                "id": "upgHpC007",
+                "amount": 6
+            }
+        ]
+    },
+    "upgDmgR13C": {
+        "name": "Prey-Sight",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75,
+        "crafting": [
+            {
+                "id": "upgDmgU012",
+                "amount": 5
+            },
+            {
+                "id": "upgDmgC010",
+                "amount": 3
+            },
+            {
+                "id": "upgDmgC013",
+                "amount": 3
+            }
+        ]
+    },
+    "upgDmgR14C": {
+        "name": "Supernatural Sight",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75,
+        "crafting": [
+            {
+                "id": "upgDmgU011",
+                "amount": 5
+            },
+            {
+                "id": "upgDmgC008",
+                "amount": 3
+            },
+            {
+                "id": "upgDmgC005",
+                "amount": 3
+            }
+        ]
+    },
+    "upgDmgR015C": {
+        "name": "Sanctified Weapon Oils",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75,
+        "crafting": [
+            {
+                "id": "upgDmgU015C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgU003",
+                "amount": 5
+            }
+        ]
+    },
+    "upgDmgR016C": {
+        "name": "Murderous Spikes",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75,
+        "crafting": [
+            {
+                "id": "upgDmgU016C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgU019",
+                "amount": 5
+            }
+        ]
+    },
+    "upgDmgR017C": {
+        "name": "Ratiocination Targeting",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75,
+        "crafting": [
+            {
+                "id": "upgDmgU017C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgU004",
+                "amount": 5
+            }
+        ]
+    },
+    "upgDmgR021": {
+        "name": "Chain of Zeal",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75
+    },
+    "upgDmgR022": {
+        "name": "Hymn of Martyrs",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75
+    },
+    "upgDmgR025": {
+        "name": "Entrenching Tool",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75
+    },
+    "upgDmgR023": {
+        "name": "Icon of Vengeance",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75
+    },
+    "upgDmgR024": {
+        "name": "Sigil of Decay",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75
+    },
+    "upgDmgR026": {
+        "name": "Iron Jaw",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75
+    },
+    "upgDmgR027": {
+        "name": "Sensor Suite",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75
+    },
+    "upgDmgR028": {
+        "name": "Psytronome",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75
+    },
+    "upgDmgR029": {
+        "name": "Inferno Bolts",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75
+    },
+    "upgDmgR031": {
+        "name": "Wolf Tooth Necklace",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75
+    },
+    "upgDmgR032": {
+        "name": "Chapter Pendant",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75
+    },
+    "upgDmgR033": {
+        "name": "Toxin Sacs",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75
+    },
+    "upgDmgR034": {
+        "name": "Motive Force Capacitator",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75
+    },
+    "upgDmgR035": {
+        "name": "Blood Shard Bolt",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75
+    },
+    "upgDmgR036": {
+        "name": "Proclamation Receiver",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75
+    },
+    "upgDmgR037": {
+        "name": "Integrated Bolt Feeder",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75
+    },
+    "upgDmgR038": {
+        "name": "Chainaxe Teeth",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75
+    },
+    "upgDmgR039": {
+        "name": "Vox Grill Amplifier",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75
+    },
+    "upgDmgR040": {
+        "name": "Personal Scanner",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75
+    },
+    "upgDmgE001": {
+        "name": "Special Issue Ammo",
+        "rarity": "Epic",
+        "statType": "dmg",
+        "gold": 215
+    },
+    "upgDmgE002C": {
+        "name": "Belt of Krak Grenades",
+        "rarity": "Epic",
+        "statType": "dmg",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR013C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgR002",
+                "amount": 4
+            },
+            {
+                "id": "upgDmgC003",
+                "amount": 4
+            }
+        ]
+    },
+    "upgDmgE003": {
+        "name": "Blessed Promethium Canister",
+        "rarity": "Epic",
+        "statType": "dmg",
+        "gold": 215
+    },
+    "upgDmgE004": {
+        "name": "Bionic Neural Pathways",
+        "rarity": "Epic",
+        "statType": "dmg",
+        "gold": 215
+    },
+    "upgDmgE005": {
+        "name": "Greater Reliquary of Vengeance",
+        "rarity": "Epic",
+        "statType": "dmg",
+        "gold": 215
+    },
+    "upgDmgE006C": {
+        "name": "Anointed Micro-Generator",
+        "rarity": "Epic",
+        "statType": "dmg",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgDmgR010C",
+                "amount": 1
+            },
+            {
+                "id": "upgArmR006",
+                "amount": 4
+            },
+            {
+                "id": "upgArmC011",
+                "amount": 4
+            }
+        ]
+    },
+    "upgDmgE007C": {
+        "name": "Plasma Cell Crate",
+        "rarity": "Epic",
+        "statType": "dmg",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgDmgR004C",
+                "amount": 1
+            },
+            {
+                "id": "upgArmR006",
+                "amount": 4
+            },
+            {
+                "id": "upgDmgC012",
+                "amount": 4
+            }
+        ]
+    },
+    "upgDmgE008C": {
+        "name": "Anointed Auxiliary Core",
+        "rarity": "Epic",
+        "statType": "dmg",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgDmgR011C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgR003",
+                "amount": 4
+            },
+            {
+                "id": "upgHpC014",
+                "amount": 4
+            }
+        ]
+    },
+    "upgDmgE009C": {
+        "name": "Refined Combat Stimms",
+        "rarity": "Epic",
+        "statType": "dmg",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgDmgR012C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgR003",
+                "amount": 4
+            },
+            {
+                "id": "upgHpC006",
+                "amount": 4
+            }
+        ]
+    },
+    "upgDmgE010": {
+        "name": "Warp Locus",
+        "rarity": "Epic",
+        "statType": "dmg",
+        "gold": 215
+    },
+    "upgDmgE011": {
+        "name": "Elaborate Hilt",
+        "rarity": "Epic",
+        "statType": "dmg",
+        "gold": 215
+    },
+    "upgDmgE020C": {
+        "name": "Reliquary of Vengeance",
+        "rarity": "Epic",
+        "statType": "dmg",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgDmgR007",
+                "amount": 9
+            }
+        ]
+    },
+    "upgDmgE021C": {
+        "name": "Chain of Righteous Zeal",
+        "rarity": "Epic",
+        "statType": "dmg",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgDmgR021",
+                "amount": 9
+            }
+        ]
+    },
+    "upgDmgE022C": {
+        "name": "Hymn of Sacrifice",
+        "rarity": "Epic",
+        "statType": "dmg",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgDmgR022",
+                "amount": 9
+            }
+        ]
+    },
+    "upgDmgE025C": {
+        "name": "Veteran's Entrenching Tool",
+        "rarity": "Epic",
+        "statType": "dmg",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgDmgR025",
+                "amount": 9
+            }
+        ]
+    },
+    "upgDmgE023C": {
+        "name": "Icon of Daemonic Vengeance",
+        "rarity": "Epic",
+        "statType": "dmg",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgDmgR023",
+                "amount": 9
+            }
+        ]
+    },
+    "upgDmgE024C": {
+        "name": "Sigil of Inevitable Decay",
+        "rarity": "Epic",
+        "statType": "dmg",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgDmgR024",
+                "amount": 9
+            }
+        ]
+    },
+    "upgDmgE026C": {
+        "name": "Brutal Iron Jaw",
+        "rarity": "Epic",
+        "statType": "dmg",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgDmgR026",
+                "amount": 9
+            }
+        ]
+    },
+    "upgDmgE027C": {
+        "name": "Advanced Sensor Suite",
+        "rarity": "Epic",
+        "statType": "dmg",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgDmgR027",
+                "amount": 9
+            }
+        ]
+    },
+    "upgDmgE028C": {
+        "name": "Filigrane Psytronome",
+        "rarity": "Epic",
+        "statType": "dmg",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgDmgR028",
+                "amount": 9
+            }
+        ]
+    },
+    "upgDmgE029C": {
+        "name": "Ensorcelled Infusion",
+        "rarity": "Epic",
+        "statType": "dmg",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgDmgR029",
+                "amount": 9
+            }
+        ]
+    },
+    "upgDmgE030C": {
+        "name": "Protocol of the Hungry Void",
+        "rarity": "Epic",
+        "statType": "dmg",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgDmgR009",
+                "amount": 9
+            }
+        ]
+    },
+    "upgDmgE031C": {
+        "name": "Thunderwolf Tooth Necklace",
+        "rarity": "Epic",
+        "statType": "dmg",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgDmgR031",
+                "amount": 9
+            }
+        ]
+    },
+    "upgDmgE032C": {
+        "name": "Bolts of Judgement",
+        "rarity": "Epic",
+        "statType": "dmg",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgDmgR032",
+                "amount": 9
+            }
+        ]
+    },
+    "upgDmgE033C": {
+        "name": "Adaptive Toxin Sacs",
+        "rarity": "Epic",
+        "statType": "dmg",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgDmgR033",
+                "amount": 9
+            }
+        ]
+    },
+    "upgDmgE034C": {
+        "name": "Enhanced Motive Force Capacitator",
+        "rarity": "Epic",
+        "statType": "dmg",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgDmgR034",
+                "amount": 9
+            }
+        ]
+    },
+    "upgDmgE035C": {
+        "name": "Quake Bolts",
+        "rarity": "Epic",
+        "statType": "dmg",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgDmgR035",
+                "amount": 9
+            }
+        ]
+    },
+    "upgDmgE036C": {
+        "name": "Proclamation Caster",
+        "rarity": "Epic",
+        "statType": "dmg",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgDmgR036",
+                "amount": 9
+            }
+        ]
+    },
+    "upgDmgE037C": {
+        "name": "Embellished Bolt Feeder",
+        "rarity": "Epic",
+        "statType": "dmg",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgDmgR037",
+                "amount": 9
+            }
+        ]
+    },
+    "upgDmgE038C": {
+        "name": "Blessed Chainaxe Teeth",
+        "rarity": "Epic",
+        "statType": "dmg",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgDmgR038",
+                "amount": 9
+            }
+        ]
+    },
+    "upgDmgE039C": {
+        "name": "Sonic Greave Amplifier",
+        "rarity": "Epic",
+        "statType": "dmg",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgDmgR039",
+                "amount": 9
+            }
+        ]
+    },
+    "upgDmgE040C": {
+        "name": "ECog Scanner",
+        "rarity": "Epic",
+        "statType": "dmg",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgDmgR040",
+                "amount": 9
+            }
+        ]
+    },
+    "upgDmgL001": {
+        "name": "Master-crafted Ammo",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650
+    },
+    "upgDmgL002C": {
+        "name": "Blessed Promethium Tank",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgE003",
+                "amount": 7
+            },
+            {
+                "id": "upgDmgR003",
+                "amount": 7
+            },
+            {
+                "id": "upgDmgR004C",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgL003": {
+        "name": "Archeotech Bionics",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650
+    },
+    "upgDmgL004C": {
+        "name": "Legendary Reliquary of Vengeance",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgE020C",
+                "amount": 2
+            },
+            {
+                "id": "upgDmgR015C",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgL005C": {
+        "name": "Optimal Micro-Generator",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgE006C",
+                "amount": 2
+            },
+            {
+                "id": "upgHpE017",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgL006C": {
+        "name": "Optimal Auxiliary Core",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgE008C",
+                "amount": 2
+            },
+            {
+                "id": "upgArmE010",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgL007C": {
+        "name": "Autoloader",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgE001",
+                "amount": 7
+            },
+            {
+                "id": "upgDmgR002",
+                "amount": 7
+            },
+            {
+                "id": "upgDmgR001C",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgL008C": {
+        "name": "Powered Blade",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgE011",
+                "amount": 7
+            },
+            {
+                "id": "upgHpR018",
+                "amount": 7
+            },
+            {
+                "id": "upgDmgR010C",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgL009C": {
+        "name": "Hyperstim",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgE004",
+                "amount": 7
+            },
+            {
+                "id": "upgHpR019",
+                "amount": 7
+            },
+            {
+                "id": "upgDmgR012C",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgL010C": {
+        "name": "Psychic Focus",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgE010",
+                "amount": 7
+            },
+            {
+                "id": "upgHpR002",
+                "amount": 7
+            },
+            {
+                "id": "upgDmgR14C",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgL012C": {
+        "name": "Plasma Coil",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgE007C",
+                "amount": 2
+            },
+            {
+                "id": "upgDmgE003",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgL015C": {
+        "name": "Digital Weapons",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgR015C",
+                "amount": 2
+            },
+            {
+                "id": "upgDmgR13C",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgL016C": {
+        "name": "Imposing Horns",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgR016C",
+                "amount": 2
+            },
+            {
+                "id": "upgHpR015C",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgL017C": {
+        "name": "Overcapacitator",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgR017C",
+                "amount": 2
+            },
+            {
+                "id": "upgDmgR008C",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgL021C": {
+        "name": "Chain of Zealous Wrath",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgE021C",
+                "amount": 2
+            },
+            {
+                "id": "upgDmgR015C",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgL022C": {
+        "name": "Hymn of the Divine",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgE022C",
+                "amount": 2
+            },
+            {
+                "id": "upgDmgR015C",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgL025C": {
+        "name": "Heirloom Entrenching Tool",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgE025C",
+                "amount": 2
+            },
+            {
+                "id": "upgDmgR015C",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgL023C": {
+        "name": "Icon of Infernal Vengeance",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgE023C",
+                "amount": 2
+            },
+            {
+                "id": "upgDmgR016C",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgL024C": {
+        "name": "Sigil of Eternal Decay",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgE024C",
+                "amount": 2
+            },
+            {
+                "id": "upgDmgR016C",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgL026C": {
+        "name": "Ded Brutal Iron Jaw",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgE026C",
+                "amount": 2
+            },
+            {
+                "id": "upgDmgR016C",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgL027C": {
+        "name": "Multi-Spectrum Sensor Suite",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgE027C",
+                "amount": 2
+            },
+            {
+                "id": "upgDmgR017C",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgL028C": {
+        "name": "Soul-Bonded Psytronome",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgE028C",
+                "amount": 2
+            },
+            {
+                "id": "upgDmgR017C",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgL029C": {
+        "name": "Warpflame Infusion",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgE029C",
+                "amount": 2
+            },
+            {
+                "id": "upgDmgR016C",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgL030C": {
+        "name": "Extermination Protocols",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgE030C",
+                "amount": 2
+            },
+            {
+                "id": "upgDmgR017C",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgL031C": {
+        "name": "Kraken Tooth Necklace",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgE031C",
+                "amount": 2
+            },
+            {
+                "id": "upgDmgR015C",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgL032C": {
+        "name": "Bolts of Furious Vengeance",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgE032C",
+                "amount": 2
+            },
+            {
+                "id": "upgDmgR015C",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgL033C": {
+        "name": "Hyper-Adaptive Toxin Sacs",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgE033C",
+                "amount": 2
+            },
+            {
+                "id": "upgDmgR016C",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgL034C": {
+        "name": "Optimal Motive Force Capacitator",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgE034C",
+                "amount": 2
+            },
+            {
+                "id": "upgDmgR015C",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgL035C": {
+        "name": "Decimator Bolts",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgE035C",
+                "amount": 2
+            },
+            {
+                "id": "upgDmgR015C",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgL036C": {
+        "name": "Proclamation Hailer",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgE036C",
+                "amount": 2
+            },
+            {
+                "id": "upgDmgR017C",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgL037C": {
+        "name": "Adorned Bolt Feeder",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgE037C",
+                "amount": 2
+            },
+            {
+                "id": "upgDmgR015C",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgL038C": {
+        "name": "Exalted Chainaxe Teeth",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgE038C",
+                "amount": 2
+            },
+            {
+                "id": "upgDmgR016C",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgL039C": {
+        "name": "Siren Amplifier",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgE039C",
+                "amount": 2
+            },
+            {
+                "id": "upgDmgR016C",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgL040C": {
+        "name": "Panspectral Scanner",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgE040C",
+                "amount": 2
+            },
+            {
+                "id": "upgDmgR017C",
+                "amount": 2
+            }
+        ]
+    },
+    "upgDmgL120C": {
+        "name": "Hellfury Bolts",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL100",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR13C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgE001",
+                "amount": 6
+            }
+        ]
+    },
+    "upgDmgL121C": {
+        "name": "Witchseeker Bolts",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL101",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR13C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgE001",
+                "amount": 6
+            }
+        ]
+    },
+    "upgDmgL122C": {
+        "name": "Blessed Bolts",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL102",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR14C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgE001",
+                "amount": 6
+            }
+        ]
+    },
+    "upgDmgL125C": {
+        "name": "Medallion Resolute",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL105",
+                "amount": 9
+            },
+            {
+                "id": "upgHpR017C",
+                "amount": 1
+            },
+            {
+                "id": "upgArmE009",
+                "amount": 6
+            }
+        ]
+    },
+    "upgDmgL123C": {
+        "name": "Daemon Shells",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL103",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR14C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgE001",
+                "amount": 6
+            }
+        ]
+    },
+    "upgDmgL124C": {
+        "name": "Virulent Rounds",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL104",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR14C",
+                "amount": 1
+            },
+            {
+                "id": "upgHpE015",
+                "amount": 6
+            }
+        ]
+    },
+    "upgDmgL126C": {
+        "name": "Snazzy Dakka",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL106",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR001C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgE003",
+                "amount": 6
+            }
+        ]
+    },
+    "upgDmgL127C": {
+        "name": "Target Lock",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL107",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR13C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgE004",
+                "amount": 6
+            }
+        ]
+    },
+    "upgDmgL128C": {
+        "name": "Scriptures of Battle",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL108",
+                "amount": 9
+            },
+            {
+                "id": "upgHpR017C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgE010",
+                "amount": 6
+            }
+        ]
+    },
+    "upgDmgL129C": {
+        "name": "Boonstone",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL109",
+                "amount": 9
+            },
+            {
+                "id": "upgArmU004C",
+                "amount": 2
+            },
+            {
+                "id": "upgDmgE010",
+                "amount": 6
+            }
+        ]
+    },
+    "upgDmgL130C": {
+        "name": "Molecular Vaporiser",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL010",
+                "amount": 9
+            },
+            {
+                "id": "upgHpR009C",
+                "amount": 1
+            },
+            {
+                "id": "upgArmE008",
+                "amount": 6
+            }
+        ]
+    },
+    "upgDmgL131C": {
+        "name": "Frostblade",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL111",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgU018C",
+                "amount": 2
+            },
+            {
+                "id": "upgDmgE011",
+                "amount": 6
+            }
+        ]
+    },
+    "upgDmgL132C": {
+        "name": "Arbiter's Gaze",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL112",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR017C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgE004",
+                "amount": 6
+            }
+        ]
+    },
+    "upgDmgL133C": {
+        "name": "Implant Attack",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL113",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR14C",
+                "amount": 1
+            },
+            {
+                "id": "upgArmE013",
+                "amount": 6
+            }
+        ]
+    },
+    "upgDmgL134C": {
+        "name": "Prehensile Dataspike",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL114",
+                "amount": 9
+            },
+            {
+                "id": "upgHpR012C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgE004",
+                "amount": 6
+            }
+        ]
+    },
+    "upgDmgL135C": {
+        "name": "Archangel's Shard",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL115",
+                "amount": 9
+            },
+            {
+                "id": "upgHpR016C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgE011",
+                "amount": 6
+            }
+        ]
+    },
+    "upgDmgL136C": {
+        "name": "Gene-twisted Muscle",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL116",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR012C",
+                "amount": 1
+            },
+            {
+                "id": "upgArmE013",
+                "amount": 6
+            }
+        ]
+    },
+    "upgDmgL137C": {
+        "name": "Panoptispex",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL117",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR13C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgE004",
+                "amount": 6
+            }
+        ]
+    },
+    "upgDmgL138C": {
+        "name": "Butcher's Nails",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL118",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR012C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgE004",
+                "amount": 6
+            }
+        ]
+    },
+    "upgDmgL139C": {
+        "name": "Amplified Senses",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL119",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR012C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgE004",
+                "amount": 6
+            }
+        ]
+    },
+    "upgDmgL140C": {
+        "name": "Experimental Kin Technology",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL099",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR008C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgE001",
+                "amount": 6
+            }
+        ]
+    },
+    "upgDmgL202": {
+        "name": "Psychic Force Conduit",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650
+    },
+    "upgDmgL204": {
+        "name": "Ancient Power Cell",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650
+    },
+    "upgDmgL211C": {
+        "name": "Monstrous Strength",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgL202",
+                "amount": 8
+            },
+            {
+                "id": "upgDmgL003",
+                "amount": 8
+            },
+            {
+                "id": "upgDmgE003",
+                "amount": 8
+            }
+        ]
+    },
+    "upgDmgL212C": {
+        "name": "Preternatural Strength",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgL001",
+                "amount": 8
+            },
+            {
+                "id": "upgDmgL202",
+                "amount": 8
+            },
+            {
+                "id": "upgDmgE010",
+                "amount": 8
+            }
+        ]
+    },
+    "upgDmgL213C": {
+        "name": "Superaugmented Strength",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgL204",
+                "amount": 8
+            },
+            {
+                "id": "upgDmgL001",
+                "amount": 8
+            },
+            {
+                "id": "upgDmgE011",
+                "amount": 8
+            }
+        ]
+    },
+    "upgDmgL214C": {
+        "name": "Technocrafted Strength",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgDmgL003",
+                "amount": 8
+            },
+            {
+                "id": "upgDmgL204",
+                "amount": 8
+            },
+            {
+                "id": "upgDmgE004",
+                "amount": 8
+            }
+        ]
+    },
+    "upgDmgM211C": {
+        "name": "Arcane Substances",
+        "rarity": "Mythic",
+        "statType": "dmg",
+        "gold": 2000,
+        "crafting": [
+            {
+                "id": "upgDmgL202",
+                "amount": 3
+            },
+            {
+                "id": "upgHpM003",
+                "amount": 6
+            },
+            {
+                "id": "upgDmgL009C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgDmgM212C": {
+        "name": "Sundering Talons",
+        "rarity": "Mythic",
+        "statType": "dmg",
+        "gold": 2000,
+        "crafting": [
+            {
+                "id": "upgDmgL003",
+                "amount": 3
+            },
+            {
+                "id": "upgHpM002",
+                "amount": 6
+            },
+            {
+                "id": "upgDmgL008C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgDmgM213C": {
+        "name": "Ancient Weapon Augmentation",
+        "rarity": "Mythic",
+        "statType": "dmg",
+        "gold": 2000,
+        "crafting": [
+            {
+                "id": "upgDmgL001",
+                "amount": 3
+            },
+            {
+                "id": "upgHpM001",
+                "amount": 6
+            },
+            {
+                "id": "upgDmgL007C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgDmgM214C": {
+        "name": "Ancient Power Source",
+        "rarity": "Mythic",
+        "statType": "dmg",
+        "gold": 2000,
+        "crafting": [
+            {
+                "id": "upgDmgL204",
+                "amount": 3
+            },
+            {
+                "id": "upgHpM004",
+                "amount": 6
+            },
+            {
+                "id": "upgDmgL010C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgArmC001": {
+        "name": "Purity Seal",
+        "rarity": "Common",
+        "statType": "fixedArmor",
+        "gold": 10
+    },
+    "upgArmC002": {
+        "name": "Fine Purity Seal",
+        "rarity": "Common",
+        "statType": "fixedArmor",
+        "gold": 10
+    },
+    "upgArmC003": {
+        "name": "Pile of Salvage",
+        "rarity": "Common",
+        "statType": "fixedArmor",
+        "gold": 10
+    },
+    "upgArmC004": {
+        "name": "Adamantium Ore",
+        "rarity": "Common",
+        "statType": "fixedArmor",
+        "gold": 10
+    },
+    "upgArmC005": {
+        "name": "Sophisticated Material",
+        "rarity": "Common",
+        "statType": "fixedArmor",
+        "gold": 10
+    },
+    "upgArmC006": {
+        "name": "Rebreather",
+        "rarity": "Common",
+        "statType": "fixedArmor",
+        "gold": 10
+    },
+    "upgArmC007": {
+        "name": "Mutation: Tough Skin",
+        "rarity": "Common",
+        "statType": "fixedArmor",
+        "gold": 10
+    },
+    "upgArmC011": {
+        "name": "Filaments",
+        "rarity": "Common",
+        "statType": "fixedArmor",
+        "gold": 10
+    },
+    "upgArmC012": {
+        "name": "Metal Joints",
+        "rarity": "Common",
+        "statType": "fixedArmor",
+        "gold": 10
+    },
+    "upgArmC013": {
+        "name": "Armor Trim",
+        "rarity": "Common",
+        "statType": "fixedArmor",
+        "gold": 10
+    },
+    "upgArmU001": {
+        "name": "Oath Seal",
+        "rarity": "Uncommon",
+        "statType": "fixedArmor",
+        "gold": 25
+    },
+    "upgArmU002": {
+        "name": "Box of Salvage",
+        "rarity": "Uncommon",
+        "statType": "fixedArmor",
+        "gold": 25
+    },
+    "upgArmU003C": {
+        "name": "Adamantium Lump",
+        "rarity": "Uncommon",
+        "statType": "fixedArmor",
+        "gold": 25,
+        "crafting": [
+            {
+                "id": "upgArmC004",
+                "amount": 6
+            }
+        ]
+    },
+    "upgArmU004C": {
+        "name": "Sophisticated Material Ingot",
+        "rarity": "Uncommon",
+        "statType": "fixedArmor",
+        "gold": 25,
+        "crafting": [
+            {
+                "id": "upgArmC005",
+                "amount": 6
+            }
+        ]
+    },
+    "upgArmU005": {
+        "name": "Ceramite Lump",
+        "rarity": "Uncommon",
+        "statType": "fixedArmor",
+        "gold": 25
+    },
+    "upgArmU006": {
+        "name": "Advanced Filaments",
+        "rarity": "Uncommon",
+        "statType": "fixedArmor",
+        "gold": 25
+    },
+    "upgArmU007": {
+        "name": "Mutation: Scaly Skin",
+        "rarity": "Uncommon",
+        "statType": "fixedArmor",
+        "gold": 25
+    },
+    "upgArmU008": {
+        "name": "Advanced Rebreather",
+        "rarity": "Uncommon",
+        "statType": "fixedArmor",
+        "gold": 25
+    },
+    "upgArmU009": {
+        "name": "Blessed Tasset Plate",
+        "rarity": "Uncommon",
+        "statType": "fixedArmor",
+        "gold": 25
+    },
+    "upgArmU010C": {
+        "name": "Blessed Ceramite",
+        "rarity": "Uncommon",
+        "statType": "fixedArmor",
+        "gold": 25,
+        "crafting": [
+            {
+                "id": "upgArmC002",
+                "amount": 6
+            }
+        ]
+    },
+    "upgArmU012": {
+        "name": "Scale-Plates",
+        "rarity": "Uncommon",
+        "statType": "fixedArmor",
+        "gold": 25
+    },
+    "upgArmU012C": {
+        "name": "Sturdy Pieces",
+        "rarity": "Uncommon",
+        "statType": "fixedArmor",
+        "gold": 25,
+        "crafting": [
+            {
+                "id": "upgArmC003",
+                "amount": 6
+            }
+        ]
+    },
+    "upgArmU013": {
+        "name": "Cloak",
+        "rarity": "Uncommon",
+        "statType": "fixedArmor",
+        "gold": 25
+    },
+    "upgArmU014": {
+        "name": "Mesh Weave",
+        "rarity": "Uncommon",
+        "statType": "fixedArmor",
+        "gold": 25
+    },
+    "upgArmR001C": {
+        "name": "Blessed Purity Seal",
+        "rarity": "Rare",
+        "statType": "fixedArmor",
+        "gold": 75,
+        "crafting": [
+            {
+                "id": "upgArmU001",
+                "amount": 5
+            },
+            {
+                "id": "upgArmC001",
+                "amount": 3
+            },
+            {
+                "id": "upgHpC016",
+                "amount": 3
+            }
+        ]
+    },
+    "upgArmR002C": {
+        "name": "Sophisticated Material Bar",
+        "rarity": "Rare",
+        "statType": "fixedArmor",
+        "gold": 75,
+        "crafting": [
+            {
+                "id": "upgArmU006",
+                "amount": 5
+            },
+            {
+                "id": "upgArmC005",
+                "amount": 6
+            }
+        ]
+    },
+    "upgArmR003C": {
+        "name": "Ceramite Bar",
+        "rarity": "Rare",
+        "statType": "fixedArmor",
+        "gold": 75,
+        "crafting": [
+            {
+                "id": "upgArmU005",
+                "amount": 5
+            },
+            {
+                "id": "upgArmC002",
+                "amount": 6
+            }
+        ]
+    },
+    "upgArmR004C": {
+        "name": "Mutation: Warped Skin",
+        "rarity": "Rare",
+        "statType": "fixedArmor",
+        "gold": 75,
+        "crafting": [
+            {
+                "id": "upgArmU007",
+                "amount": 5
+            },
+            {
+                "id": "upgArmC007",
+                "amount": 3
+            },
+            {
+                "id": "upgHpC010",
+                "amount": 3
+            }
+        ]
+    },
+    "upgArmR005": {
+        "name": "Artificer Tasset Plate",
+        "rarity": "Rare",
+        "statType": "fixedArmor",
+        "gold": 75
+    },
+    "upgArmR006": {
+        "name": "Crate of Salvage",
+        "rarity": "Rare",
+        "statType": "fixedArmor",
+        "gold": 75
+    },
+    "upgArmR007C": {
+        "name": "Adamantium Bar",
+        "rarity": "Rare",
+        "statType": "fixedArmor",
+        "gold": 75,
+        "crafting": [
+            {
+                "id": "upgArmU002",
+                "amount": 5
+            },
+            {
+                "id": "upgArmC004",
+                "amount": 6
+            }
+        ]
+    },
+    "upgArmR008C": {
+        "name": "Sturdy Parts",
+        "rarity": "Rare",
+        "statType": "fixedArmor",
+        "gold": 75,
+        "crafting": [
+            {
+                "id": "upgArmU002",
+                "amount": 5
+            },
+            {
+                "id": "upgArmC012",
+                "amount": 6
+            }
+        ]
+    },
+    "upgArmR009": {
+        "name": "Unnatural Vapour Dispenser",
+        "rarity": "Rare",
+        "statType": "fixedArmor",
+        "gold": 75
+    },
+    "upgArmR010": {
+        "name": "Valuable Fabric",
+        "rarity": "Rare",
+        "statType": "fixedArmor",
+        "gold": 75
+    },
+    "upgArmR012C": {
+        "name": "Impressive Armor Trim",
+        "rarity": "Rare",
+        "statType": "fixedArmor",
+        "gold": 75,
+        "crafting": [
+            {
+                "id": "upgArmU009",
+                "amount": 5
+            },
+            {
+                "id": "upgArmC013",
+                "amount": 4
+            },
+            {
+                "id": "upgHpC013",
+                "amount": 2
+            }
+        ]
+    },
+    "upgArmR013C": {
+        "name": "Fine Cloak",
+        "rarity": "Rare",
+        "statType": "fixedArmor",
+        "gold": 75,
+        "crafting": [
+            {
+                "id": "upgArmU013",
+                "amount": 5
+            },
+            {
+                "id": "upgArmC006",
+                "amount": 4
+            },
+            {
+                "id": "upgHpC015",
+                "amount": 2
+            }
+        ]
+    },
+    "upgArmR014C": {
+        "name": "Mesh Weave Garment",
+        "rarity": "Rare",
+        "statType": "fixedArmor",
+        "gold": 75,
+        "crafting": [
+            {
+                "id": "upgArmU014",
+                "amount": 5
+            },
+            {
+                "id": "upgArmC011",
+                "amount": 4
+            },
+            {
+                "id": "upgDmgC015",
+                "amount": 2
+            }
+        ]
+    },
+    "upgArmR015": {
+        "name": "Subdermal Plating",
+        "rarity": "Rare",
+        "statType": "fixedArmor",
+        "gold": 75
+    },
+    "upgArmR021": {
+        "name": "Blessed Tabard",
+        "rarity": "Rare",
+        "statType": "fixedArmor",
+        "gold": 75
+    },
+    "upgArmR022": {
+        "name": "Blessed Corset Armor",
+        "rarity": "Rare",
+        "statType": "fixedArmor",
+        "gold": 75
+    },
+    "upgArmR025": {
+        "name": "Flak Plates",
+        "rarity": "Rare",
+        "statType": "fixedArmor",
+        "gold": 75
+    },
+    "upgArmR023": {
+        "name": "Blasphemous Armor Trim",
+        "rarity": "Rare",
+        "statType": "fixedArmor",
+        "gold": 75
+    },
+    "upgArmR026": {
+        "name": "'ard Plate",
+        "rarity": "Rare",
+        "statType": "fixedArmor",
+        "gold": 75
+    },
+    "upgArmR027": {
+        "name": "Drone Controller",
+        "rarity": "Rare",
+        "statType": "fixedArmor",
+        "gold": 75
+    },
+    "upgArmR028": {
+        "name": "Wraithbone Plate",
+        "rarity": "Rare",
+        "statType": "fixedArmor",
+        "gold": 75
+    },
+    "upgArmR029": {
+        "name": "Ritual Implements",
+        "rarity": "Rare",
+        "statType": "fixedArmor",
+        "gold": 75
+    },
+    "upgArmR030": {
+        "name": "Reinforced Scale-Plates",
+        "rarity": "Rare",
+        "statType": "fixedArmor",
+        "gold": 75
+    },
+    "upgArmR031": {
+        "name": "Beast Hide",
+        "rarity": "Rare",
+        "statType": "fixedArmor",
+        "gold": 75
+    },
+    "upgArmR032": {
+        "name": "Dark Hood",
+        "rarity": "Rare",
+        "statType": "fixedArmor",
+        "gold": 75
+    },
+    "upgArmR033": {
+        "name": "Reinforced Chitin",
+        "rarity": "Rare",
+        "statType": "fixedArmor",
+        "gold": 75
+    },
+    "upgArmR034": {
+        "name": "Cogwheel Crest",
+        "rarity": "Rare",
+        "statType": "fixedArmor",
+        "gold": 75
+    },
+    "upgArmR035": {
+        "name": "Artisan Plating",
+        "rarity": "Rare",
+        "statType": "fixedArmor",
+        "gold": 75
+    },
+    "upgArmR036": {
+        "name": "Industrial Padding",
+        "rarity": "Rare",
+        "statType": "fixedArmor",
+        "gold": 75
+    },
+    "upgArmR037": {
+        "name": "Auramite Wing",
+        "rarity": "Rare",
+        "statType": "fixedArmor",
+        "gold": 75
+    },
+    "upgArmR038": {
+        "name": "Cadaere Renissum",
+        "rarity": "Rare",
+        "statType": "fixedArmor",
+        "gold": 75
+    },
+    "upgArmR039": {
+        "name": "Lavish Helmet Crest",
+        "rarity": "Rare",
+        "statType": "fixedArmor",
+        "gold": 75
+    },
+    "upgArmR040": {
+        "name": "Void Armour Plating",
+        "rarity": "Rare",
+        "statType": "fixedArmor",
+        "gold": 75
+    },
+    "upgArmE001C": {
+        "name": "Grand Purity Seal",
+        "rarity": "Epic",
+        "statType": "fixedArmor",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgArmR001C",
+                "amount": 1
+            },
+            {
+                "id": "upgHpR002",
+                "amount": 4
+            },
+            {
+                "id": "upgArmC002",
+                "amount": 4
+            }
+        ]
+    },
+    "upgArmE002C": {
+        "name": "Adamantium Sheet",
+        "rarity": "Epic",
+        "statType": "fixedArmor",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgHpR019",
+                "amount": 6
+            },
+            {
+                "id": "upgArmU003C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgU004",
+                "amount": 6
+            }
+        ]
+    },
+    "upgArmE003C": {
+        "name": "Sophisticated Material Sheet",
+        "rarity": "Epic",
+        "statType": "fixedArmor",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgDmgR005",
+                "amount": 6
+            },
+            {
+                "id": "upgArmU004C",
+                "amount": 1
+            },
+            {
+                "id": "upgArmU006",
+                "amount": 6
+            }
+        ]
+    },
+    "upgArmE004C": {
+        "name": "Ceramite Sheet",
+        "rarity": "Epic",
+        "statType": "fixedArmor",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgArmR015",
+                "amount": 6
+            },
+            {
+                "id": "upgArmU010C",
+                "amount": 1
+            },
+            {
+                "id": "upgArmU005",
+                "amount": 6
+            }
+        ]
+    },
+    "upgArmE005C": {
+        "name": "Mutation: Metallic Skin",
+        "rarity": "Epic",
+        "statType": "fixedArmor",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgArmR004C",
+                "amount": 1
+            },
+            {
+                "id": "upgHpR008",
+                "amount": 4
+            },
+            {
+                "id": "upgHpC008",
+                "amount": 4
+            }
+        ]
+    },
+    "upgArmE006C": {
+        "name": "Ancient Tasset Plate",
+        "rarity": "Epic",
+        "statType": "fixedArmor",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgArmR012C",
+                "amount": 1
+            },
+            {
+                "id": "upgArmR005",
+                "amount": 4
+            },
+            {
+                "id": "upgHpC015",
+                "amount": 4
+            }
+        ]
+    },
+    "upgArmE007C": {
+        "name": "Death Shroud",
+        "rarity": "Epic",
+        "statType": "fixedArmor",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgArmR009",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmE008": {
+        "name": "Hypermaterial Shifter",
+        "rarity": "Epic",
+        "statType": "fixedArmor",
+        "gold": 215
+    },
+    "upgArmE009": {
+        "name": "Revered Talisman",
+        "rarity": "Epic",
+        "statType": "fixedArmor",
+        "gold": 215
+    },
+    "upgArmE010": {
+        "name": "Unyielding Rivets",
+        "rarity": "Epic",
+        "statType": "fixedArmor",
+        "gold": 215
+    },
+    "upgArmE011C": {
+        "name": "Decorated Cloak",
+        "rarity": "Epic",
+        "statType": "fixedArmor",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgArmR013C",
+                "amount": 1
+            },
+            {
+                "id": "upgHpR002",
+                "amount": 4
+            },
+            {
+                "id": "upgHpC015",
+                "amount": 4
+            }
+        ]
+    },
+    "upgArmE012C": {
+        "name": "Sturdy Segments",
+        "rarity": "Epic",
+        "statType": "fixedArmor",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgArmR006",
+                "amount": 6
+            },
+            {
+                "id": "upgArmU012C",
+                "amount": 1
+            },
+            {
+                "id": "upgArmU002",
+                "amount": 6
+            }
+        ]
+    },
+    "upgArmE013": {
+        "name": "Duplicate Organ",
+        "rarity": "Epic",
+        "statType": "fixedArmor",
+        "gold": 215
+    },
+    "upgArmE014C": {
+        "name": "Advanced Mesh Weave Garment",
+        "rarity": "Epic",
+        "statType": "fixedArmor",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgArmR014C",
+                "amount": 1
+            },
+            {
+                "id": "upgArmR010",
+                "amount": 4
+            },
+            {
+                "id": "upgDmgC015",
+                "amount": 4
+            }
+        ]
+    },
+    "upgArmE020C": {
+        "name": "Layered Ceramite Plating",
+        "rarity": "Epic",
+        "statType": "fixedArmor",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgArmR005",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmE021C": {
+        "name": "Crusader's Tabard",
+        "rarity": "Epic",
+        "statType": "fixedArmor",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgArmR021",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmE022C": {
+        "name": "Sanctified Corset Armor",
+        "rarity": "Epic",
+        "statType": "fixedArmor",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgArmR022",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmE025C": {
+        "name": "High-grade Flak Plates",
+        "rarity": "Epic",
+        "statType": "fixedArmor",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgArmR025",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmE023C": {
+        "name": "Daemonic Armor Trim",
+        "rarity": "Epic",
+        "statType": "fixedArmor",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgArmR023",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmE026C": {
+        "name": "Ded 'ard Plate",
+        "rarity": "Epic",
+        "statType": "fixedArmor",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgArmR026",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmE027C": {
+        "name": "Advanced Drone Controller",
+        "rarity": "Epic",
+        "statType": "fixedArmor",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgArmR027",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmE028C": {
+        "name": "Filigrane Wraithbone Plate",
+        "rarity": "Epic",
+        "statType": "fixedArmor",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgArmR028",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmE029C": {
+        "name": "Cabalistic Implements",
+        "rarity": "Epic",
+        "statType": "fixedArmor",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgArmR029",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmE030C": {
+        "name": "Scale-Plate Strand",
+        "rarity": "Epic",
+        "statType": "fixedArmor",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgArmR030",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmE031C": {
+        "name": "Ice Troll Hide",
+        "rarity": "Epic",
+        "statType": "fixedArmor",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgArmR031",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmE032C": {
+        "name": "Calibanite Hood",
+        "rarity": "Epic",
+        "statType": "fixedArmor",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgArmR032",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmE033C": {
+        "name": "Adaptive Chitin Carapace",
+        "rarity": "Epic",
+        "statType": "fixedArmor",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgArmR033",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmE034C": {
+        "name": "Enhanced Cogwheel Crest",
+        "rarity": "Epic",
+        "statType": "fixedArmor",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgArmR034",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmE035C": {
+        "name": "Artisan of War Plating",
+        "rarity": "Epic",
+        "statType": "fixedArmor",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgArmR035",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmE036C": {
+        "name": "Industrial Protection Suit",
+        "rarity": "Epic",
+        "statType": "fixedArmor",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgArmR036",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmE037C": {
+        "name": "Auramite Wing Embellishment",
+        "rarity": "Epic",
+        "statType": "fixedArmor",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgArmR037",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmE038C": {
+        "name": "Blessed Cadaere Renissum",
+        "rarity": "Epic",
+        "statType": "fixedArmor",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgArmR038",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmE039C": {
+        "name": "Lavish Helmet Spike",
+        "rarity": "Epic",
+        "statType": "fixedArmor",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgArmR039",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmE040C": {
+        "name": "Exoarmour Plating",
+        "rarity": "Epic",
+        "statType": "fixedArmor",
+        "gold": 215,
+        "crafting": [
+            {
+                "id": "upgArmR040",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmL001": {
+        "name": "Purity Seal of the Primarch",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650
+    },
+    "upgArmL002C": {
+        "name": "Adamantium Plates",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgArmE002C",
+                "amount": 2
+            },
+            {
+                "id": "upgHpE015",
+                "amount": 3
+            }
+        ]
+    },
+    "upgArmL003C": {
+        "name": "Sophisticated Material Plates",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgArmE003C",
+                "amount": 2
+            },
+            {
+                "id": "upgArmE008",
+                "amount": 3
+            }
+        ]
+    },
+    "upgArmL004C": {
+        "name": "Ceramite Plates",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgArmE004C",
+                "amount": 2
+            },
+            {
+                "id": "upgArmE010",
+                "amount": 3
+            }
+        ]
+    },
+    "upgArmL005C": {
+        "name": "Mutation: Impervious Skin",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpE015",
+                "amount": 5
+            },
+            {
+                "id": "upgArmR004C",
+                "amount": 3
+            }
+        ]
+    },
+    "upgArmL006C": {
+        "name": "Grand Tasset Plate",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgArmE010",
+                "amount": 5
+            },
+            {
+                "id": "upgArmR012C",
+                "amount": 3
+            }
+        ]
+    },
+    "upgArmL007C": {
+        "name": "Immaterial Shroud",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgArmE007C",
+                "amount": 2
+            },
+            {
+                "id": "upgArmE005C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgArmL008": {
+        "name": "Transdimensional Sanctum",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650
+    },
+    "upgArmL008C": {
+        "name": "Sturdy Plates",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgArmE012C",
+                "amount": 2
+            },
+            {
+                "id": "upgArmE009",
+                "amount": 3
+            }
+        ]
+    },
+    "upgArmL009C": {
+        "name": "Mysterious Device",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgArmE008",
+                "amount": 5
+            },
+            {
+                "id": "upgArmR014C",
+                "amount": 3
+            }
+        ]
+    },
+    "upgArmL010C": {
+        "name": "Seal of the Emperor's Protection",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpE003",
+                "amount": 5
+            },
+            {
+                "id": "upgArmR001C",
+                "amount": 3
+            }
+        ]
+    },
+    "upgArmL011C": {
+        "name": "Divine Cloak",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgArmE009",
+                "amount": 5
+            },
+            {
+                "id": "upgArmR013C",
+                "amount": 3
+            }
+        ]
+    },
+    "upgArmL020C": {
+        "name": "Adamantine Blast Plating",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgArmE020C",
+                "amount": 2
+            },
+            {
+                "id": "upgArmE001C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgArmL021C": {
+        "name": "Tabard of Righteous Wrath",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgArmE021C",
+                "amount": 2
+            },
+            {
+                "id": "upgArmE001C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgArmL022C": {
+        "name": "Holy Corset Armor",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgArmE022C",
+                "amount": 2
+            },
+            {
+                "id": "upgArmE001C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgArmL025C": {
+        "name": "Artificer Flak Plates",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgArmE025C",
+                "amount": 2
+            },
+            {
+                "id": "upgArmE012C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgArmL023C": {
+        "name": "Infernal Armor Trim",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgArmE023C",
+                "amount": 2
+            },
+            {
+                "id": "upgArmE005C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgArmL026C": {
+        "name": "Ded Shiny 'ard Plate",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgArmE026C",
+                "amount": 2
+            },
+            {
+                "id": "upgArmE012C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgArmL027C": {
+        "name": "Sentry AI Drone Controller",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgArmE027C",
+                "amount": 2
+            },
+            {
+                "id": "upgArmE014C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgArmL028C": {
+        "name": "Soul-Bonded Wraithbone Plate",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgArmE028C",
+                "amount": 2
+            },
+            {
+                "id": "upgArmE014C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgArmL029C": {
+        "name": "Great Cult Implements",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgArmE029C",
+                "amount": 2
+            },
+            {
+                "id": "upgArmE005C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgArmL030C": {
+        "name": "Scale-Plate Mantle",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgArmE030C",
+                "amount": 2
+            },
+            {
+                "id": "upgArmE014C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgArmL031C": {
+        "name": "Ice Wyrm Hide",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgArmE031C",
+                "amount": 2
+            },
+            {
+                "id": "upgArmE001C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgArmL032C": {
+        "name": "Inner Circle Hood",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgArmE032C",
+                "amount": 2
+            },
+            {
+                "id": "upgArmE001C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgArmL033C": {
+        "name": "Hyper-Adaptive Chitin Carapace",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgArmE033C",
+                "amount": 2
+            },
+            {
+                "id": "upgArmE005C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgArmL034C": {
+        "name": "Artificer Cogwheel Crest",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgArmE034C",
+                "amount": 2
+            },
+            {
+                "id": "upgArmE001C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgArmL035C": {
+        "name": "Angelic Plating",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgArmE035C",
+                "amount": 2
+            },
+            {
+                "id": "upgArmE001C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgArmL036C": {
+        "name": "Industrial Carapace",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgArmE036C",
+                "amount": 2
+            },
+            {
+                "id": "upgArmE012C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgArmL037C": {
+        "name": "Auramite Wing Adornment",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgArmE037C",
+                "amount": 2
+            },
+            {
+                "id": "upgArmE001C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgArmL038C": {
+        "name": "Exalted Cadaere Renissum",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgArmE038C",
+                "amount": 2
+            },
+            {
+                "id": "upgArmE005C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgArmL039C": {
+        "name": "Lavish Helmet Plume",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgArmE039C",
+                "amount": 2
+            },
+            {
+                "id": "upgArmE005C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgArmL040C": {
+        "name": "Forge Wrought Plating",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgArmE040C",
+                "amount": 2
+            },
+            {
+                "id": "upgArmE014C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgArmL120C": {
+        "name": "Adamantine Mantle",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL100",
+                "amount": 9
+            },
+            {
+                "id": "upgArmR013C",
+                "amount": 1
+            },
+            {
+                "id": "upgArmR005",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmL121C": {
+        "name": "Octarian Crusade Seal",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL101",
+                "amount": 9
+            },
+            {
+                "id": "upgHpR016C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgR003",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmL122C": {
+        "name": "Sabbat-Pattern Visor",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL102",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR13C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgR006",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmL125C": {
+        "name": "Bastion Honour",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL105",
+                "amount": 9
+            },
+            {
+                "id": "upgHpR017C",
+                "amount": 1
+            },
+            {
+                "id": "upgHpR005",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmL123C": {
+        "name": "Black Rune",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL103",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR14C",
+                "amount": 1
+            },
+            {
+                "id": "upgHpR014",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmL124C": {
+        "name": "Cloud of Flies",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL104",
+                "amount": 9
+            },
+            {
+                "id": "upgHpR009C",
+                "amount": 1
+            },
+            {
+                "id": "upgHpR019",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmL126C": {
+        "name": "Bosspole",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL106",
+                "amount": 9
+            },
+            {
+                "id": "upgHpR015C",
+                "amount": 1
+            },
+            {
+                "id": "upgHpR018",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmL127C": {
+        "name": "Iridium Plating",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL107",
+                "amount": 9
+            },
+            {
+                "id": "upgArmR002C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgR005",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmL128C": {
+        "name": "Scriptures of Fortune",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL108",
+                "amount": 9
+            },
+            {
+                "id": "upgHpR016C",
+                "amount": 1
+            },
+            {
+                "id": "upgArmR010",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmL129C": {
+        "name": "Warpweave Robe",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL109",
+                "amount": 9
+            },
+            {
+                "id": "upgArmR014C",
+                "amount": 1
+            },
+            {
+                "id": "upgHpR008",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmL130C": {
+        "name": "Transdimensional Sanctum",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL010",
+                "amount": 9
+            },
+            {
+                "id": "upgDmgR011C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgR006",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmL131C": {
+        "name": "Runic Tasset Plate",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL111",
+                "amount": 9
+            },
+            {
+                "id": "upgArmR003C",
+                "amount": 1
+            },
+            {
+                "id": "upgArmR005",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmL132C": {
+        "name": "Shroud of Heroes",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL112",
+                "amount": 9
+            },
+            {
+                "id": "upgArmR013C",
+                "amount": 1
+            },
+            {
+                "id": "upgDmgR005",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmL133C": {
+        "name": "Symbiotic Carapace",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL113",
+                "amount": 9
+            },
+            {
+                "id": "upgArmR004C",
+                "amount": 1
+            },
+            {
+                "id": "upgHpR008",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmL134C": {
+        "name": "Kataphron Armour",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL114",
+                "amount": 9
+            },
+            {
+                "id": "upgHpR012C",
+                "amount": 1
+            },
+            {
+                "id": "upgArmR015",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmL135C": {
+        "name": "Visage of Death",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL115",
+                "amount": 9
+            },
+            {
+                "id": "upgArmR012C",
+                "amount": 1
+            },
+            {
+                "id": "upgHpR019",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmL136C": {
+        "name": "Gene-sire's Reliquant",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL116",
+                "amount": 9
+            },
+            {
+                "id": "upgHpR015C",
+                "amount": 1
+            },
+            {
+                "id": "upgHpR002",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmL137C": {
+        "name": "Adamantine Thread Cloak",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL117",
+                "amount": 9
+            },
+            {
+                "id": "upgArmR007C",
+                "amount": 1
+            },
+            {
+                "id": "upgHpR014",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmL138C": {
+        "name": "Collar of Khorne",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL118",
+                "amount": 9
+            },
+            {
+                "id": "upgHpR013C",
+                "amount": 1
+            },
+            {
+                "id": "upgHpR018",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmL139C": {
+        "name": "Abhorrent Plating",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL119",
+                "amount": 9
+            },
+            {
+                "id": "upgHpR012C",
+                "amount": 1
+            },
+            {
+                "id": "upgHpR018",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmL140C": {
+        "name": "RAM Shield Technology",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgHpL099",
+                "amount": 9
+            },
+            {
+                "id": "upgArmR008C",
+                "amount": 1
+            },
+            {
+                "id": "upgHpR014",
+                "amount": 9
+            }
+        ]
+    },
+    "upgArmL202": {
+        "name": "Psyk-Conductive Material",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650
+    },
+    "upgArmL203": {
+        "name": "Archeotech Remnant",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650
+    },
+    "upgArmL204": {
+        "name": "Ancient Alloy",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650
+    },
+    "upgArmL211C": {
+        "name": "Monstrous Defences",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgArmL203",
+                "amount": 8
+            },
+            {
+                "id": "upgArmL202",
+                "amount": 8
+            },
+            {
+                "id": "upgArmE009",
+                "amount": 8
+            }
+        ]
+    },
+    "upgArmL212C": {
+        "name": "Preternatural Defences",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgArmL202",
+                "amount": 8
+            },
+            {
+                "id": "upgArmL001",
+                "amount": 8
+            },
+            {
+                "id": "upgArmE008",
+                "amount": 8
+            }
+        ]
+    },
+    "upgArmL213C": {
+        "name": "Superaugmented Defences",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgArmL001",
+                "amount": 8
+            },
+            {
+                "id": "upgArmL204",
+                "amount": 8
+            },
+            {
+                "id": "upgArmE013",
+                "amount": 8
+            }
+        ]
+    },
+    "upgArmL214C": {
+        "name": "Technocrafted Defences",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650,
+        "crafting": [
+            {
+                "id": "upgArmL204",
+                "amount": 8
+            },
+            {
+                "id": "upgArmL203",
+                "amount": 8
+            },
+            {
+                "id": "upgArmE010",
+                "amount": 8
+            }
+        ]
+    },
+    "upgArmM211C": {
+        "name": "Seal of Indomitability",
+        "rarity": "Mythic",
+        "statType": "fixedArmor",
+        "gold": 2000,
+        "crafting": [
+            {
+                "id": "upgArmL001",
+                "amount": 3
+            },
+            {
+                "id": "upgHpM001",
+                "amount": 6
+            },
+            {
+                "id": "upgArmL010C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgArmM212C": {
+        "name": "Mutation: Impenetrable Skin",
+        "rarity": "Mythic",
+        "statType": "fixedArmor",
+        "gold": 2000,
+        "crafting": [
+            {
+                "id": "upgArmL202",
+                "amount": 3
+            },
+            {
+                "id": "upgHpM002",
+                "amount": 6
+            },
+            {
+                "id": "upgArmL005C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgArmM213C": {
+        "name": "Magnificient Garment",
+        "rarity": "Mythic",
+        "statType": "fixedArmor",
+        "gold": 2000,
+        "crafting": [
+            {
+                "id": "upgArmL204",
+                "amount": 3
+            },
+            {
+                "id": "upgHpM003",
+                "amount": 6
+            },
+            {
+                "id": "upgArmL011C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgArmM214C": {
+        "name": "Warforged Safeguard",
+        "rarity": "Mythic",
+        "statType": "fixedArmor",
+        "gold": 2000,
+        "crafting": [
+            {
+                "id": "upgArmL203",
+                "amount": 3
+            },
+            {
+                "id": "upgHpM004",
+                "amount": 6
+            },
+            {
+                "id": "upgArmL006C",
+                "amount": 1
+            }
+        ]
+    },
+    "upgHpRCS": {
+        "name": "Coming soon",
+        "rarity": "Rare",
+        "statType": "hp",
+        "gold": 75
+    },
+    "upgDmgRCS": {
+        "name": "Coming soon",
+        "rarity": "Rare",
+        "statType": "dmg",
+        "gold": 75
+    },
+    "upgArmRCS": {
+        "name": "Coming soon",
+        "rarity": "Rare",
+        "statType": "fixedArmor",
+        "gold": 75
+    },
+    "upgHpECS": {
+        "name": "Coming soon",
+        "rarity": "Epic",
+        "statType": "hp",
+        "gold": 215
+    },
+    "upgDmgECS": {
+        "name": "Coming soon",
+        "rarity": "Epic",
+        "statType": "dmg",
+        "gold": 215
+    },
+    "upgArmECS": {
+        "name": "Coming soon",
+        "rarity": "Epic",
+        "statType": "fixedArmor",
+        "gold": 215
+    },
+    "upgHpCS": {
+        "name": "Coming soon",
+        "rarity": "Legendary",
+        "statType": "hp",
+        "gold": 650
+    },
+    "upgDmgCS": {
+        "name": "Coming soon",
+        "rarity": "Legendary",
+        "statType": "dmg",
+        "gold": 650
+    },
+    "upgArmCS": {
+        "name": "Coming soon",
+        "rarity": "Legendary",
+        "statType": "fixedArmor",
+        "gold": 650
+    }
+}

--- a/src/fsd/4-entities/unit/character-power/index.ts
+++ b/src/fsd/4-entities/unit/character-power/index.ts
@@ -1,0 +1,9 @@
+export { calculateRosterCharacterPower, calculateRosterMowPower } from './character-power';
+export type { RosterPowerInput, RosterMowPowerInput } from './character-power';
+export { progressionIndexFromRarityStars } from './progression-index';
+export {
+    getRosterCharacterPower,
+    getProjectedRankUpPower,
+    getRosterMowPower,
+    toRosterPowerInput,
+} from './roster-power.adapter';

--- a/src/fsd/4-entities/unit/character-power/progression-index.ts
+++ b/src/fsd/4-entities/unit/character-power/progression-index.ts
@@ -1,0 +1,15 @@
+import { Rarity, RarityStars } from '@/fsd/5-shared/model';
+
+const MAX_PROGRESSION_INDEX = 19;
+
+/**
+ * Forward map of `(rarity, stars)` to the game's `progressionIndex` (0..19).
+ *
+ * Inverse of `TacticusIntegrationService.convertProgressionIndex`, which derives
+ * `rarity = highest threshold <= progressionIndex` and `stars = progressionIndex - rarity`.
+ * Since the `Rarity` and `RarityStars` enums are both zero-based and contiguous, that collapses
+ * to `progressionIndex = rarity + stars`.
+ */
+export const progressionIndexFromRarityStars = (rarity: Rarity, stars: RarityStars): number => {
+    return Math.min(Math.max(rarity + stars, 0), MAX_PROGRESSION_INDEX);
+};

--- a/src/fsd/4-entities/unit/character-power/roster-power.adapter.ts
+++ b/src/fsd/4-entities/unit/character-power/roster-power.adapter.ts
@@ -1,0 +1,73 @@
+/* eslint-disable boundaries/element-types -- adapter bridges the roster character model into the power formula */
+import { Rank } from '@/fsd/5-shared/model';
+
+import { ICharacter2 } from '@/fsd/4-entities/character';
+import { IMow2 } from '@/fsd/4-entities/mow';
+
+import { calculateRosterCharacterPower, calculateRosterMowPower, RosterPowerInput } from './character-power';
+import { bundledPowerConfig } from './character-power.data';
+import { progressionIndexFromRarityStars } from './progression-index';
+
+interface ToInputOptions {
+    /** Compute power as if the character were at this rank instead of its current one. */
+    rankOverride?: Rank;
+    /** Ignore the character's applied current-rank upgrades (used for a freshly ranked-up projection). */
+    dropAppliedUpgrades?: boolean;
+}
+
+const lineupUpgradeRow = (unitId: string, gameRank: number): string[] => {
+    const units = bundledPowerConfig.units as { lineup?: Record<string, { upgrades?: unknown }> };
+    const rows = units.lineup?.[unitId]?.upgrades;
+    if (!Array.isArray(rows)) return [];
+    const row = rows[gameRank];
+    return Array.isArray(row) && row.every((entry): entry is string => typeof entry === 'string') ? row : [];
+};
+
+/** Map the character's applied upgrade-material ids to their column indices in the game's rank row. */
+const resolveAppliedUpgradeIndices = (unitId: string, gameRank: number, appliedIds: string[]): number[] => {
+    const row = lineupUpgradeRow(unitId, gameRank);
+    return appliedIds.map(id => row.indexOf(id)).filter(index => index >= 0);
+};
+
+export const toRosterPowerInput = (char: ICharacter2, options: ToInputOptions = {}): RosterPowerInput => {
+    const gameRank = (options.rankOverride ?? char.rank) - 1;
+    return {
+        unitId: char.snowprintId,
+        progressionIndex: progressionIndexFromRarityStars(char.rarity, char.stars),
+        rank: gameRank,
+        activeLevel: char.activeAbilityLevel,
+        passiveLevel: char.passiveAbilityLevel,
+        appliedUpgradeIndices: options.dropAppliedUpgrades
+            ? []
+            : resolveAppliedUpgradeIndices(char.snowprintId, gameRank, char.upgrades ?? []),
+        equipment: (char.equipment ?? []).map(item => ({ itemId: item.id, level: item.level })),
+    };
+};
+
+/** Accurate current in-game power for a roster character (0 when locked). */
+export const getRosterCharacterPower = (char: ICharacter2): number => {
+    if (char.rank <= Rank.Locked) return 0;
+    return calculateRosterCharacterPower(toRosterPowerInput(char));
+};
+
+/**
+ * Accurate power for a roster character as if it had just ranked up to `targetRank` — at that rank
+ * with no current-rank upgrades applied yet. Equipment and ability levels are unchanged.
+ */
+export const getProjectedRankUpPower = (char: ICharacter2, targetRank: Rank): number => {
+    if (char.rank <= Rank.Locked) return 0;
+    return calculateRosterCharacterPower(
+        toRosterPowerInput(char, { rankOverride: targetRank, dropAppliedUpgrades: true })
+    );
+};
+
+/** Accurate current in-game power for a roster Machine of War (0 when locked). */
+export const getRosterMowPower = (mow: IMow2): number => {
+    if (!mow.unlocked) return 0;
+    return calculateRosterMowPower({
+        unitId: mow.snowprintId,
+        progressionIndex: progressionIndexFromRarityStars(mow.rarity, mow.stars),
+        primaryAbilityLevel: mow.primaryAbilityLevel,
+        secondaryAbilityLevel: mow.secondaryAbilityLevel,
+    });
+};

--- a/src/fsd/5-shared/ui/unit-portrait/unit-portrait.hooks.ts
+++ b/src/fsd/5-shared/ui/unit-portrait/unit-portrait.hooks.ts
@@ -8,13 +8,15 @@ export const useUnitPortraitAssets = (
     isChar: boolean,
     rarity: Rarity,
     rank: Rank | undefined,
-    rarityStars: RarityStars
+    rarityStars: RarityStars,
+    targetRank?: Rank
 ) => {
     const assets = useContext(UnitPortraitAssetContext);
     if (!assets) throw new Error('useUnitPortraitAssets must be used within UnitPortraitAssetsProvider');
 
     const frame = isChar ? assets.charFrames[rarity] : assets.mowFrames[rarity];
     const rankIcon = assets.ranks[rank ? rank - 1 : 0];
+    const targetRankIcon = targetRank ? assets.ranks[targetRank - 1] : undefined;
 
     const starIcon =
         rarityStars <= RarityStars.FiveStars
@@ -28,6 +30,7 @@ export const useUnitPortraitAssets = (
     return {
         frame,
         rankIcon,
+        targetRankIcon,
         starIcon,
         shardIcon: assets.shardIcon,
         mythicShardIcon: assets.mythicShardIcon,

--- a/src/fsd/5-shared/ui/unit-portrait/unit-portrait.tsx
+++ b/src/fsd/5-shared/ui/unit-portrait/unit-portrait.tsx
@@ -45,6 +45,8 @@ interface Props {
     mowData?: IMowStatic2;
     isDisabled?: boolean;
     customPortraitUrl?: string;
+    /** When set, draws a "→ <rank>" rank-up target indicator along the bottom of the portrait. */
+    targetRank?: Rank;
 }
 
 const CircularBadge = ({ val, x, y }: { val: number; x: number; y: number }) => {
@@ -93,12 +95,14 @@ export const UnitPortrait = ({
     mowData,
     isDisabled,
     customPortraitUrl,
+    targetRank,
 }: Props) => {
-    const { frame, rankIcon, starIcon, shardIcon, mythicShardIcon } = useUnitPortraitAssets(
+    const { frame, rankIcon, targetRankIcon, starIcon, shardIcon, mythicShardIcon } = useUnitPortraitAssets(
         char !== undefined,
         char?.rarity ?? mow?.rarity ?? 0,
         char?.rank ?? undefined,
-        char?.stars ?? mow?.stars ?? 0
+        char?.stars ?? mow?.stars ?? 0,
+        targetRank
     );
     const charIcon = customPortraitUrl ?? getImageUrl(charData?.icon ?? mowData?.icon ?? 'default-character-icon.png');
     const rank = getRank(char?.rank ?? 0);
@@ -415,6 +419,17 @@ export const UnitPortrait = ({
                             src={rankIcon[0]?.src}
                             className={`absolute top-[100px] left-[-10px] z-20 h-[40px] w-auto`}
                         />
+                    )}
+                    {targetRankIcon && targetRankIcon[0] && char !== undefined && !isLocked && (
+                        <>
+                            <span className="absolute top-[109px] left-[24px] z-30 text-[22px] leading-none font-bold text-white [text-shadow:0_0_2px_#000,0_0_4px_#000]">
+                                →
+                            </span>
+                            <img
+                                src={targetRankIcon[0]?.src}
+                                className="absolute top-[100px] left-[36px] z-20 h-[40px] w-auto"
+                            />
+                        </>
                     )}
                     {shouldShowAbilities() &&
                         char &&


### PR DESCRIPTION
## Summary
- Show each ability's name next to its slot label on the unit details page, and replace the verbose stat-percentile list under the radar chart with the same icons the chart axes use (plus 0/infinity glyphs), moving the full description to a hover tooltip.
- Add a "Ready to Rank Up" filter to who-you-own: flags characters whose XP level qualifies them for a higher rank (rarity permitting), shows a target-rank portrait indicator, and sorts/sums power as if already ranked up.
- Replace the coarse power heuristic with an accurate GameConfig-driven power formula (ported from characterPower.mjs) for both characters and MoWs, used generally for power display/sort/tooltips with a heuristic fallback.
- Add an "Add Ready to Rank Up" button to the Bulk Goal Creator: opens a dialog to bound the eligible rank range and optionally raise active/passive abilities to XP level, then stages one card per qualifying character (sorted descending by target rank) for review before inserting goals.

## Test plan
- [x] `npm run tsc`
- [x] `npm run lint`
- [x] `npm test` (76 files / 1381 tests passing)
- [ ] Manual check on unit details page: ability names and radar chart labels
- [ ] Manual check on `/input/wyo`: "Ready to Rank Up" filter, portrait indicator, and rank-up-projected power sort
- [ ] Manual check on `/plan/bulk-goals`: "Add Ready to Rank Up" dialog behavior and staged card output

🤖 Generated with [Claude Code](https://claude.com/claude-code)